### PR TITLE
fips: add pre_enable prompt indicating that additional debs required

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -70,6 +70,15 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         self
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
+            "pre_enable": [
+                (
+                    util.prompt_for_confirmation,
+                    {
+                        "msg": status.PROMPT_FIPS_PRE_ENABLE,
+                        "assume_yes": self.assume_yes,
+                    },
+                )
+            ],
             "post_enable": [
                 status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
                     operation="install"

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -52,6 +52,15 @@ class TestFIPSEntitlementDefaults:
         entitlement = fips_entitlement_factory(assume_yes=assume_yes)
         expected_msging = {
             "fips": {
+                "pre_enable": [
+                    (
+                        util.prompt_for_confirmation,
+                        {
+                            "assume_yes": assume_yes,
+                            "msg": status.PROMPT_FIPS_PRE_ENABLE,
+                        },
+                    )
+                ],
                 "post_enable": [
                     status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
                         operation="install"

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -164,6 +164,13 @@ MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 
 PROMPT_YES_NO = """Are you sure? (y/N) """
+PROMPT_FIPS_PRE_ENABLE = (
+    """\
+Installation of additional packages are required to make this system FIPS
+compliant.
+"""
+    + PROMPT_YES_NO
+)
 PROMPT_FIPS_UPDATES_PRE_ENABLE = (
     """\
 This system will NOT be considered FIPS certified, but will include security


### PR DESCRIPTION
Addresses the last remaining FIPS-related prompt and message when
running: ua enable fips.

Fixes: #1031

To test:
```
cat > ua-dev.yaml <<EOF
#cloud-config
packages:
 - git
 - make
runcmd:
 - git clone -b feature/fips-pre-enable-prompt https://github.com/blackboxsw/ubuntu-advantage-client.git /var/tmp/uac
 - cd /var/tmp/uac/
 - make deps
 - dpkg-buildpackage -us -uc
 - apt-get remove ubuntu-advantage-tools   # Issue: #1044
 - dpkg -i /var/tmp/ubuntu-advantage-tools_20.4_amd64.deb
 - ua attach <YOUR_TOKEN>
EOF

multipass launch daily:xenial --cloud-init ua-dev.yaml  -n dev-xx
# connect to the vm and test fips prompts
multipass connect dev-xx
cloud-init status --wait --long
sudo ua status
sudo ua enable fips