### PR TITLE
repo: allow for pre_enable messaging interactions

### DIFF
--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -1,5 +1,11 @@
 from uaclient.entitlements import repo
 
+try:
+    from typing import Callable, Dict, List, Tuple, Union  # noqa
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 CC_README = "/usr/share/doc/ubuntu-commoncriteria/README"
 
 
@@ -11,14 +17,19 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     description = "Common Criteria EAL2 Provisioning Packages"
     repo_key_file = "ubuntu-cc-keyring.gpg"
     packages = ["ubuntu-commoncriteria"]
-    messaging = {
-        "pre_install": [
-            "(This will download more than 500MB of packages, so may take some"
-            " time.)"
-        ],
-        "post_enable": [
-            "Please follow instructions in {} to configure EAL2".format(
-                CC_README
-            )
-        ],
-    }
+
+    @property
+    def messaging(
+        self
+    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+        return {
+            "pre_install": [
+                "(This will download more than 500MB of packages, so may take"
+                " some time.)"
+            ],
+            "post_enable": [
+                "Please follow instructions in {} to configure EAL2".format(
+                    CC_README
+                )
+            ],
+        }

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -2,7 +2,7 @@ from uaclient.entitlements import repo
 from uaclient import apt, status, util
 
 try:
-    from typing import Dict, List, Set, Tuple  # noqa
+    from typing import Callable, Dict, List, Set, Tuple, Union  # noqa
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -60,25 +60,24 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     name = "fips"
     title = "FIPS"
     description = "NIST-certified FIPS modules"
-    messaging = {
-        "post_enable": ["A reboot is required to complete the install"]
-    }
     origin = "UbuntuFIPS"
     static_affordances = (
         ("Cannot install FIPS on a container", util.is_container, False),
     )
+
+    @property
+    def messaging(
+        self
+    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+        return {
+            "post_enable": ["A reboot is required to complete the install"]
+        }
 
 
 class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     name = "fips-updates"
     title = "FIPS Updates"
-    messaging = {
-        "post_enable": [
-            "FIPS Updates configured and pending, please reboot to make"
-            " active."
-        ]
-    }
     origin = "UbuntuFIPSUpdates"
     description = "Uncertified security updates to FIPS modules"
     static_affordances = (
@@ -88,3 +87,14 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
             False,
         ),
     )
+
+    @property
+    def messaging(
+        self
+    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+        return {
+            "post_enable": [
+                "FIPS Updates configured and pending, please reboot to make"
+                " active."
+            ]
+        }

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -49,7 +49,11 @@ class RepoEntitlement(base.UAEntitlement):
 
     # Any custom messages to emit to the console or callables which are
     # handled at pre_enable, pre_disable, pre_install or post_enable stages
-    messaging = {}  # type: Dict[str, List[Union[str, Tuple[Callable, Dict]]]]
+    @property
+    def messaging(
+        self
+    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+        return {}
 
     @property
     def packages(self) -> "List[str]":

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -4,7 +4,16 @@ import os
 import re
 
 try:
-    from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
+    from typing import (  # noqa: F401
+        Any,
+        Callable,
+        Dict,
+        List,
+        Optional,
+        Sequence,
+        Tuple,
+        Union,
+    )
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -38,9 +47,9 @@ class RepoEntitlement(base.UAEntitlement):
     def disable_apt_auth_only(self) -> bool:
         return False  # Set True on ESM to only remove apt auth
 
-    # Any custom messages to emit pre or post enable or disable operations;
-    # currently post_enable is used in CommonCriteria
-    messaging = {}  # type: Dict[str, List[str]]
+    # Any custom messages to emit to the console or callables which are
+    # handled at pre_enable, pre_disable, pre_install or post_enable stages
+    messaging = {}  # type: Dict[str, List[Union[str, Tuple[Callable, Dict]]]]
 
     @property
     def packages(self) -> "List[str]":
@@ -64,12 +73,16 @@ class RepoEntitlement(base.UAEntitlement):
         """
         if not self.can_enable(silent=silent_if_inapplicable):
             return False
+        msg_ops = self.messaging.get("pre_enable", [])
+        if not handle_message_operations(msg_ops):
+            return False
         self.setup_apt_config()
         if self.packages:
             try:
                 print("Installing {title} packages".format(title=self.title))
-                for msg in self.messaging.get("pre_install", []):
-                    print(msg)
+                msg_ops = self.messaging.get("pre_install", [])
+                if not handle_message_operations(msg_ops):
+                    return False
                 apt.run_apt_command(
                     ["apt-get", "install", "--assume-yes"] + self.packages,
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
@@ -80,12 +93,16 @@ class RepoEntitlement(base.UAEntitlement):
                 self._cleanup()
                 raise
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
-        for msg in self.messaging.get("post_enable", []):
-            print(msg)
+        msg_ops = self.messaging.get("post_enable", [])
+        if not handle_message_operations(msg_ops):
+            return False
         return True
 
     def disable(self, silent=False):
         if not self.can_disable(silent):
+            return False
+        msg_ops = self.messaging.get("pre_disable", [])
+        if not handle_message_operations(msg_ops):
             return False
         self._cleanup()
         return True
@@ -301,3 +318,25 @@ class RepoEntitlement(base.UAEntitlement):
         apt.run_apt_command(
             ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
         )
+
+
+def handle_message_operations(
+    msg_ops: "List[Union[str, Tuple[Callable, Dict]]]"
+) -> bool:
+    """Emit messages to the console for user interaction
+
+    :param msg_op: A list of strings or tuples. Any string items are printed.
+        Any tuples will contain a callable and a dict of args to pass to the
+        callable. Callables are expected to return True on success and
+        False upon failure.
+
+    :return: True upon success, False on failure.
+    """
+    for msg_op in msg_ops:
+        if isinstance(msg_op, str):
+            print(msg_op)
+        else:  # Then we are a callable and dict of args
+            functor, args = msg_op
+            if not functor(**args):
+                return False
+    return True

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -344,8 +344,11 @@ class TestRepoEnable:
         entitlement,
         capsys,
     ):
-        messaging = {"pre_enable": pre_enable_msg}
-        with mock.patch.object(type(entitlement), "messaging", messaging):
+        with mock.patch(
+            M_PATH + "RepoEntitlement.messaging",
+            new_callable=mock.PropertyMock,
+        ) as m_messaging:
+            m_messaging.return_value = {"pre_enable": pre_enable_msg}
             with mock.patch.object(type(entitlement), "packages", []):
                 entitlement.enable()
         stdout, _ = capsys.readouterr()
@@ -411,8 +414,10 @@ class TestRepoEnable:
 
         pre_install_msgs = ["Some pre-install information", "Some more info"]
         if with_pre_install_msg:
-            messaging_patch = mock.patch.object(
-                entitlement, "messaging", {"pre_install": pre_install_msgs}
+            messaging_patch = mock.patch(
+                M_PATH + "RepoEntitlement.messaging",
+                new_callable=mock.PropertyMock,
+                return_value={"pre_install": pre_install_msgs},
             )
         else:
             messaging_patch = mock.MagicMock()


### PR DESCRIPTION
Consolidate messaging hook processing under a single function
handle_message_operations.

Make messaging an instance property so it can dynamically leverage instance variables at runtime.

This is groundwork for FIPS pre-enable and pre-disable custom
messaging and prompts for #1031.

As a note, the final branch for the prompt features which contains this PR will be this branch:
https://github.com/blackboxsw/ubuntu-advantage-client/tree/feature/fips-support