### PR TITLE
Fix uaclient/version for git-ubuntu pkg branches release 24.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,11 @@
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:
-      - livepatch: run snap wait system snap.seeded before trying to install
-        (GH: #1049)
+    - livepatch: run snap wait system snap.seeded before trying to install
+      (GH: #1049)
+    - version: return debian/changelog version when git describe fails to
+      match upstream <major>.<minor> tags for git-ubuntu workflow
+      (GH: #1058)
 
  -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:07:17 -0600
 

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -1,0 +1,61 @@
+import mock
+
+import os.path
+
+from uaclient import util
+from uaclient.version import get_version
+
+
+@mock.patch("uaclient.util.subp")
+class TestGetVersion:
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "24.1~18.04.1")
+    def test_get_version_returns_packaged_version(self, m_subp):
+        assert "24.1~18.04.1" == get_version()
+        assert 0 == m_subp.call_count
+
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_get_version_returns_matching_git_describe_long(
+        self, m_exists, m_subp
+    ):
+        m_subp.return_value = ("24.1-5-g12345678", "")
+        assert "24.1-5-g12345678" == get_version()
+        assert [
+            mock.call(
+                ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
+            )
+        ] == m_subp.call_args_list
+        top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        top_dir_git = os.path.join(top_dir, ".git")
+        assert [mock.call(top_dir_git)] == m_exists.call_args_list
+
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_returns_dpkg_parsechangelog_on_git_ubuntu_pkg_branch(
+        self, m_exists, m_subp
+    ):
+        """Call dpkg-parsechangelog if git describe fails to --match=[0-9]*"""
+
+        def fake_subp(cmd):
+            if cmd[0] == "git":
+                # Not matching tag on git-ubuntu pkg branches
+                raise util.ProcessExecutionError(
+                    "fatal: No names found, cannot describe anything."
+                )
+            if cmd[0] == "dpkg-parsechangelog":
+                return ("24.1\n", "")
+            assert False, "Unexpected subp cmd {}".format(cmd)
+
+        m_subp.side_effect = fake_subp
+
+        assert "24.1" == get_version()
+        expected_calls = [
+            mock.call(
+                ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
+            ),
+            mock.call(["dpkg-parsechangelog", "-S", "version"]),
+        ]
+        assert expected_calls == m_subp.call_args_list
+        top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        top_dir_git = os.path.join(top_dir, ".git")
+        assert [mock.call(top_dir_git)] == m_exists.call_args_list

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -5,7 +5,7 @@ These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
 import os.path
-from subprocess import check_output
+from uaclient import util
 
 
 __VERSION__ = "24.1"
@@ -13,11 +13,28 @@ PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 
 def get_version(_args=None):
-    """Return the package version if set, otherwise return git describe."""
+    """Return the packaged version as a string
+
+         Prefer the binary PACKAGED_VESION set by debian/rules to DEB_VERSION.
+         If unavailable, check for a .git development environments:
+           a. If run in our upstream repo `git describe` will gives a leading
+              XX.Y so return the --long version to allow daily build recipes
+              to count commit offset from upstream's XX.Y signed tag.
+           b. If run in a git-ubuntu pkg repo, upstream tags aren't visible,
+              parse the debian/changelog in that case
+    """
     if not PACKAGED_VERSION.startswith("@@PACKAGED_VERSION"):
         return PACKAGED_VERSION
     topdir = os.path.dirname(os.path.dirname(__file__))
     if os.path.exists(os.path.join(topdir, ".git")):
         cmd = ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
-        return check_output(cmd, universal_newlines=True).strip()
+        try:
+            out, _ = util.subp(cmd)
+            return out.strip()
+        except util.ProcessExecutionError:
+            # Rely on debian/changelog because we are in a git-ubuntu or other
+            # packaging repo
+            cmd = ["dpkg-parsechangelog", "-S", "version"]
+            out, _ = util.subp(cmd)
+            return out.strip()
     return __VERSION__


### PR DESCRIPTION
In order to use git-ubuntu workflow, we have to replay git commits from our release-XX branches onto a git-ubuntu pkg/ubuntu/devel branch in order to submit merge proposals such as the following [git-ubuntu MP to release ubuntu-advantage-tools on groovy](https://code.launchpad.net/~chad.smith/ubuntu/+source/ubuntu-advantage-tools/+git/ubuntu-advantage-tools/+merge/384297)

Bryce, caught that tox and autopkgtest both fail because git describe --match [0-9]* doesn't find an valid signed upstream tag.  

This branch falls back to dpkg-parsechangelog -S version in the event that git describe fails. This allows pkg testing and verification to proceed during the package build process.

To put together an MP for git-ubuntu upload release-24 we follow this mechanism:
```
snap install git-ubuntu
git-ubuntu clone ubuntu-advantage-tools
cd ubuntu-advantage-tools
git remote add upstream git@github.com:canonical/ubuntu-advantage-client.git
git remote add blackboxsw git@github.com:blackboxsw/ubuntu-advantage-client.git
git fetch blackboxsw
git rebase --onto pkg/ubuntu/devel 20.3 24.1
git checkout -b pkg-upload-24.1
tox
```


To test this locally:
   python3 -m uaclient.cli version