### PR TITLE
wip entitlements: static_affordances as runtime instance property

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -50,10 +50,12 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         """A sentence describing this entitlement"""
         pass
 
-    # A tuple of 3-tuples with (failure_message, functor, expected_results)
-    # If any static_affordance does not match expected_results fail with
-    # <failure_message>. Overridden in livepatch and fips
-    static_affordances = ()  # type: Tuple[StaticAffordance, ...]
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        # A tuple of 3-tuples with (failure_message, callable, expected_result)
+        # If any static_affordance does not match expected_result, fail with
+        # <failure_message>. Overridden in livepatch and fips
+        return ()
 
     def __init__(self, cfg: "Optional[config.UAConfig]" = None) -> None:
         """Setup UAEntitlement instance

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -2,7 +2,9 @@ from uaclient.entitlements import repo
 from uaclient import apt, status, util
 
 try:
-    from typing import Dict, List, Set, Tuple  # noqa
+    from typing import Any, Callable, Dict, List, Set, Tuple  # noqa
+
+    StaticAffordance = Tuple[str, Callable[[], Any], bool]
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -64,9 +66,12 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         "post_enable": ["A reboot is required to complete the install"]
     }
     origin = "UbuntuFIPS"
-    static_affordances = (
-        ("Cannot install FIPS on a container", util.is_container, False),
-    )
+
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        return (
+            ("Cannot install FIPS on a container", util.is_container, False),
+        )
 
 
 class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
@@ -81,10 +86,13 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
     }
     origin = "UbuntuFIPSUpdates"
     description = "Uncertified security updates to FIPS modules"
-    static_affordances = (
-        (
-            "Cannot install FIPS Updates on a container",
-            util.is_container,
-            False,
-        ),
-    )
+
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        return (
+            (
+                "Cannot install FIPS Updates on a container",
+                util.is_container,
+                False,
+            ),
+        )

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -9,7 +9,9 @@ SNAP_CMD = "/usr/bin/snap"
 SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
 
 try:
-    from typing import Any, Dict, Tuple  # noqa: F401
+    from typing import Any, Callable, Dict, Tuple  # noqa: F401
+
+    StaticAffordance = Tuple[str, Callable[[], Any], bool]
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -27,14 +29,16 @@ class LivepatchEntitlement(base.UAEntitlement):
     title = "Livepatch"
     description = "Canonical Livepatch service"
 
-    # Use a lambda so we can mock util.is_container in tests
-    static_affordances = (
-        (
-            "Cannot install Livepatch on a container",
-            lambda: util.is_container(),
-            False,
-        ),
-    )
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        # Use a lambda so we can mock util.is_container in tests
+        return (
+            (
+                "Cannot install Livepatch on a container",
+                lambda: util.is_container(),
+                False,
+            ),
+        )
 
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -22,8 +22,6 @@ class TestCISEntitlementCanEnable:
         self, capsys, entitlement
     ):
         """When entitlement is INACTIVE, can_enable returns True."""
-        # Unset static affordance container check
-        entitlement.static_affordances = ()
         with mock.patch.object(
             entitlement,
             "application_status",
@@ -49,8 +47,6 @@ class TestCISEntitlementEnable:
 
         m_platform_info.side_effect = fake_platform
         m_subp.return_value = ("fakeout", "")
-        # Unset static affordance container check
-        entitlement.static_affordances = ()
 
         with mock.patch(
             M_REPOPATH + "os.path.exists", mock.Mock(return_value=True)


### PR DESCRIPTION
# WIP part of exclusive FIPS vs livepatch support which is yet to be confirmed from kernel/security
Entitlement.static_affordances need to be an instance property
determined at runtime so that FIPS* can prevent FIPS enable if livepatch is running.
issue #1029 .

Once the support is there for dynamically calling external functions,
FIPS can validate livepatch status at FIPE enable time and vice versa.