### PR TITLE
Open milestone 25 for active development

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (25.0) UNRELEASED; urgency=medium
+
+  * Open 25.0 release for active development
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 26 May 2020 21:23:29 -0600
+
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,19 @@
-ubuntu-advantage-tools (20.4) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
-  * Open 20.4 release for development
+  * New bug-fix-only release 24.1:
+    - livepatch: run snap wait system snap.seeded before trying to install
+      (GH: #1049)
+    - version: return debian/changelog version when git describe fails to
+      match upstream <major>.<minor> tags for git-ubuntu workflow
+      (GH: #1058)
 
- -- Chad Smith <chad.smith@canonical.com>  Mon, 30 Mar 2020 15:47:18 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:07:17 -0600
+
+ubuntu-advantage-tools (24.0) groovy; urgency=medium
+
+  * bump version to 24.0 for new versioninig scheme
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:04:33 -0600
 
 ubuntu-advantage-tools (20.3) focal; urgency=medium
 

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -1,0 +1,61 @@
+import mock
+
+import os.path
+
+from uaclient import util
+from uaclient.version import get_version
+
+
+@mock.patch("uaclient.util.subp")
+class TestGetVersion:
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "24.1~18.04.1")
+    def test_get_version_returns_packaged_version(self, m_subp):
+        assert "24.1~18.04.1" == get_version()
+        assert 0 == m_subp.call_count
+
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_get_version_returns_matching_git_describe_long(
+        self, m_exists, m_subp
+    ):
+        m_subp.return_value = ("24.1-5-g12345678", "")
+        assert "24.1-5-g12345678" == get_version()
+        assert [
+            mock.call(
+                ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
+            )
+        ] == m_subp.call_args_list
+        top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        top_dir_git = os.path.join(top_dir, ".git")
+        assert [mock.call(top_dir_git)] == m_exists.call_args_list
+
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_returns_dpkg_parsechangelog_on_git_ubuntu_pkg_branch(
+        self, m_exists, m_subp
+    ):
+        """Call dpkg-parsechangelog if git describe fails to --match=[0-9]*"""
+
+        def fake_subp(cmd):
+            if cmd[0] == "git":
+                # Not matching tag on git-ubuntu pkg branches
+                raise util.ProcessExecutionError(
+                    "fatal: No names found, cannot describe anything."
+                )
+            if cmd[0] == "dpkg-parsechangelog":
+                return ("24.1\n", "")
+            assert False, "Unexpected subp cmd {}".format(cmd)
+
+        m_subp.side_effect = fake_subp
+
+        assert "24.1" == get_version()
+        expected_calls = [
+            mock.call(
+                ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
+            ),
+            mock.call(["dpkg-parsechangelog", "-S", "version"]),
+        ]
+        assert expected_calls == m_subp.call_args_list
+        top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        top_dir_git = os.path.join(top_dir, ".git")
+        assert [mock.call(top_dir_git)] == m_exists.call_args_list

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from uaclient import util
 
 
-__VERSION__ = "20.4"
+__VERSION__ = "25.0"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -5,7 +5,7 @@ These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
 import os.path
-from subprocess import check_output
+from uaclient import util
 
 
 __VERSION__ = "20.4"
@@ -13,11 +13,28 @@ PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 
 def get_version(_args=None):
-    """Return the package version if set, otherwise return git describe."""
+    """Return the packaged version as a string
+
+         Prefer the binary PACKAGED_VESION set by debian/rules to DEB_VERSION.
+         If unavailable, check for a .git development environments:
+           a. If run in our upstream repo `git describe` will gives a leading
+              XX.Y so return the --long version to allow daily build recipes
+              to count commit offset from upstream's XX.Y signed tag.
+           b. If run in a git-ubuntu pkg repo, upstream tags aren't visible,
+              parse the debian/changelog in that case
+    """
     if not PACKAGED_VERSION.startswith("@@PACKAGED_VERSION"):
         return PACKAGED_VERSION
     topdir = os.path.dirname(os.path.dirname(__file__))
     if os.path.exists(os.path.join(topdir, ".git")):
         cmd = ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
-        return check_output(cmd, universal_newlines=True).strip()
+        try:
+            out, _ = util.subp(cmd)
+            return out.strip()
+        except util.ProcessExecutionError:
+            # Rely on debian/changelog because we are in a git-ubuntu or other
+            # packaging repo
+            cmd = ["dpkg-parsechangelog", "-S", "version"]
+            out, _ = util.subp(cmd)
+            return out.strip()
     return __VERSION__


### PR DESCRIPTION
Bump the version of ua-tools under active development to version 25 to ensure that daily recipe
builds from 'master' are greater than any public releases of ubuntu-advantage-tools which
were published from a release-24 branch.

The master branch will remain in version 25 until release-25 branch is created for public release.
At that time, master' will open version 26 for active development.

This version follows our new versioning scheme proposal which is a milestone-based versioning instead of year-based versioning scheme as documented in the [branch release strategy spec](https://docs.google.com/document/d/1rmq-Vm18lmCmxT-aTzErtzL0AZt3-ZRWtny6FQE2Ah4/edit#) 


Also in this branch:
 - manually add debian/changelog entries for 24.0 and 24.1 in existing release-24 to ensure master
   does not lose the changelog content for any point release published from release-24
 - git cherry-pick 64934fa1ab31a0e704864dd8068c61f5dd8e09f2 from release-24 branch, to support running tox in a git-ubuntu packaging branch

Use the following procedure to recreate this branch:
```
 git checkout upstream/master -b master
 git pull

# grab uaclient/version.py fix to support tox on git-ubuntu based branches
git cherry-pick 64934fa1ab31a0e704864dd8068c61f5dd8e09f2

# redact existing top-most debian/changelog entry for 20.4 (as we will change it to 25.0)
tail -n +7 debian/changelog  >changelog
mv changelog debian/changelog

# grab the two debian/changelog entries from the release-24 branch so we don't lose released changelog history in master
git show upstream/release-24:debian/changelog | head -n 17 | cat - debian/changelog > changelog
mv changelog debian/changelog
git commit -am 'changelog: sync 24.0 and 24.1 debian/changelog entries'

sed -i 's/20.4/25.0/' uaclient/version.py
git commit -am 'version.py: 25.0'
dch --newversion 25.0 -m 'Open 25.0 release for active development'
git commit -am 'update changelog opening version 25.0 for development'
```