### PR TITLE
WIP integration tests: modification to reduce duplication

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1,15 +1,21 @@
 @uses.config.contract_token
 Feature: Enable command behaviour when attached to an UA subscription
 
-    @series.trusty
-    Scenario: Attached enable Livepatch service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+    Background: Attached enable a service in a trusty lxd container
+        Given a series lxd container with ubuntu-advantage-tools installed
+        |  series   |
+        |  trusty   |
+        |  focal    |
         When I attach contract_token with sudo
         And I run `ua enable livepatch` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
+
+    @wip
+    @series.trusty
+    Scenario: Attached enable Livepatch service in a trusty lxd container
         When I run `ua enable livepatch` with sudo
         Then I will see the following on stdout:
             """
@@ -17,15 +23,9 @@ Feature: Enable command behaviour when attached to an UA subscription
             Cannot install Livepatch on a container
             """
 
+    @wip
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable cc-eal` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable cc-eal` with sudo
         Then I will see the following on stdout
             """
@@ -35,13 +35,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable CIS Audit service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable cis-audit` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable cis-audit` with sudo
         Then I will see the following on stdout:
             """
@@ -52,13 +45,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable UA Apps service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable esm-apps` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable esm-apps` with sudo
         Then I will see the following on stdout:
             """
@@ -69,13 +55,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable NIST-certified FIPS service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable fips` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable fips` with sudo
         Then I will see the following on stdout:
             """
@@ -85,13 +64,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable Uncertified FIPS service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable fips-updates` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable fips-updates` with sudo
         Then I will see the following on stdout:
             """
@@ -101,13 +73,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable of an unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable foobar` with sudo
         Then I will see the following on stderr:
             """
@@ -117,13 +82,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable of a known service already enabled (UA Infra) in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
-        And I run `ua enable esm-infra` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable esm-infra` with sudo
         Then I will see the following on stdout:
             """
@@ -131,3 +89,79 @@ Feature: Enable command behaviour when attached to an UA subscription
             ESM Infra is already enabled.
             See: sudo ua status
             """
+    @wip
+    @series.focal
+    Scenario: Attached enable Livepatch service in a focal lxd container
+        When I run `ua enable livepatch` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install Livepatch on a container
+            """
+
+    @series.focal
+    Scenario: Attached enable Common Criteria service in a focal lxd container
+        When I run `ua enable cc-eal` with sudo
+        Then I will see the following on stdout
+            """
+            One moment, checking your subscription first
+            CC EAL2 is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            """
+
+    @series.focal
+    Scenario: Attached enable CIS Audit service in a focal lxd container
+        When I run `ua enable cis-audit` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            This subscription is not entitled to CIS Audit.
+            For more information see: https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Attached enable UA Apps service in a focal lxd container
+        When I run `ua enable esm-apps` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            This subscription is not entitled to ESM Apps.
+            For more information see: https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Attached enable NIST-certified FIPS service in a focal lxd container
+        When I run `ua enable fips` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install FIPS on a container
+            """
+
+    @series.focal
+    Scenario: Attached enable Uncertified FIPS service in a focal lxd container
+        When I run `ua enable fips-updates` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install FIPS Updates on a container
+            """
+
+    @series.focal
+    Scenario: Attached enable of an unknown service in a focal lxd container
+        When I run `ua enable foobar` with sudo
+        Then stderr matches regexp:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+    @series.focal
+    Scenario: Attached enable of a known service already enabled (UA Infra) in a focal lxd container
+        When I run `ua enable esm-infra` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            ESM Infra is already enabled.
+            See: sudo ua status
+            """
+

--- a/features/environment.py
+++ b/features/environment.py
@@ -152,6 +152,7 @@ def before_scenario(context: Context, scenario: Scenario):
         parts = tag.split(".")
         if parts[0] == "series":
             series = parts[1]
+            context.current_series = series
             if series not in context.series_image_name:
                 create_uat_lxd_image(context, series)
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -10,8 +10,9 @@ from features.util import launch_lxd_container, lxc_exec
 CONTAINER_PREFIX = "behave-test-"
 
 
-@given("a `{series}` lxd container with ubuntu-advantage-tools installed")
-def given_a_lxd_container(context, series):
+@given("a series lxd container with ubuntu-advantage-tools installed")
+def given_a_lxd_container(context):
+    series = context.current_series
     if series in context.reuse_container:
         context.container_name = context.reuse_container[series]
     else:


### PR DESCRIPTION
what do you think about adding the background scenario to our feature files?
I've added this just to attached_enable. 
Compared to PR1034 this file has 265 lines, this way it would have 166lines.
If it is ok, so I need to change all other feature files.

to test it: (I've added wip tag)
$ UACLIENT_BEHAVE_CONTRACT_TOKEN=$contract_token tox -e behave -- --tags=wip attached_enable.feature
(or remove the tags option to run all scenarios)