### PR TITLE
bug-fix "livepatch snap wait" into release-24 branch 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (24.1) groovy; urgency=medium
+
+  * New bug-fix-only release 24.1:
+      - livepatch: run snap wait system snap.seeded before trying to install
+        (GH: #1051)
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:07:17 -0600
+
 ubuntu-advantage-tools (24.0) groovy; urgency=medium
 
   * bump version to 24.0 for new versioninig scheme

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (24.0) groovy; urgency=medium
+
+  * bump version to 24.0 for new versioninig scheme
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:04:33 -0600
+
 ubuntu-advantage-tools (20.3) focal; urgency=medium
 
   * New upstream release 20.3:

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -66,14 +66,14 @@ class LivepatchEntitlement(base.UAEntitlement):
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
                 )
-                util.subp(
-                    [SNAP_CMD, "wait", "system", "seed.loaded"], capture=True
-                )
             elif "snapd" not in apt.get_installed_packages():
                 raise exceptions.UserFacingError(
                     "/usr/bin/snap is present but snapd is not installed;"
                     " cannot enable {}".format(self.title)
                 )
+            util.subp(
+                [SNAP_CMD, "wait", "system", "seed.loaded"], capture=True
+            )
             print("Installing canonical-livepatch snap")
             try:
                 util.subp(

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -404,10 +404,12 @@ class TestLivepatchEntitlementEnable:
             ["apt-get", "install", "--assume-yes", "snapd"],
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
-        ),
+        )
+    ]
+    mocks_snap_wait_seed = [
         mock.call(
             ["/usr/bin/snap", "wait", "system", "seed.loaded"], capture=True
-        ),
+        )
     ]
     mocks_livepatch_install = [
         mock.call(
@@ -416,7 +418,9 @@ class TestLivepatchEntitlementEnable:
             retry_sleeps=[0.5, 1, 5],
         )
     ]
-    mocks_install = mocks_snapd_install + mocks_livepatch_install
+    mocks_install = (
+        mocks_snapd_install + mocks_snap_wait_seed + mocks_livepatch_install
+    )
     mocks_config = [
         mock.call(
             [
@@ -535,7 +539,9 @@ class TestLivepatchEntitlementEnable:
         m_app_status.return_value = application_status, "enabled"
         assert entitlement.enable()
         assert (
-            self.mocks_livepatch_install + self.mocks_config
+            self.mocks_snap_wait_seed
+            + self.mocks_livepatch_install
+            + self.mocks_config
             in m_subp.call_args_list
         )
         msg = (

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from subprocess import check_output
 
 
-__VERSION__ = "24.0"
+__VERSION__ = "24.1"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from subprocess import check_output
 
 
-__VERSION__ = "20.3"
+__VERSION__ = "24.0"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
Update the released versioning scheme for ubuntu-advantage-tools to be milestone-based (24.0)

* Apply a single bugfix for livepatch enablement that calls snap wait system seed.loaded
   `git cherry-pick 97643f9b9627887d8329f4c1c7fd76856214a37a`
* Increment the minor version to 24.1 to represent a bug-fix only release
   `dch --newversion 24.1`   # add new bug-fix-only release