### PR TITLE
Update disable and enable commands

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -28,8 +28,12 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable livepatch` with sudo
         Then I will see the following on stdout:
             """
+            livepatch
             Livepatch is not currently enabled
             See: sudo ua status
+
+            disabled results:
+            Services not disabled: livepatch
             """
 
     @series.trusty
@@ -42,10 +46,49 @@ Feature: Command behaviour when attached to an UA subscription
             This command must be run as root (try using sudo)
             """
         When I run `ua disable foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            disabled results:
+            Services not found: foobar
+            """
+
+    @series.trusty
+    Scenario: Attached disable of different services in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua disable esm-infra livepatch foobar` as non-root
         Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua disable esm-infra livepatch foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            esm-infra
+            Updating package lists
+
+            livepatch
+            Livepatch is not currently enabled
+            See: sudo ua status
+            """
+        And stderr matches regexp:
             """
             Cannot disable 'foobar'
             For a list of services see: sudo ua status
+            """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+            """
+            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
+            """
+        When I run `apt-cache policy` with sudo
+        Then stdout matches regexp:
+            """
+            -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-updates/main amd64 Packages
+            """
+        And stdout matches regexp:
+            """
+            -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-security/main amd64 Packages
             """
 
     @series.trusty
@@ -60,6 +103,7 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
             """
+            esm-infra
             Updating package lists
             """
         When I run `ua status` with sudo
@@ -176,8 +220,40 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable livepatch` with sudo
         Then I will see the following on stdout:
             """
+            livepatch
             Livepatch is not currently enabled
             See: sudo ua status
+            """
+
+    @wip
+    @series.focal
+    Scenario: Attached disable of an already disabled, enabled and not found services
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua disable livepatch esm-infra foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua disable livepatch esm-infra foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            livepatch
+            Livepatch is not currently enabled
+            See: sudo ua status
+
+            esm-infra
+            Updating package lists
+            """
+        And stderr matches regexp:
+            """
+            Cannot disable 'foobar'
+            For a list of services see: sudo ua status
+            """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+            """
+            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
             """
 
     @series.focal
@@ -209,6 +285,7 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
             """
+            esm-infra
             Updating package lists
             """
         When I run `ua status` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -28,12 +28,8 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable livepatch` with sudo
         Then I will see the following on stdout:
             """
-            livepatch
             Livepatch is not currently enabled
             See: sudo ua status
-
-            disabled results:
-            Services not disabled: livepatch
             """
 
     @series.trusty
@@ -46,16 +42,16 @@ Feature: Command behaviour when attached to an UA subscription
             This command must be run as root (try using sudo)
             """
         When I run `ua disable foobar` with sudo
-        Then I will see the following on stdout:
+        Then I will see the following on stderr:
             """
-            disabled results:
-            Services not found: foobar
+            Cannot disable 'foobar'
+            For a list of services see: sudo ua status
             """
 
     @series.trusty
     Scenario: Attached disable of different services in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable esm-infra livepatch foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -64,10 +60,7 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable esm-infra livepatch foobar` with sudo
         Then I will see the following on stdout:
             """
-            esm-infra
             Updating package lists
-
-            livepatch
             Livepatch is not currently enabled
             See: sudo ua status
             """
@@ -103,7 +96,6 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
             """
-            esm-infra
             Updating package lists
             """
         When I run `ua status` with sudo
@@ -138,7 +130,7 @@ Feature: Command behaviour when attached to an UA subscription
             Updating package lists
             This machine is now detached
             """
-       When I run `ua status` as non-root
+       When I run `ua status --beta` as non-root
        Then stdout matches regexp:
            """
            SERVICE       AVAILABLE  DESCRIPTION
@@ -168,6 +160,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
             This machine is already attached
             """
+
     @series.trusty
     Scenario: Attached show version in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
@@ -220,16 +213,14 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable livepatch` with sudo
         Then I will see the following on stdout:
             """
-            livepatch
             Livepatch is not currently enabled
             See: sudo ua status
             """
 
-    @wip
     @series.focal
     Scenario: Attached disable of an already disabled, enabled and not found services
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable livepatch esm-infra foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -238,11 +229,8 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable livepatch esm-infra foobar` with sudo
         Then I will see the following on stdout:
             """
-            livepatch
             Livepatch is not currently enabled
             See: sudo ua status
-
-            esm-infra
             Updating package lists
             """
         And stderr matches regexp:
@@ -285,7 +273,6 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
             """
-            esm-infra
             Updating package lists
             """
         When I run `ua status` with sudo
@@ -311,7 +298,7 @@ Feature: Command behaviour when attached to an UA subscription
             Updating package lists
             This machine is now detached
             """
-       When I run `ua status` as non-root
+       When I run `ua status --beta` as non-root
        Then stdout matches regexp:
            """
            SERVICE       AVAILABLE  DESCRIPTION

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -14,8 +14,6 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-
-            <service>
             Cannot install <title> on a container
             """
 
@@ -59,7 +57,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable cc-eal` with sudo
+        When I run `ua enable cc-eal --beta` with sudo
         Then I will see the following on stdout
             """
             One moment, checking your subscription first
@@ -75,7 +73,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable <service>` with sudo
+        When I run `ua enable <service> --beta` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -121,8 +119,6 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-
-            esm-infra
             ESM Infra is already enabled.
             See: sudo ua status
             """
@@ -130,7 +126,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached enable a disabled, enable and unknown service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable livepatch esm-infra foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -140,17 +136,33 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-
-            livepatch
             Cannot install Livepatch on a container
-
-            esm-infra
             ESM Infra is already enabled.
             See: sudo ua status
             """
         And I will see the following on stderr:
             """
             Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+    @series.trusty
+    Scenario: Attached enable a disabled beta service and unknown service in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable fips foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable fips foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable 'foobar, fips'
             For a list of services see: sudo ua status
             """
 
@@ -167,8 +179,6 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-
-            <service>
             Cannot install <title> on a container
             """
 
@@ -212,7 +222,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable cc-eal` with sudo
+        When I run `ua enable cc-eal --beta` with sudo
         Then I will see the following on stdout
             """
             One moment, checking your subscription first
@@ -228,7 +238,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable <service>` with sudo
+        When I run `ua enable <service> --beta` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -270,16 +280,14 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-
-            esm-infra
             ESM Infra is already enabled.
             See: sudo ua status
             """
 
     @series.focal
-    Scenario: Attached enable a disabled, enable and unknown service in a focal lxd container
+    Scenario: Attached enable a disabled, enabled and unknown service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable livepatch esm-infra foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -289,16 +297,32 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-
-            livepatch
             Cannot install Livepatch on a container
-
-            esm-infra
             ESM Infra is already enabled.
             See: sudo ua status
             """
         And stderr matches regexp:
             """
             Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+    @series.focal
+    Scenario: Attached enable a disabled beta service and unknown service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable fips foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable fips foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable 'foobar, fips'
             For a list of services see: sudo ua status
             """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Enable command behaviour when attached to an UA subscription
 
-    @wip
     @series.trusty
     Scenario Outline:  Attached enable of non-container services in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
@@ -179,7 +178,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips         | FIPS         | --assume-yes --beta  |
            | fips-updates | FIPS Updates | --assume-yes --beta  |
 
-    @wip
     @series.focal
     Scenario Outline:  Attached enable of non-container beta services in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1,6 +1,7 @@
 @uses.config.contract_token
 Feature: Enable command behaviour when attached to an UA subscription
 
+    @wip
     @series.trusty
     Scenario Outline:  Attached enable of non-container services in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
@@ -14,6 +15,8 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
+
+            <service>
             Cannot install <title> on a container
             """
 
@@ -96,7 +99,11 @@ Feature: Enable command behaviour when attached to an UA subscription
             This command must be run as root (try using sudo)
             """
         When I run `ua enable foobar` with sudo
-        Then I will see the following on stderr:
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And I will see the following on stderr:
             """
             Cannot enable 'foobar'
             For a list of services see: sudo ua status
@@ -115,8 +122,37 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
+
+            esm-infra
             ESM Infra is already enabled.
             See: sudo ua status
+            """
+
+    @series.trusty
+    Scenario: Attached enable a disabled, enable and unknown service in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable livepatch esm-infra foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable livepatch esm-infra foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+
+            livepatch
+            Cannot install Livepatch on a container
+
+            esm-infra
+            ESM Infra is already enabled.
+            See: sudo ua status
+            """
+        And I will see the following on stderr:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
             """
 
     @series.focal
@@ -132,6 +168,8 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
+
+            <service>
             Cannot install <title> on a container
             """
 
@@ -234,6 +272,35 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
+
+            esm-infra
             ESM Infra is already enabled.
             See: sudo ua status
+            """
+
+    @series.focal
+    Scenario: Attached enable a disabled, enable and unknown service in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua enable livepatch esm-infra foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable livepatch esm-infra foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+
+            livepatch
+            Cannot install Livepatch on a container
+
+            esm-infra
+            ESM Infra is already enabled.
+            See: sudo ua status
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
             """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -49,17 +49,17 @@ Feature: Command behaviour when unattached
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua <command> foobar` with sudo
+        When I run `ua <command> <service>` with sudo
         Then I will see the following on stderr:
             """
-            Cannot <command> 'foobar'
+            Cannot <command> '<message>'
             For a list of services see: sudo ua status
             """
 
         Examples: ua commands
-           | command |
-           | enable  |
-           | disable |
+           | command | service     | message     |
+           | enable  | foobar      | foobar      |
+           | disable | foobar foo  | foo, foobar |
 
     @series.trusty
     Scenario: Unattached auto-attach does nothing in a trusty lxd container
@@ -126,17 +126,17 @@ Feature: Command behaviour when unattached
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua <command> foobar` with sudo
+        When I run `ua <command> <service>` with sudo
         Then stderr matches regexp:
             """
-            Cannot <command> 'foobar'
+            Cannot <command> '<message>'
             For a list of services see: sudo ua status
             """
 
         Examples: ua commands
-           | command |
-           | disable |
-           | enable  |
+           | command | service     | message     |
+           | disable | foobar      | foobar      |
+           | enable  | foobar foo  | foo, foobar |
 
     @series.focal
     Scenario: Unattached auto-attach does nothing in a focal lxd container

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -37,28 +37,8 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command |
-           | enable  |
-           | disable |
-
-    @series.trusty
-    Scenario Outline: Unattached command of an unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua <command> foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua <command> <service>` with sudo
-        Then I will see the following on stderr:
-            """
-            Cannot <command> '<message>'
-            For a list of services see: sudo ua status
-            """
-
-        Examples: ua commands
            | command | service     | message     |
-           | enable  | foobar      | foobar      |
+           | enable  | livepatch   | livepatch   |
            | disable | foobar foo  | foo, foobar |
 
     @series.trusty
@@ -97,6 +77,7 @@ Feature: Command behaviour when unattached
            | refresh |
 
 
+    @wip
     @series.focal
     Scenario Outline: Unattached command of a known service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
@@ -114,28 +95,8 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command |
-           | disable |
-           | enable  |
-
-    @series.focal
-    Scenario Outline: Unattached command of an unknown service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua <command> foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua <command> <service>` with sudo
-        Then stderr matches regexp:
-            """
-            Cannot <command> '<message>'
-            For a list of services see: sudo ua status
-            """
-
-        Examples: ua commands
            | command | service     | message     |
-           | disable | foobar      | foobar      |
+           | disable | livepatch   | livepatch   |
            | enable  | foobar foo  | foo, foobar |
 
     @series.focal

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -11,7 +11,11 @@ import pathlib
 import sys
 import textwrap
 
-from typing import List
+try:
+    from typing import List  # noqa
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
 
 from uaclient import config
 from uaclient import contract

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -353,13 +353,21 @@ def action_enable(args, cfg, **kwargs):
     entitlements_found, entitlements_not_found = get_valid_entitlement_names(
         names
     )
-    tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
     ret = True
 
     for entitlement in entitlements_found:
-        ret &= _perform_enable(entitlement, cfg, assume_yes=args.assume_yes)
+        try:
+            ret &= _perform_enable(
+                entitlement,
+                cfg,
+                assume_yes=args.assume_yes,
+                allow_beta=args.beta,
+            )
+        except exceptions.UserFacingError:
+            entitlements_not_found.append(entitlement)
 
     if entitlements_not_found:
+        tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
         raise exceptions.UserFacingError(
             tmpl.format(
                 operation="enable", name=", ".join(entitlements_not_found)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -349,7 +349,7 @@ def action_enable(args, cfg, **kwargs):
 
     @return: 0 on success, 1 otherwise
     """
-    print(ua_status.MESSAGE_REFRESH_ENABLE)
+    print(ua_status.MESSAGE_REFRESH_ENABLE, end="\n\n")
     try:
         contract.request_updated_contract(cfg)
     except (util.UrlError, exceptions.UserFacingError):

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -234,38 +234,6 @@ MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
 
-def action_report(
-    action_name,
-    entitlements_not_found,
-    entitlements_not_succeeded,
-    entitlements_succeeded,
-):
-    msg_tmpl = "{} results:\n{}{}{}\n"
-    not_found_msg = (
-        "Services not found: {}\n".format(", ".join(entitlements_not_found))
-        if len(entitlements_not_found)
-        else ""
-    )
-    fail_to_succeed_msg = (
-        "Services not {}: {}\n".format(
-            action_name, ", ".join(entitlements_not_succeeded)
-        )
-        if len(entitlements_not_succeeded)
-        else ""
-    )
-    succeed_msg = (
-        "Services {}: {}\n".format(
-            action_name, ", ".join(entitlements_succeeded)
-        )
-        if len(entitlements_succeeded)
-        else ""
-    )
-
-    return msg_tmpl.format(
-        action_name, not_found_msg, fail_to_succeed_msg, succeed_msg
-    )
-
-
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""
     return STATUS_COLOR.get(string, string) if sys.stdout.isatty() else string

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -234,6 +234,38 @@ MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
 
+def action_report(
+    action_name,
+    entitlements_not_found,
+    entitlements_not_succeeded,
+    entitlements_succeeded,
+):
+    msg_tmpl = "{} results:\n{}{}{}\n"
+    not_found_msg = (
+        "Services not found: {}\n".format(", ".join(entitlements_not_found))
+        if len(entitlements_not_found)
+        else ""
+    )
+    fail_to_succeed_msg = (
+        "Services not {}: {}\n".format(
+            action_name, ", ".join(entitlements_not_succeeded)
+        )
+        if len(entitlements_not_succeeded)
+        else ""
+    )
+    succeed_msg = (
+        "Services {}: {}\n".format(
+            action_name, ", ".join(entitlements_succeeded)
+        )
+        if len(entitlements_succeeded)
+        else ""
+    )
+
+    return msg_tmpl.format(
+        action_name, not_found_msg, fail_to_succeed_msg, succeed_msg
+    )
+
+
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""
     return STATUS_COLOR.get(string, string) if sys.stdout.isatty() else string

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -15,7 +15,7 @@ from uaclient.cli import (
     assert_root,
     get_parser,
     main,
-    require_valid_entitlement_names,
+    get_valid_entitlement_names,
     setup_logging,
 )
 
@@ -192,38 +192,6 @@ class TestAssertNotAttached:
 
         out, _err = capsys.readouterr()
         assert "" == out.strip()
-
-
-class TestRequireValidEntitlementName:
-    # rven used in test names as short hand for require_valid_entitlement_names
-    def test_rven_without_name(self):
-        @require_valid_entitlement_names("operation")
-        def test_function(args, cfg, **kwargs):
-            return mock.sentinel.success
-
-        assert mock.sentinel.success == test_function(object(), object())
-
-    def test_rven_with_valid_name(self):
-        @require_valid_entitlement_names("operation")
-        def test_function(args, cfg, **kwargs):
-            return mock.sentinel.success
-
-        m_args = mock.Mock()
-        m_args.names = ["esm-infra"]
-        assert mock.sentinel.success == test_function(m_args, object())
-
-    @pytest.mark.parametrize("operation_name", ["operation1", "operation2"])
-    def test_rven_with_invalid_name(self, operation_name):
-        @require_valid_entitlement_names(operation_name)
-        def test_function(args, cfg, **kwargs):
-            return kwargs["entitlements_found"]
-
-        m_args = mock.Mock()
-        names = ["invalid_entitlement"]
-        m_args.names = names
-        ret = test_function(m_args, object())
-
-        assert ret == []
 
 
 class TestMain:
@@ -455,3 +423,24 @@ class TestSetupLogging:
         assert "after setup" in log_content
         if pre_existing:
             assert "existing content" in log_content
+
+
+class TestGetValidEntitlementNames:
+    @mock.patch("uaclient.cli.entitlements")
+    def test_get_valid_entitlements(self, m_entitlements):
+        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            "ent1": True,
+            "ent2": True,
+            "ent3": True,
+        }
+
+        names = ["ent1", "ent3", "ent4"]
+        expected_ents_found = ["ent1", "ent3"]
+        expected_ents_not_found = ["ent4"]
+
+        actual_ents_found, actual_ents_not_found = get_valid_entitlement_names(
+            names
+        )
+
+        assert expected_ents_found == actual_ents_found
+        assert expected_ents_not_found == actual_ents_not_found

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -216,14 +216,14 @@ class TestRequireValidEntitlementName:
     def test_rven_with_invalid_name(self, operation_name):
         @require_valid_entitlement_names(operation_name)
         def test_function(args, cfg, **kwargs):
-            return kwargs["entitlements_not_found"]
+            return kwargs["entitlements_found"]
 
         m_args = mock.Mock()
         names = ["invalid_entitlement"]
         m_args.names = names
         ret = test_function(m_args, object())
 
-        assert ret == names
+        assert ret == []
 
 
 class TestMain:

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import mock
 import pytest
 
@@ -8,6 +10,7 @@ from uaclient import status
 
 @mock.patch("uaclient.cli.os.getuid", return_value=0)
 class TestDisable:
+    @pytest.mark.parametrize("names", [["testitlement"], ["ent1", "ent2"]])
     @pytest.mark.parametrize("assume_yes", (True, False))
     @pytest.mark.parametrize(
         "disable_return,return_code", ((True, 0), (False, 1))
@@ -20,37 +23,105 @@ class TestDisable:
         disable_return,
         return_code,
         assume_yes,
+        names,
     ):
-        m_entitlement_cls = mock.Mock()
-        m_entitlement = m_entitlement_cls.return_value
-        m_entitlement.disable.return_value = disable_return
-        m_cfg = mock.Mock()
-        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
-            "testitlement": m_entitlement_cls
-        }
+        entitlements_cls = []
+        entitlements_obj = []
+        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {}
+        for entitlement_name in names:
+            m_entitlement_cls = mock.Mock()
 
+            m_entitlement = m_entitlement_cls.return_value
+            m_entitlement.disable.return_value = disable_return
+
+            m_entitlements.ENTITLEMENT_CLASS_BY_NAME[
+                entitlement_name
+            ] = m_entitlement_cls
+
+            entitlements_obj.append(m_entitlement)
+            entitlements_cls.append(m_entitlement_cls)
+
+        m_cfg = mock.Mock()
         args_mock = mock.Mock()
-        args_mock.name = "testitlement"
+        args_mock.names = names
         args_mock.assume_yes = assume_yes
 
         ret = action_disable(args_mock, m_cfg)
 
-        assert [
-            mock.call(m_cfg, assume_yes=assume_yes)
-        ] == m_entitlement_cls.call_args_list
+        for m_entitlement_cls in entitlements_cls:
+            assert [
+                mock.call(m_cfg, assume_yes=assume_yes)
+            ] == m_entitlement_cls.call_args_list
 
         expected_disable_call = mock.call()
-        assert [expected_disable_call] == m_entitlement.disable.call_args_list
-        assert return_code == ret
+        for m_entitlement in entitlements_obj:
+            assert [
+                expected_disable_call
+            ] == m_entitlement.disable.call_args_list
 
-        assert 1 == m_cfg.status.call_count
+        assert return_code == ret
+        assert len(entitlements_cls) == m_cfg.status.call_count
+
+    @pytest.mark.parametrize("assume_yes", (True, False))
+    @mock.patch("uaclient.cli.entitlements")
+    def test_entitlements_not_found_disabled_and_enabled(
+        self, m_entitlements, _m_getuid, assume_yes
+    ):
+        return_code = 1
+        num_calls = 2
+
+        m_ent1_cls = mock.Mock()
+        m_ent1_obj = m_ent1_cls.return_value
+        m_ent1_obj.disable.return_value = False
+
+        m_ent2_cls = mock.Mock()
+        m_ent2_obj = m_ent2_cls.return_value
+        m_ent2_obj.disable.return_value = False
+
+        m_ent3_cls = mock.Mock()
+        m_ent3_obj = m_ent3_cls.return_value
+        m_ent3_obj.disable.return_value = True
+
+        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            "ent2": m_ent2_cls,
+            "ent3": m_ent3_cls,
+        }
+
+        m_cfg = mock.Mock()
+        args_mock = mock.Mock()
+        args_mock.names = ["ent1", "ent2", "ent3"]
+        args_mock.assume_yes = assume_yes
+
+        expected_msg = "Disabling ent2\n\nDisabling ent3\nDisabled ent3\n\n"
+        expected_msg += status.action_report(
+            action_name="disabled",
+            entitlements_not_found=["ent1"],
+            entitlements_not_succeeded=["ent2"],
+            entitlements_succeeded=["ent3"],
+        )
+
+        fake_stdout = io.StringIO()
+        with contextlib.redirect_stdout(fake_stdout):
+            ret = action_disable(args_mock, m_cfg)
+
+        assert expected_msg == fake_stdout.getvalue()
+
+        for m_ent_cls in [m_ent2_cls, m_ent3_cls]:
+            assert [
+                mock.call(m_cfg, assume_yes=assume_yes)
+            ] == m_ent_cls.call_args_list
+
+        expected_disable_call = mock.call()
+        for m_ent in [m_ent2_obj, m_ent3_obj]:
+            assert [expected_disable_call] == m_ent.disable.call_args_list
+
+        assert 0 == m_ent1_obj.call_count
+
+        assert return_code == ret
+        assert num_calls == m_cfg.status.call_count
 
     @pytest.mark.parametrize(
-        "uid,expected_error_template",
-        [
-            (0, status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL),
-            (1000, status.MESSAGE_NONROOT_USER),
-        ],
+        "uid,expected_error_template", [(1000, status.MESSAGE_NONROOT_USER)]
     )
     def test_invalid_service_error_message(
         self, m_getuid, uid, expected_error_template, FakeConfig
@@ -61,11 +132,32 @@ class TestDisable:
         cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
-            args.name = "bogus"
+            args.names = ["bogus"]
             action_disable(args, cfg)
         assert (
             expected_error_template.format(operation="disable", name="bogus")
             == err.value.msg
+        )
+
+    @pytest.mark.parametrize("names", [["bogus"], ["bogus1", "bogus2"]])
+    def test_invalid_servive_names(self, m_getuid, names, FakeConfig):
+        m_getuid.return_value = 0
+
+        cfg = FakeConfig.for_attached_machine()
+        fake_stdout = io.StringIO()
+        with contextlib.redirect_stdout(fake_stdout):
+            args = mock.MagicMock()
+            args.names = names
+            action_disable(args, cfg)
+
+        assert (
+            status.action_report(
+                action_name="disabled",
+                entitlements_not_found=names,
+                entitlements_not_succeeded=[],
+                entitlements_succeeded=[],
+            )
+            == fake_stdout.getvalue()
         )
 
     @pytest.mark.parametrize(
@@ -84,7 +176,7 @@ class TestDisable:
         cfg = FakeConfig()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
-            args.name = "esm-infra"
+            args.names = ["esm-infra"]
             action_disable(args, cfg)
         assert (
             expected_error_template.format(name="esm-infra") == err.value.msg

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -92,7 +92,7 @@ class TestDisable:
         args_mock.names = ["ent1", "ent2", "ent3"]
         args_mock.assume_yes = assume_yes
 
-        expected_msg = "Disabling ent2\n\nDisabling ent3\nDisabled ent3\n\n"
+        expected_msg = "ent2\n\nent3\n\n"
         expected_msg += status.action_report(
             action_name="disabled",
             entitlements_not_found=["ent1"],

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -1,5 +1,3 @@
-import contextlib
-import io
 import mock
 import pytest
 
@@ -92,19 +90,13 @@ class TestDisable:
         args_mock.names = ["ent1", "ent2", "ent3"]
         args_mock.assume_yes = assume_yes
 
-        expected_msg = "ent2\n\nent3\n\n"
-
         with pytest.raises(exceptions.UserFacingError) as err:
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                action_disable(args_mock, m_cfg)
+            action_disable(args_mock, m_cfg)
 
         assert (
             expected_error_tmpl.format(operation="disable", name="ent1")
             == err.value.msg
         )
-
-        assert expected_msg == fake_stdout.getvalue()
 
         for m_ent_cls in [m_ent2_cls, m_ent3_cls]:
             assert [
@@ -148,13 +140,10 @@ class TestDisable:
 
         cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.UserFacingError) as err:
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                args = mock.MagicMock()
-                args.names = names
-                action_disable(args, cfg)
+            args = mock.MagicMock()
+            args.names = names
+            action_disable(args, cfg)
 
-        assert "" == fake_stdout.getvalue()
         assert (
             expected_error_tmpl.format(
                 operation="disable", name=", ".join(sorted(names))

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -133,7 +133,7 @@ class TestActionEnable:
         args_mock.names = ["ent1", "ent2", "ent3"]
         args_mock.assume_yes = assume_yes
 
-        expected_msg = "One moment, checking your subscription first\n"
+        expected_msg = "One moment, checking your subscription first\n\n"
         expected_msg += "ent2\n\nent3\n\n"
 
         with pytest.raises(exceptions.UserFacingError) as err:
@@ -162,7 +162,7 @@ class TestActionEnable:
     def test_invalid_service_names(self, m_getuid, names, FakeConfig):
         m_getuid.return_value = 0
         expected_error_tmpl = status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
-        expected_msg = "One moment, checking your subscription first\n"
+        expected_msg = "One moment, checking your subscription first\n\n"
 
         cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.UserFacingError) as err:

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -148,7 +148,7 @@ class TestActionEnable:
         args_mock.assume_yes = assume_yes
 
         expected_msg = "One moment, checking your subscription first\n"
-        expected_msg += "Enabling ent2\n\nEnabling ent3\n\n"
+        expected_msg += "ent2\n\nent3\n\n"
         expected_msg += status.action_report(
             action_name="enabled",
             entitlements_not_found=["ent1"],

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -64,6 +64,7 @@ class TestActionEnable:
             == err.value.msg
         )
 
+    @pytest.mark.parametrize("beta_flag, beta_count", ((False, 1), (True, 0)))
     @pytest.mark.parametrize("assume_yes", (True, False))
     @mock.patch("uaclient.contract.get_available_resources", return_value={})
     @mock.patch("uaclient.contract.request_updated_contract")
@@ -75,6 +76,8 @@ class TestActionEnable:
         _m_get_available_resources,
         m_getuid,
         assume_yes,
+        beta_flag,
+        beta_count,
         FakeConfig,
     ):
         """assume-yes parameter is passed to entitlement instantiation."""
@@ -93,12 +96,14 @@ class TestActionEnable:
         args = mock.MagicMock()
         args.names = ["testitlement"]
         args.assume_yes = assume_yes
+        args.beta = beta_flag
         action_enable(args, cfg)
         assert [
             mock.call(cfg, assume_yes=assume_yes)
         ] == m_entitlement_cls.call_args_list
-        assert 1 == m_ent_is_beta.call_count
+        assert beta_count == m_ent_is_beta.call_count
 
+    @pytest.mark.parametrize("beta_flag, beta_count", ((False, 1), (True, 0)))
     @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
     @mock.patch("uaclient.contract.get_available_resources", return_value={})
     @mock.patch("uaclient.cli.entitlements")
@@ -108,6 +113,8 @@ class TestActionEnable:
         _m_get_available_resources,
         m_getuid,
         silent_if_inapplicable,
+        beta_flag,
+        beta_count,
         FakeConfig,
     ):
         m_getuid.return_value = 0
@@ -139,6 +146,7 @@ class TestActionEnable:
         args_mock = mock.Mock()
         args_mock.names = ["ent1", "ent2", "ent3"]
         args_mock.assume_yes = assume_yes
+        args_mock.beta = beta_flag
 
         expected_msg = "One moment, checking your subscription first\n"
 
@@ -163,8 +171,89 @@ class TestActionEnable:
             assert [expected_enable_call] == m_ent.enable.call_args_list
 
         assert 0 == m_ent1_obj.call_count
-        assert 1 == m_ent2_is_beta.call_count
-        assert 1 == m_ent3_is_beta.call_count
+        assert beta_count == m_ent2_is_beta.call_count
+        assert beta_count == m_ent3_is_beta.call_count
+
+    @pytest.mark.parametrize("beta_flag, beta_count", ((False, 1), (True, 0)))
+    @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
+    @mock.patch("uaclient.contract.get_available_resources", return_value={})
+    @mock.patch("uaclient.cli.entitlements")
+    def test_entitlements_not_found_and_beta(
+        self,
+        m_entitlements,
+        _m_get_available_resources,
+        m_getuid,
+        silent_if_inapplicable,
+        beta_flag,
+        beta_count,
+        FakeConfig,
+    ):
+        m_getuid.return_value = 0
+        expected_error_tmpl = status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
+
+        m_ent1_cls = mock.Mock()
+        m_ent1_obj = m_ent1_cls.return_value
+        m_ent1_obj.enable.return_value = False
+
+        m_ent2_cls = mock.Mock()
+        m_ent2_is_beta = mock.PropertyMock(return_value=True)
+        type(m_ent2_cls).is_beta = m_ent2_is_beta
+        m_ent2_obj = m_ent2_cls.return_value
+        m_ent2_obj.enable.return_value = False
+
+        m_ent3_cls = mock.Mock()
+        m_ent3_is_beta = mock.PropertyMock(return_value=False)
+        type(m_ent3_cls).is_beta = m_ent3_is_beta
+        m_ent3_obj = m_ent3_cls.return_value
+        m_ent3_obj.enable.return_value = True
+
+        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            "ent2": m_ent2_cls,
+            "ent3": m_ent3_cls,
+        }
+
+        cfg = FakeConfig.for_attached_machine()
+        assume_yes = False
+        args_mock = mock.Mock()
+        args_mock.names = ["ent1", "ent2", "ent3"]
+        args_mock.assume_yes = assume_yes
+        args_mock.beta = beta_flag
+
+        expected_msg = "One moment, checking your subscription first\n"
+
+        with pytest.raises(exceptions.UserFacingError) as err:
+            fake_stdout = io.StringIO()
+            with contextlib.redirect_stdout(fake_stdout):
+                action_enable(args_mock, cfg)
+
+        not_found_name = "ent1"
+        mock_ent_list = [m_ent3_cls]
+        mock_obj_list = [m_ent3_obj]
+
+        if not beta_flag:
+            not_found_name += ", ent2"
+        else:
+            mock_ent_list.append(m_ent2_cls)
+            mock_obj_list.append(m_ent3_obj)
+
+        assert (
+            expected_error_tmpl.format(operation="enable", name=not_found_name)
+            == err.value.msg
+        )
+        assert expected_msg == fake_stdout.getvalue()
+
+        for m_ent_cls in mock_ent_list:
+            assert [
+                mock.call(cfg, assume_yes=assume_yes)
+            ] == m_ent_cls.call_args_list
+
+        expected_enable_call = mock.call(silent_if_inapplicable=False)
+        for m_ent in mock_obj_list:
+            assert [expected_enable_call] == m_ent.enable.call_args_list
+
+        assert 0 == m_ent1_obj.call_count
+        assert beta_count == m_ent2_is_beta.call_count
+        assert beta_count == m_ent3_is_beta.call_count
 
     @pytest.mark.parametrize("names", [["bogus"], ["bogus1", "bogus2"]])
     def test_invalid_service_names(self, m_getuid, names, FakeConfig):


### PR DESCRIPTION
This PR creates an initial abstraction to allow multiple entitlements to be enables/disabled using the uaclient command. Right now, the idea is to try to enable/disable as much entitlements as we can. This means that we will not abort if we find an invalid entitlement or cannot disable/enable one of them.

To be more clear, this is an example of the output of the following command:

`ua disable ent1 ent2 ent3 --asume-yes true`

Where:

* ent1 is an invalid entitlement
* ent2 is not enabled
* ent3 is enabled

The command output will be the following:

```
ent2
ent2 is not currently enabled
See: sudo ua status

ent3
Updating packages lists

Disabled results:
Services not found: ent1
Services not disabled: ent2
Services disabled: ent3
```

What I am trying to achieve is a better way to give the user a report of what happened when he runs the command, but there is definitely room for improvement here.

This is a WIP because I have not created the BDD tests yet. I will start writing them, but I think I can still collect feedback for the code and the output message I am proposing.