### PR TITLE
tox.ini: bump pyflakes version to 2.2.0

### DIFF
--- a/tools/constraints-bionic.txt
+++ b/tools/constraints-bionic.txt
@@ -2,6 +2,7 @@ attrs==17.4
 flake8==3.5.0
 py==1.5.2
 pycodestyle==2.3.1
+pyflakes==2.2.0
 pytest==3.3.2
 pytest-cov==2.5.1
 pyyaml==3.12

--- a/tools/constraints-xenial.txt
+++ b/tools/constraints-xenial.txt
@@ -2,6 +2,7 @@ attrs==15.2
 flake8==2.5.4
 pep8==1.7.0
 py==1.4.31
+pyflakes==2.2.0
 pytest==2.8.7
 pytest-cov==2.2.1
 pyyaml==3.11


### PR DESCRIPTION
pyflakes versions older than 2.1.0 are incompatible with Python 3.8
(which is the Python version in the Focal release).
See https://github.com/PyCQA/pyflakes/issues/367 for details.

2.1.1 is the latest version ATM, so bump to that.

Fixes: #1023

To test:
 # on focal before this PR
 tox -e flake8-xenial  # expect traceback with CONSTANT
 tox -e flake8-bionic  # expect traceback with CONSTANT

# after checking out this branch 
 success on both tox -e flake8-xenial and flake8-bionic 

Comparable change done in cloud-init as well https://github.com/canonical/cloud-init/commit/64c33704853087c05c54e157fc42a340a4350159
 