### PR TITLE
Use additionalPackages from service payload

### DIFF
--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -16,7 +16,6 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     title = "CC EAL2"
     description = "Common Criteria EAL2 Provisioning Packages"
     repo_key_file = "ubuntu-cc-keyring.gpg"
-    packages = ["ubuntu-commoncriteria"]
 
     @property
     def messaging(

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -8,7 +8,3 @@ class CISEntitlement(repo.RepoEntitlement):
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"
     repo_key_file = "ubuntu-securitybenchmarks-keyring.gpg"
-
-    @property
-    def packages(self):
-        return ["ubuntu-cisbenchmark-16.04"] + super().packages

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -8,4 +8,7 @@ class CISEntitlement(repo.RepoEntitlement):
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"
     repo_key_file = "ubuntu-securitybenchmarks-keyring.gpg"
-    packages = ["ubuntu-cisbenchmark-16.04"]
+
+    @property
+    def packages(self):
+        return ["ubuntu-cisbenchmark-16.04"] + super().packages

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -14,27 +14,22 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     repo_pin_priority = 1001
     fips_required_packages = frozenset({"fips-initramfs", "linux-fips"})
-    fips_packages = {
-        "libssl1.0.0": {"libssl1.0.0-hmac"},
-        "openssh-client": {"openssh-client-hmac"},
-        "openssh-server": {"openssh-server-hmac"},
-        "openssl": set(),
-        "strongswan": {"strongswan-hmac"},
-    }  # type: Dict[str, Set[str]]
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
 
     @property
     def packages(self) -> "List[str]":
-        packages = list(self.fips_required_packages)
+        packages = []  # type: List[str]
         installed_packages = apt.get_installed_packages()
 
         pkg_groups = groupby(
-            filter(lambda pkg: pkg not in packages, super().packages),
+            super().packages,
             key=lambda pkg_name: pkg_name.replace("-hmac", ""),
         )
 
         for pkg_name, pkg_list in pkg_groups:
             if pkg_name in installed_packages:
+                packages += pkg_list
+            elif pkg_name in self.fips_required_packages:
                 packages += pkg_list
 
         return packages

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -60,16 +60,15 @@ class RepoEntitlement(base.UAEntitlement):
         """debs to install on enablement"""
         packages = []
 
-        if self.cfg:
-            entitlement = self.cfg.entitlements.get(self.name, {}).get(
-                "entitlement", {}
-            )
+        entitlement = self.cfg.entitlements.get(self.name, {}).get(
+            "entitlement", {}
+        )
 
-            if entitlement:
-                directives = entitlement.get("directives", {})
-                additional_packages = directives.get("additionalPackages", [])
+        if entitlement:
+            directives = entitlement.get("directives", {})
+            additional_packages = directives.get("additionalPackages", [])
 
-                packages = additional_packages
+            packages = additional_packages
 
         return packages
 

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -58,7 +58,20 @@ class RepoEntitlement(base.UAEntitlement):
     @property
     def packages(self) -> "List[str]":
         """debs to install on enablement"""
-        return []
+        packages = []
+
+        if self.cfg:
+            entitlement = self.cfg.entitlements.get(self.name, {}).get(
+                "entitlement", {}
+            )
+
+            if entitlement:
+                directives = entitlement.get("directives", {})
+                additional_packages = directives.get("additionalPackages", [])
+
+                packages = additional_packages
+
+        return packages
 
     @property
     @abc.abstractmethod

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -16,7 +16,8 @@ def machine_token(
     directives: "Dict[str, Any]" = None,
     entitled: bool = True,
     obligations: "Dict[str, Any]" = None,
-    suites: "List[str]" = None
+    suites: "List[str]" = None,
+    additional_packages: "List[str]" = None
 ) -> "Dict[str, Any]":
     return {
         "resourceTokens": [
@@ -36,6 +37,7 @@ def machine_token(
                         entitled=entitled,
                         obligations=obligations,
                         suites=suites,
+                        additional_packages=additional_packages,
                     )
                 ]
             }
@@ -50,7 +52,8 @@ def machine_access(
     directives: "Dict[str, Any]" = None,
     entitled: bool = True,
     obligations: "Dict[str, Any]" = None,
-    suites: "List[str]" = None
+    suites: "List[str]" = None,
+    additional_packages: "List[str]" = None
 ) -> "Dict[str, Any]":
     if affordances is None:
         affordances = {"series": []}  # Will match all series
@@ -64,6 +67,9 @@ def machine_access(
             "aptKey": "APTKEY",
             "suites": suites,
         }
+
+        if additional_packages:
+            directives["additionalPackages"] = additional_packages
     return {
         "obligations": obligations,
         "type": entitlement_type,
@@ -91,7 +97,8 @@ def entitlement_factory(tmpdir):
         directives: "Dict[str, Any]" = None,
         entitled: bool = True,
         assume_yes: "Optional[bool]" = None,
-        suites: "List[str]" = None
+        suites: "List[str]" = None,
+        additional_packages: "List[str]" = None
     ):
         cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
         cfg.write_cache(
@@ -102,6 +109,7 @@ def entitlement_factory(tmpdir):
                 directives=directives,
                 entitled=entitled,
                 suites=suites,
+                additional_packages=additional_packages,
             ),
         )
         args = {}

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -24,6 +24,7 @@ CC_MACHINE_TOKEN = machine_token(
         "aptURL": "http://CC",
         "aptKey": "APTKEY",
         "suites": ["xenial"],
+        "additionalPackages": ["ubuntu-commoncriteria"],
     },
     affordances={
         "architectures": ["x86_64", "ppc64le", "s390x"],

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -14,7 +14,7 @@ M_REPOPATH = "uaclient.entitlements.repo."
 
 @pytest.fixture
 def entitlement(entitlement_factory):
-    return entitlement_factory(CISEntitlement)
+    return entitlement_factory(CISEntitlement, additional_packages=["pkg1"])
 
 
 class TestCISEntitlementCanEnable:

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -398,17 +398,11 @@ class TestFipsEntitlementPackages:
         # Make it appear like all packages are installed
         m_get_installed_packages.return_value.__contains__.return_value = True
 
-        before = (
-            copy.deepcopy(entitlement.fips_required_packages),
-            copy.deepcopy(entitlement.fips_packages),
-        )
+        before = copy.deepcopy(entitlement.fips_required_packages)
 
         assert entitlement.packages
 
-        after = (
-            copy.deepcopy(entitlement.fips_required_packages),
-            copy.deepcopy(entitlement.fips_packages),
-        )
+        after = copy.deepcopy(entitlement.fips_required_packages)
 
         assert before == after
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -389,7 +389,7 @@ class TestFipsEntitlementPackages:
         full_expected_installs = (
             list(entitlement.fips_required_packages) + expected_installs
         )
-        assert full_expected_installs == entitlement.packages
+        assert sorted(full_expected_installs) == sorted(entitlement.packages)
 
     @mock.patch(M_PATH + "apt.get_installed_packages")
     def test_multiple_packages_calls_dont_mutate_state(


### PR DESCRIPTION
Right now, ua-client is not using the `additionalPackages` field when enabling repo services, like `cc-eal` and `fips`. This PR adds the possibility for ua-client to start using these data when enabling repo services.

For fips, we are now using it understand which extra packages should be installed when enabling the service.