### PR TITLE
livepatch: run snap wait system snap.seeded before trying to install

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -66,14 +66,14 @@ class LivepatchEntitlement(base.UAEntitlement):
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
                 )
-                util.subp(
-                    [SNAP_CMD, "wait", "system", "seed.loaded"], capture=True
-                )
             elif "snapd" not in apt.get_installed_packages():
                 raise exceptions.UserFacingError(
                     "/usr/bin/snap is present but snapd is not installed;"
                     " cannot enable {}".format(self.title)
                 )
+            util.subp(
+                [SNAP_CMD, "wait", "system", "seed.loaded"], capture=True
+            )
             print("Installing canonical-livepatch snap")
             try:
                 util.subp(

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -404,10 +404,12 @@ class TestLivepatchEntitlementEnable:
             ["apt-get", "install", "--assume-yes", "snapd"],
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
-        ),
+        )
+    ]
+    mocks_snap_wait_seed = [
         mock.call(
             ["/usr/bin/snap", "wait", "system", "seed.loaded"], capture=True
-        ),
+        )
     ]
     mocks_livepatch_install = [
         mock.call(
@@ -416,7 +418,9 @@ class TestLivepatchEntitlementEnable:
             retry_sleeps=[0.5, 1, 5],
         )
     ]
-    mocks_install = mocks_snapd_install + mocks_livepatch_install
+    mocks_install = (
+        mocks_snapd_install + mocks_snap_wait_seed + mocks_livepatch_install
+    )
     mocks_config = [
         mock.call(
             [
@@ -535,7 +539,9 @@ class TestLivepatchEntitlementEnable:
         m_app_status.return_value = application_status, "enabled"
         assert entitlement.enable()
         assert (
-            self.mocks_livepatch_install + self.mocks_config
+            self.mocks_snap_wait_seed
+            + self.mocks_livepatch_install
+            + self.mocks_config
             in m_subp.call_args_list
         )
         msg = (


### PR DESCRIPTION
Before installing additional snaps, we need to wait for snap seeding
to complete. Make sure blocking is called always instead of just
when we have installed the snapd deb package.

Fixes: #1049