### PR TITLE
fix reuse_container option

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -12,8 +12,8 @@ CONTAINER_PREFIX = "behave-test-"
 
 @given("a `{series}` lxd container with ubuntu-advantage-tools installed")
 def given_a_lxd_container(context, series):
-    if context.reuse_container:
-        context.container_name = context.reuse_container
+    if series in context.reuse_container:
+        context.container_name = context.reuse_container[series]
     else:
         now = datetime.datetime.now()
         context.container_name = (

--- a/features/util.py
+++ b/features/util.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import textwrap
 import time
 import yaml
 from typing import Any, List
@@ -145,10 +146,13 @@ def lxc_get_series(name: str, image: bool = False):
         try:
             series = image_config["properties"]["release"]
             print(
-                """\n You are providing a {series} image.
+                textwrap.dedent(
+                    """
+                You are providing a {series} image.
                 Make sure you are running this series tests.
                 For instance: --tags=series.{series}""".format(
-                    series=series
+                        series=series
+                    )
                 )
             )
             return series


### PR DESCRIPTION
Currently it is not checking the correct series to run the tests in.
It fixes the issue: if you provide a container `-D reuse_container=cont_name`
it will run either series tests with the same container.