### PR TITLE
verison: bump to version 24. 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-ubuntu-advantage-tools (20.4) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (24.0) UNRELEASED; urgency=medium
 
-  * Open 20.4 release for development
+  * Open 24.0 release for development
 
  -- Chad Smith <chad.smith@canonical.com>  Mon, 30 Mar 2020 15:47:18 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-ubuntu-advantage-tools (24.0) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (24) UNRELEASED; urgency=medium
 
-  * Open 24.0 release for development
+  * Change package versioning scheme which is milestone-based instead
+    of year-based
 
- -- Chad Smith <chad.smith@canonical.com>  Mon, 30 Mar 2020 15:47:18 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 15 May 2020 15:41:58 -0600
 
 ubuntu-advantage-tools (20.3) focal; urgency=medium
 

--- a/tools/make-release
+++ b/tools/make-release
@@ -2,13 +2,17 @@
 set -ex
 #
 # Create a native package release of ubuntu-advantage-tools for a given series
-# This assumes latest debian/changelog entry version is (MM.NN) UNRELEASED.
+# This assumes latest debian/changelog entry version is (XX.YY) UNRELEASED.
 #
-# Release this package version to devel release with the format: YY.N where
-# YY is the 2-digit year and N is a counter of public releases in that year.
-#
-# When releasing to stable series, an ~ubuntu1~XX.YY.1 suffix will be added
-# where XX.YY is the release version 18.04, 16.04 etc.
+# Release this package version to devel release with the format: XX.Y where
+# XX is a major milestone version represented in
+#   https://github.com/canonical/ubuntu-advantage-client/milestones
+# YY is a minor release count relative to the number of releases published
+#   of XX
+# When bugfixing an existing XX.YY release, append a .Z patch counter
+
+# When releasing to stable series, an ~ubuntu1~RR.SS.1 suffix will be added
+# where RR.SS is the release version 18.04, 16.04 etc.
 
 # This scipt temporarily sets the appropriate version and series in the most
 # recent debian/changelog entry, runs build-package, and prints the steps
@@ -86,7 +90,7 @@ else
 fi
 
 if [ "${SERIES}" != "${DEVEL_SERIES}" ]; then
-  # Only append ~XX.YY.1 to stable releases
+  # Only append ~RR.SS.1 to stable releases
   CHANGELOG_VERSION=${CHANGELOG_VERSION}~${RELEASE_NUMBER/ LTS/}.1
 fi
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from subprocess import check_output
 
 
-__VERSION__ = "20.4"
+__VERSION__ = "24"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
Update version schema to be milestone-based major revision instead of year-based

Detailed discussion here, but ultimately each major upstream pkg version will be a whole number and map to a github project milestone: 24 -> 25 represents a significant feature milestone

Any bug-fix releases will generally result in a minor pkg revision increment: 24 -> 24.1

Each package uploaded into an Ubuntu stable release will carry a ~RR.SS.X suffix where RR.SS maps to the RELEASE_VERSION 14.04, 16.04, 18.04 etc.

Detailed discussion here and docs and tool PRs to follow about each separate release.
This is just groundwork to move us to whole number upstream release versions.

https://docs.google.com/document/d/1rmq-Vm18lmCmxT-aTzErtzL0AZt3-ZRWtny6FQE2Ah4/edit#

Immediate PR to follow will be opening version (25) for development on master