### PR TITLE
focal: add integration tests

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -14,3 +14,16 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              """
              This command must be run as root (try using sudo)
              """
+    @series.focal
+    Scenario: Attach command in a trusty lxd container
+       Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua attach INVALID_TOKEN` with sudo
+        Then stderr matches regexp:
+            """
+            Invalid token. See https://ubuntu.com/advantage
+            """
+        When I run `ua attach INVALID_TOKEN` as non-root
+        Then I will see the following on stderr:
+             """
+             This command must be run as root (try using sudo)
+             """

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -14,6 +14,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              """
              This command must be run as root (try using sudo)
              """
+
     @series.focal
     Scenario: Attach command in a trusty lxd container
        Given a `focal` lxd container with ubuntu-advantage-tools installed

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -16,7 +16,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              """
 
     @series.focal
-    Scenario: Attach command in a trusty lxd container
+    Scenario: Attach command in a focal lxd container
        Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I run `ua attach INVALID_TOKEN` with sudo
         Then stderr matches regexp:

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -29,3 +29,31 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Enabling default service esm-infra
         """
+
+    @series.focal
+    Scenario: Attach command in a focal lxd container
+       Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        Then stdout matches regexp:
+        """
+        ESM Infra enabled
+        """
+        And stdout matches regexp:
+        """
+        This machine is now attached to
+        """
+        And stdout matches regexp:
+        """
+        SERVICE       ENTITLED  STATUS    DESCRIPTION
+        cc-eal       +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        cis-audit    +no       +—        +Center for Internet Security Audit Tools
+        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
+        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
+        fips         +yes      +n/a      +NIST-certified FIPS modules
+        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
+        livepatch    +yes      +n/a      +Canonical Livepatch service
+        """
+        And stderr matches regexp:
+        """
+        Enabling default service esm-infra
+        """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -2,20 +2,26 @@
 Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
-    Scenario: Attached enable Livepatch service in a trusty lxd container
+    Scenario Outline:  Attached enable of non-container services in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
         When I attach contract_token with sudo
-        And I run `ua enable livepatch` as non-root
+        And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable livepatch` with sudo
+        When I run `ua enable <service> <flag>` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            Cannot install Livepatch on a container
+            Cannot install <title> on a container
             """
+
+        Examples: Un-supported services in containers
+           | service      | title        | flag          |
+           | livepatch    | Livepatch    |               |
+           | fips         | FIPS         | --assume-yes  |
+           | fips-updates | FIPS Updates | --assume-yes  |
 
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty lxd container
@@ -68,38 +74,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached enable NIST-certified FIPS service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable fips` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable fips` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install FIPS on a container
-            """
-
-    @series.trusty
-    Scenario: Attached enable Uncertified FIPS service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable fips-updates` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable fips-updates` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install FIPS Updates on a container
-            """
-
-    @series.trusty
     Scenario: Attached enable of an unknown service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
         When I attach contract_token with sudo
@@ -133,20 +107,28 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached enable Livepatch service in a focal lxd container
+    Scenario Outline: Attached enable of non-container services in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I attach contract_token with sudo
-        And I run `ua enable livepatch` as non-root
+        And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable livepatch` with sudo
+        When I run `ua enable <service> <flag>` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            Cannot install Livepatch on a container
+            Cannot install <title> on a container
             """
+
+        Examples: Un-supported services in containers
+           | service      | title        | flag          |
+           | livepatch    | Livepatch    |               |
+           | fips         | FIPS         | --assume-yes  |
+           | fips-updates | FIPS Updates | --assume-yes  |
+
+
 
     @series.focal
     Scenario: Attached enable Common Criteria service in a focal lxd container
@@ -198,37 +180,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             For more information see: https://ubuntu.com/advantage
             """
 
-    @series.focal
-    Scenario: Attached enable NIST-certified FIPS service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable fips` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable fips` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install FIPS on a container
-            """
-
-    @series.focal
-    Scenario: Attached enable Uncertified FIPS service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable fips-updates` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable fips-updates` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install FIPS Updates on a container
-            """
 
     @series.focal
     Scenario: Attached enable of an unknown service in a focal lxd container

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -131,3 +131,135 @@ Feature: Enable command behaviour when attached to an UA subscription
             ESM Infra is already enabled.
             See: sudo ua status
             """
+
+    @series.focal
+    Scenario: Attached enable Livepatch service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable livepatch` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable livepatch` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install Livepatch on a container
+            """
+
+    @series.focal
+    Scenario: Attached enable Common Criteria service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable cc-eal` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable cc-eal` with sudo
+        Then I will see the following on stdout
+            """
+            One moment, checking your subscription first
+            CC EAL2 is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            """
+
+    @series.focal
+    Scenario: Attached enable CIS Audit service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable cis-audit` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable cis-audit` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            This subscription is not entitled to CIS Audit.
+            For more information see: https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Attached enable UA Apps service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable esm-apps` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable esm-apps` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            This subscription is not entitled to ESM Apps.
+            For more information see: https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Attached enable NIST-certified FIPS service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable fips` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable fips` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install FIPS on a container
+            """
+
+    @series.focal
+    Scenario: Attached enable Uncertified FIPS service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable fips-updates` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable fips-updates` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install FIPS Updates on a container
+            """
+
+    @series.focal
+    Scenario: Attached enable of an unknown service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable foobar` with sudo
+        Then stderr matches regexp:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+    @series.focal
+    Scenario: Attached enable of a known service already enabled (UA Infra) in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable esm-infra` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable esm-infra` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            ESM Infra is already enabled.
+            See: sudo ua status
+            """
+

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -91,3 +91,95 @@ Feature: Command behaviour when unattached
             Cannot disable 'foobar'
             For a list of services see: sudo ua status
             """
+
+    @series.focal
+    Scenario: Unattached detach in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua detach` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua detach` with sudo
+        Then stderr matches regexp:
+            """
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Unattached refresh in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua refresh` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua refresh` with sudo
+        Then stderr matches regexp:
+            """
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Unattached enable of a known service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua enable livepatch` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable livepatch` with sudo
+        Then stderr matches regexp:
+            """
+            To use 'livepatch' you need an Ubuntu Advantage subscription
+            Personal and community subscriptions are available at no charge
+            See https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Unattached enable of an unknown service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua enable foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable foobar` with sudo
+        Then stderr matches regexp:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+    @series.focal
+    Scenario: Unattached disable of a known service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua disable livepatch` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua disable livepatch` with sudo
+        Then stderr matches regexp:
+            """
+            To use 'livepatch' you need an Ubuntu Advantage subscription
+            Personal and community subscriptions are available at no charge
+            See https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Unattached disable of an unknown service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua disable foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua disable foobar` with sudo
+        Then stderr matches regexp:
+            """
+            Cannot disable 'foobar'
+            For a list of services see: sudo ua status
+            """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -33,8 +33,8 @@ Feature: Unattached status
             """ 
     
     @series.focal
-    Scenario: Unattached status in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+    Scenario: Unattached status in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I run `ua status` as non-root
         Then I will see the following on stdout:
             """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -30,4 +30,36 @@ Feature: Unattached status
 
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
+            """ 
+    
+    @series.focal
+    Scenario: Unattached status in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I run `ua status` as non-root
+        Then I will see the following on stdout:
             """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      yes        UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
+            fips          no         NIST-certified FIPS modules
+            fips-updates  no         Uncertified security updates to FIPS modules
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+        When I run `ua status` with sudo
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      yes        UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
+            fips          no         NIST-certified FIPS modules
+            fips-updates  no         Uncertified security updates to FIPS modules
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """           


### PR DESCRIPTION
focal: add integration tests for all .features' files.
This way we are going to be able to run only one specific Ubuntu series using behave tags option `--tags=series.focal`.

Closes: #1022