### PR TITLE
fips: add console prompts during to fips and fips-updates

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -225,7 +225,7 @@ def process_entitlement_delta(orig_access, new_access, allow_enable=False):
                 'Skipping entitlement deltas for "%s". No such class', name
             )
             return deltas
-        entitlement = ent_cls()
+        entitlement = ent_cls(assume_yes=allow_enable)
         entitlement.process_contract_deltas(
             orig_access, deltas, allow_enable=allow_enable
         )

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -32,6 +32,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # Optional URL for top-level product service information
     help_doc_url = None  # type: str
 
+    #  Whether to assume yes to any messaging prompts
+    assume_yes = False
+
     @property
     @abc.abstractmethod
     def name(self) -> str:
@@ -55,7 +58,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # <failure_message>. Overridden in livepatch and fips
     static_affordances = ()  # type: Tuple[StaticAffordance, ...]
 
-    def __init__(self, cfg: "Optional[config.UAConfig]" = None) -> None:
+    def __init__(
+        self, cfg: "Optional[config.UAConfig]" = None, assume_yes: bool = False
+    ) -> None:
         """Setup UAEntitlement instance
 
         @param config: Parsed configuration dictionary
@@ -63,6 +68,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         if not cfg:
             cfg = config.UAConfig()
         self.cfg = cfg
+        self.assume_yes = assume_yes
 
     @abc.abstractmethod
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -70,7 +70,11 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         self
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
-            "post_enable": [status.MESSAGE_ENABLE_REBOOT_REQUIRED],
+            "post_enable": [
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="install"
+                )
+            ],
             "pre_disable": [
                 (
                     util.prompt_for_confirmation,
@@ -78,6 +82,11 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                         "assume_yes": self.assume_yes,
                         "msg": status.PROMPT_FIPS_PRE_DISABLE,
                     },
+                )
+            ],
+            "post_disable": [
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="disable operation"
                 )
             ],
         }
@@ -111,7 +120,11 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                     },
                 )
             ],
-            "post_enable": [status.MESSAGE_ENABLE_REBOOT_REQUIRED],
+            "post_enable": [
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="install"
+                )
+            ],
             "pre_disable": [
                 (
                     util.prompt_for_confirmation,
@@ -119,6 +132,11 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                         "assume_yes": self.assume_yes,
                         "msg": status.PROMPT_FIPS_PRE_DISABLE,
                     },
+                )
+            ],
+            "post_disable": [
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="disable operation"
                 )
             ],
         }

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -70,7 +70,16 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         self
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
-            "post_enable": ["A reboot is required to complete the install"]
+            "post_enable": [status.MESSAGE_ENABLE_REBOOT_REQUIRED],
+            "pre_disable": [
+                (
+                    util.prompt_for_confirmation,
+                    {
+                        "assume_yes": self.assume_yes,
+                        "msg": status.PROMPT_FIPS_PRE_DISABLE,
+                    },
+                )
+            ],
         }
 
 
@@ -93,8 +102,23 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
         self
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
-            "post_enable": [
-                "FIPS Updates configured and pending, please reboot to make"
-                " active."
-            ]
+            "pre_enable": [
+                (
+                    util.prompt_for_confirmation,
+                    {
+                        "msg": status.PROMPT_FIPS_UPDATES_PRE_ENABLE,
+                        "assume_yes": self.assume_yes,
+                    },
+                )
+            ],
+            "post_enable": [status.MESSAGE_ENABLE_REBOOT_REQUIRED],
+            "pre_disable": [
+                (
+                    util.prompt_for_confirmation,
+                    {
+                        "assume_yes": self.assume_yes,
+                        "msg": status.PROMPT_FIPS_PRE_DISABLE,
+                    },
+                )
+            ],
         }

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -109,6 +109,9 @@ class RepoEntitlement(base.UAEntitlement):
         if not self.can_disable(silent):
             return False
         self._cleanup()
+        msg_ops = self.messaging.get("post_disable", [])
+        if not handle_message_operations(msg_ops):
+            return False
         return True
 
     def _cleanup(self) -> None:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -75,10 +75,10 @@ class RepoEntitlement(base.UAEntitlement):
         @return: True on success, False otherwise.
         @raises: UserFacingError on failure to install suggested packages
         """
-        if not self.can_enable(silent=silent_if_inapplicable):
-            return False
         msg_ops = self.messaging.get("pre_enable", [])
         if not handle_message_operations(msg_ops):
+            return False
+        if not self.can_enable(silent=silent_if_inapplicable):
             return False
         self.setup_apt_config()
         if self.packages:
@@ -103,10 +103,10 @@ class RepoEntitlement(base.UAEntitlement):
         return True
 
     def disable(self, silent=False):
-        if not self.can_disable(silent):
-            return False
         msg_ops = self.messaging.get("pre_disable", [])
         if not handle_message_operations(msg_ops):
+            return False
+        if not self.can_disable(silent):
             return False
         self._cleanup()
         return True

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from uaclient import config
 
 try:
-    from typing import Any, Dict, List  # noqa
+    from typing import Any, Dict, List, Optional  # noqa
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -90,6 +90,7 @@ def entitlement_factory(tmpdir):
         affordances: "Dict[str, Any]" = None,
         directives: "Dict[str, Any]" = None,
         entitled: bool = True,
+        assume_yes: "Optional[bool]" = None,
         suites: "List[str]" = None
     ):
         cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
@@ -103,6 +104,9 @@ def entitlement_factory(tmpdir):
                 suites=suites,
             ),
         )
-        return cls(cfg)
+        args = {}
+        if assume_yes is not None:
+            args["assume_yes"] = assume_yes
+        return cls(cfg, **args)
 
     return factory_func

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -52,7 +52,11 @@ class TestFIPSEntitlementDefaults:
         entitlement = fips_entitlement_factory(assume_yes=assume_yes)
         expected_msging = {
             "fips": {
-                "post_enable": [status.MESSAGE_ENABLE_REBOOT_REQUIRED],
+                "post_enable": [
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="install"
+                    )
+                ],
                 "pre_disable": [
                     (
                         util.prompt_for_confirmation,
@@ -60,6 +64,11 @@ class TestFIPSEntitlementDefaults:
                             "assume_yes": assume_yes,
                             "msg": status.PROMPT_FIPS_PRE_DISABLE,
                         },
+                    )
+                ],
+                "post_disable": [
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="disable operation"
                     )
                 ],
             },
@@ -73,7 +82,11 @@ class TestFIPSEntitlementDefaults:
                         },
                     )
                 ],
-                "post_enable": [status.MESSAGE_ENABLE_REBOOT_REQUIRED],
+                "post_enable": [
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="install"
+                    )
+                ],
                 "pre_disable": [
                     (
                         util.prompt_for_confirmation,
@@ -81,6 +94,11 @@ class TestFIPSEntitlementDefaults:
                             "assume_yes": assume_yes,
                             "msg": status.PROMPT_FIPS_PRE_DISABLE,
                         },
+                    )
+                ],
+                "post_disable": [
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="disable operation"
                     )
                 ],
             },

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -325,11 +325,7 @@ class TestRepoEnable:
         "pre_enable_msg, output, can_enable_call_count",
         (
             (["msg1", (lambda: False, {}), "msg2"], "msg1\n", 0),
-            (
-                ["msg1", (lambda: True, {}), "msg2"],
-                "msg1\nmsg2\n",
-                1,
-            ),
+            (["msg1", (lambda: True, {}), "msg2"], "msg1\nmsg2\n", 1),
         ),
     )
     @mock.patch.object(RepoTestEntitlement, "can_enable", return_value=False)

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -322,25 +322,23 @@ class TestRepoEnable:
         assert [expected_call] == m_can_enable.call_args_list
 
     @pytest.mark.parametrize(
-        "pre_enable_msg, output, setup_apt_call_count",
+        "pre_enable_msg, output, can_enable_call_count",
         (
             (["msg1", (lambda: False, {}), "msg2"], "msg1\n", 0),
             (
                 ["msg1", (lambda: True, {}), "msg2"],
-                "msg1\nmsg2\nRepo Test Class enabled\n",
+                "msg1\nmsg2\n",
                 1,
             ),
         ),
     )
-    @mock.patch.object(RepoTestEntitlement, "setup_apt_config")
-    @mock.patch.object(RepoTestEntitlement, "can_enable", return_value=True)
+    @mock.patch.object(RepoTestEntitlement, "can_enable", return_value=False)
     def test_enable_can_exit_on_pre_enable_messaging_hooks(
         self,
-        _can_enable,
-        setup_apt_config,
+        m_can_enable,
         pre_enable_msg,
         output,
-        setup_apt_call_count,
+        can_enable_call_count,
         entitlement,
         capsys,
     ):
@@ -353,7 +351,7 @@ class TestRepoEnable:
                 entitlement.enable()
         stdout, _ = capsys.readouterr()
         assert output == stdout
-        assert setup_apt_call_count == setup_apt_config.call_count
+        assert can_enable_call_count == m_can_enable.call_count
 
     @pytest.mark.parametrize(
         "pre_disable_msg, output, remove_apt_call_count",

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -215,7 +215,8 @@ To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
 See https://ubuntu.com/advantage"""
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
-MESSAGE_ENABLE_REBOOT_REQUIRED = "A reboot is required to complete install"
+MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL = """\
+A reboot is required to complete {operation}"""
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
 Service {name} is recommended by default. Run: sudo ua enable {name}"""
 MESSAGE_DETACH_SUCCESS = "This machine is now detached"

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -163,6 +163,21 @@ See https://ubuntu.com/advantage"""
 MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 
+PROMPT_YES_NO = """Are you sure? (y/N) """
+PROMPT_FIPS_UPDATES_PRE_ENABLE = (
+    """\
+This system will NOT be considered FIPS certified, but will include security
+and bug fixes to the FIPS packages.
+"""
+    + PROMPT_YES_NO
+)
+PROMPT_FIPS_PRE_DISABLE = (
+    """\
+This will disable access to certified FIPS packages.
+"""
+    + PROMPT_YES_NO
+)
+
 STATUS_UNATTACHED_TMPL = "{name: <14}{available: <11}{description}"
 
 STATUS_HEADER = "SERVICE       ENTITLED  STATUS    DESCRIPTION"
@@ -200,6 +215,7 @@ To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
 See https://ubuntu.com/advantage"""
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
+MESSAGE_ENABLE_REBOOT_REQUIRED = "A reboot is required to complete install"
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
 Service {name} is recommended by default. Run: sudo ua enable {name}"""
 MESSAGE_DETACH_SUCCESS = "This machine is now detached"

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -8,12 +8,18 @@ from uaclient import status
 
 @mock.patch("uaclient.cli.os.getuid", return_value=0)
 class TestDisable:
+    @pytest.mark.parametrize("assume_yes", (True, False))
     @pytest.mark.parametrize(
         "disable_return,return_code", ((True, 0), (False, 1))
     )
     @mock.patch("uaclient.cli.entitlements")
     def test_entitlement_instantiated_and_disabled(
-        self, m_entitlements, _m_getuid, disable_return, return_code
+        self,
+        m_entitlements,
+        _m_getuid,
+        disable_return,
+        return_code,
+        assume_yes,
     ):
         m_entitlement_cls = mock.Mock()
         m_entitlement = m_entitlement_cls.return_value
@@ -25,10 +31,13 @@ class TestDisable:
 
         args_mock = mock.Mock()
         args_mock.name = "testitlement"
+        args_mock.assume_yes = assume_yes
 
         ret = action_disable(args_mock, m_cfg)
 
-        assert [mock.call(m_cfg)] == m_entitlement_cls.call_args_list
+        assert [
+            mock.call(m_cfg, assume_yes=assume_yes)
+        ] == m_entitlement_cls.call_args_list
 
         expected_disable_call = mock.call()
         assert [expected_disable_call] == m_entitlement.disable.call_args_list

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -13,6 +13,8 @@ from contextlib import contextmanager
 from functools import wraps
 from http.client import HTTPMessage  # noqa: F401
 
+from uaclient import status
+
 try:
     from typing import (  # noqa: F401
         Any,
@@ -401,7 +403,7 @@ def prompt_for_confirmation(msg: str = "", assume_yes: bool = False) -> bool:
     if assume_yes:
         return True
     if not msg:
-        msg = "Are you sure? (y/N) "
+        msg = status.PROMPT_YES_NO
     value = input(msg)
     if value.lower().strip() in ["y", "yes"]:
         return True


### PR DESCRIPTION
Add the following prompts to FIPS and FIPS with Updates:
  * ua enable fips-updates: 
```
This system will NOT be considered FIPS certified, but will include security    
and bug fixes to the FIPS packages.
Are you sure? (y/N)
```
   * ua disable fips and ua disable fips-updates:
```
This will disable access to certified FIPS packages.                            
Are you sure? (y/N)
```
This addresses parts of https://github.com/canonical/ubuntu-advantage-client/issues/1031
Expect one more branch which will add remaining prompts and messaging for post_disable messaging.


to test:
```
cat > ua-dev.yaml <<EOF
#cloud-config
packages:
 - git
 - make
runcmd:
 - git clone -b feature/fips-support https://github.com/blackboxsw/ubuntu-advantage-client.git /var/tmp/uac
 - cd /var/tmp/uac/
 - make deps
 - dpkg-buildpackage -us -uc
 - apt-get remove ubuntu-advantage-tools   # Issue: #1044
 - dpkg -i /var/tmp/ubuntu-advantage-tools_20.4_amd64.deb
 - ua attach <YOUR_TOKEN>
EOF

multipass launch daily:xenial --cloud-init ua-dev.yaml  -n dev-xx
# connect to the vm and test fips prompts
multipass connect dev-xx 
cloud-init status --wait --long
sudo ua status  
sudo ua enable fips-updates  # of fips (which doesn't have a prompt)
```

