### PR TITLE
Fix version command

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -129,32 +129,22 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
         When I attach contract_token with sudo
         And I run `ua version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua version` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` with sudo
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` as non-root
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
@@ -280,32 +270,22 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I attach contract_token with sudo
         And I run `ua version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua version` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` with sudo
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` as non-root
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -124,6 +124,40 @@ Feature: Command behaviour when attached to an UA subscription
             """
             This machine is already attached
             """
+    @series.trusty
+    Scenario: Attached show version in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
 
    @series.focal
    Scenario: Attached refresh in a focal lxd container
@@ -239,4 +273,39 @@ Feature: Command behaviour when attached to an UA subscription
         Then stderr matches regexp:
             """
             This machine is already attached
+            """
+
+    @series.focal
+    Scenario: Attached show version in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach contract_token with sudo
+        And I run `ua version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
             """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,44 +1,34 @@
 Feature: Command behaviour when unattached
 
     @series.trusty
-    Scenario: Unattached detach in a trusty lxd container
+    Scenario Outline: Unattached commands that requires enabled user in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua detach` as non-root
+        When I run `ua <command>` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua detach` with sudo
+        When I run `ua <command>` with sudo
         Then I will see the following on stderr:
             """
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
 
-    @series.trusty
-    Scenario: Unattached refresh in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua refresh` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua refresh` with sudo
-        Then I will see the following on stderr:
-            """
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
+        Examples: ua commands
+           | command |
+           | detach  |
+           | refresh |
 
     @series.trusty
-    Scenario: Unattached enable of a known service in a trusty lxd container
+    Scenario Outline: Unattached command of a known service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua enable livepatch` as non-root
+        When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable livepatch` with sudo
+        When I run `ua <command> livepatch` with sudo
         Then I will see the following on stderr:
             """
             To use 'livepatch' you need an Ubuntu Advantage subscription
@@ -46,51 +36,30 @@ Feature: Command behaviour when unattached
             See https://ubuntu.com/advantage
             """
 
+        Examples: ua commands
+           | command |
+           | enable  |
+           | disable |
+
     @series.trusty
-    Scenario: Unattached enable of an unknown service in a trusty lxd container
+    Scenario Outline: Unattached command of an unknown service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua enable foobar` as non-root
+        When I run `ua <command> foobar` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable foobar` with sudo
+        When I run `ua <command> foobar` with sudo
         Then I will see the following on stderr:
             """
-            Cannot enable 'foobar'
+            Cannot <command> 'foobar'
             For a list of services see: sudo ua status
             """
 
-    @series.trusty
-    Scenario: Unattached disable of a known service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua disable livepatch` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable livepatch` with sudo
-        Then I will see the following on stderr:
-            """
-            To use 'livepatch' you need an Ubuntu Advantage subscription
-            Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
-            """
-
-    @series.trusty
-    Scenario: Unattached disable of an unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua disable foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable foobar` with sudo
-        Then I will see the following on stderr:
-            """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
-            """
+        Examples: ua commands
+           | command |
+           | enable  |
+           | disable |
 
     @series.trusty
     Scenario: Unattached auto-attach does nothing in a trusty lxd container
@@ -107,69 +76,36 @@ Feature: Command behaviour when unattached
             See: https://ubuntu.com/advantage
             """
 
-    @series.trusty
-    Scenario: Unattached show version in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I run `ua version` as non-root
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-        When I run `ua version` with sudo
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-        When I run `ua --version` as non-root
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-        When I run `ua --version` with sudo
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-
     @series.focal
-    Scenario: Unattached detach in a focal lxd container
+    Scenario Outline: Unattached commands that requires enabled user in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua detach` as non-root
+        When I run `ua <command>` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua detach` with sudo
+        When I run `ua <command>` with sudo
         Then stderr matches regexp:
             """
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
 
-    @series.focal
-    Scenario: Unattached refresh in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua refresh` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua refresh` with sudo
-        Then stderr matches regexp:
-            """
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
+        Examples: ua commands
+           | command |
+           | detach  |
+           | refresh |
+
 
     @series.focal
-    Scenario: Unattached enable of a known service in a focal lxd container
+    Scenario Outline: Unattached command of a known service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua enable livepatch` as non-root
+        When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable livepatch` with sudo
+        When I run `ua <command> livepatch` with sudo
         Then stderr matches regexp:
             """
             To use 'livepatch' you need an Ubuntu Advantage subscription
@@ -177,51 +113,31 @@ Feature: Command behaviour when unattached
             See https://ubuntu.com/advantage
             """
 
+        Examples: ua commands
+           | command |
+           | disable |
+           | enable  |
+
+    @wip
     @series.focal
-    Scenario: Unattached enable of an unknown service in a focal lxd container
+    Scenario Outline: Unattached command of an unknown service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua enable foobar` as non-root
+        When I run `ua <command> foobar` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable foobar` with sudo
+        When I run `ua <command> foobar` with sudo
         Then stderr matches regexp:
             """
-            Cannot enable 'foobar'
+            Cannot <command> 'foobar'
             For a list of services see: sudo ua status
             """
 
-    @series.focal
-    Scenario: Unattached disable of a known service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua disable livepatch` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable livepatch` with sudo
-        Then stderr matches regexp:
-            """
-            To use 'livepatch' you need an Ubuntu Advantage subscription
-            Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
-            """
-
-    @series.focal
-    Scenario: Unattached disable of an unknown service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua disable foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable foobar` with sudo
-        Then stderr matches regexp:
-            """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
-            """
+        Examples: ua commands
+           | command |
+           | disable |
+           | enable  |
 
     @series.focal
     Scenario: Unattached auto-attach does nothing in a focal lxd container
@@ -236,28 +152,4 @@ Feature: Command behaviour when unattached
             """
             Auto-attach image support is not available on lxd
             See: https://ubuntu.com/advantage
-            """
-
-    @series.focal
-    Scenario: Unattached show version in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I run `ua version` as non-root
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-        When I run `ua version` with sudo
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-        When I run `ua --version` as non-root
-        Then I will see the following on stdout:
-            """
-            20.4
-            """
-        When I run `ua --version` with sudo
-        Then I will see the following on stdout:
-            """
-            20.4
             """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -107,41 +107,29 @@ Feature: Command behaviour when unattached
             See: https://ubuntu.com/advantage
             """
 
-    @wip
     @series.trusty
     Scenario: Unattached show version in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
         When I run `ua version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua version` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
-        When I run `ua -v` as non-root
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` with sudo
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-
 
     @series.focal
     Scenario: Unattached detach in a focal lxd container
@@ -254,32 +242,22 @@ Feature: Command behaviour when unattached
     Scenario: Unattached show version in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I run `ua version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua version` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` as non-root
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """
         When I run `ua --version` with sudo
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` as non-root
-        Then stdout matches regexp:
-            """
-            20.4
-            """
-        When I run `ua -v` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
             20.4
             """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -107,6 +107,41 @@ Feature: Command behaviour when unattached
             See: https://ubuntu.com/advantage
             """
 
+    @wip
+    @series.trusty
+    Scenario: Unattached show version in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I run `ua version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+
 
     @series.focal
     Scenario: Unattached detach in a focal lxd container
@@ -213,4 +248,38 @@ Feature: Command behaviour when unattached
             """
             Auto-attach image support is not available on lxd
             See: https://ubuntu.com/advantage
+            """
+
+    @series.focal
+    Scenario: Unattached show version in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I run `ua version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua --version` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` as non-root
+        Then stdout matches regexp:
+            """
+            20.4
+            """
+        When I run `ua -v` with sudo
+        Then stdout matches regexp:
+            """
+            20.4
             """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -488,7 +488,6 @@ def get_parser():
         help="show all debug log messages to console",
     )
     parser.add_argument(
-        "-v",
         "--version",
         action="version",
         version=version.get_version(),

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -487,6 +487,13 @@ def get_parser():
         action="store_true",
         help="show all debug log messages to console",
     )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=version.get_version(),
+        help="show version of {}".format(NAME),
+    )
     parser._optionals.title = "Flags"
     subparsers = parser.add_subparsers(
         title="Available Commands", dest="command", metavar=""


### PR DESCRIPTION
Right now, ua-client does not support both `ua --version` and `ua -v` commands. This PR adds these commands and test them through behave. This feature is related to #663 