### PR TITLE
Add pip module

### DIFF
--- a/uaclient/pip.py
+++ b/uaclient/pip.py
@@ -1,0 +1,51 @@
+import os
+
+from configparser import ConfigParser
+
+
+PIP_CONFIG_FILE = "/etc/pip.conf"
+
+
+def _write_pip_conf(pip_conf):
+    """
+    Write a pip ConfigParser object into
+    a predefined path.
+
+    :param pip_conf:
+        A ConfigParser object representing a pip config file
+    """
+    with open(PIP_CONFIG_FILE, "w") as f:
+        pip_conf.write(f)
+
+
+def _load_pip_conf():
+    """
+    Parser and returns a pip.conf file in a predefined path
+
+    :return:
+        A ConfigParser object representing the pip config file
+    """
+    conf_parser = ConfigParser()
+    with open(PIP_CONFIG_FILE, "r") as pip_conf:
+        conf_parser.read_file(pip_conf)
+
+    return conf_parser
+
+
+def update_pip_conf(pip_config_dict):
+    """
+    Update pip.conf file on /etc/ with the required configurations
+    for enabling a service.
+
+    :param pip_config_dict:
+        A dictionaty representing a valid pip config
+    """
+    new_conf_parser = ConfigParser()
+    new_conf_parser.read_dict(pip_config_dict)
+
+    if os.path.exists(PIP_CONFIG_FILE):
+        existing_conf_parser = _load_pip_conf()
+        existing_conf_parser.update(new_conf_parser)
+        new_conf_parser = existing_conf_parser
+
+    _write_pip_conf(new_conf_parser)

--- a/uaclient/pip.py
+++ b/uaclient/pip.py
@@ -6,32 +6,6 @@ from configparser import ConfigParser
 PIP_CONFIG_FILE = "/etc/pip.conf"
 
 
-def _write_pip_conf(pip_conf):
-    """
-    Write a pip ConfigParser object into
-    a predefined path.
-
-    :param pip_conf:
-        A ConfigParser object representing a pip config file
-    """
-    with open(PIP_CONFIG_FILE, "w") as f:
-        pip_conf.write(f)
-
-
-def _load_pip_conf():
-    """
-    Parser and returns a pip.conf file in a predefined path
-
-    :return:
-        A ConfigParser object representing the pip config file
-    """
-    conf_parser = ConfigParser()
-    with open(PIP_CONFIG_FILE, "r") as pip_conf:
-        conf_parser.read_file(pip_conf)
-
-    return conf_parser
-
-
 def update_pip_conf(pip_config_dict):
     """
     Update pip.conf file on /etc/ with the required configurations
@@ -44,8 +18,12 @@ def update_pip_conf(pip_config_dict):
     new_conf_parser.read_dict(pip_config_dict)
 
     if os.path.exists(PIP_CONFIG_FILE):
-        existing_conf_parser = _load_pip_conf()
+        existing_conf_parser = ConfigParser()
+        with open(PIP_CONFIG_FILE, "r") as f:
+            existing_conf_parser.read_file(f)
+
         existing_conf_parser.update(new_conf_parser)
         new_conf_parser = existing_conf_parser
 
-    _write_pip_conf(new_conf_parser)
+    with open(PIP_CONFIG_FILE, "w") as f:
+        new_conf_parser.write(f)

--- a/uaclient/tests/test_pip.py
+++ b/uaclient/tests/test_pip.py
@@ -110,4 +110,9 @@ class TestPipConfUpdate:
             update_pip_conf(self.test_config_dict())
 
         with file_path.open("r") as f:
-            assert f.read().strip() == expected.strip()
+            """
+            We are sorting the result because we cannot easily allow
+            configparser to write the config in a sorted manner, meaning
+            that the order of the lines may not match if compared directly
+            """
+            assert sorted(f.read().strip()) == sorted(expected.strip())

--- a/uaclient/tests/test_pip.py
+++ b/uaclient/tests/test_pip.py
@@ -103,9 +103,11 @@ class TestPipConfUpdate:
         file_path = tmpdir / "pip.conf"
 
         if file_content:
-            file_path.write_text(file_content, encoding=None)
+            with file_path.open("w") as f:
+                f.write(file_content)
 
         with mock.patch("uaclient.pip.PIP_CONFIG_FILE", file_path.strpath):
             update_pip_conf(self.test_config_dict())
 
-        assert file_path.read_text(encoding=None).strip() == expected.strip()
+        with file_path.open("r") as f:
+            assert f.read().strip() == expected.strip()

--- a/uaclient/tests/test_pip.py
+++ b/uaclient/tests/test_pip.py
@@ -1,0 +1,111 @@
+"""Tests related to uaclient.pip module."""
+
+import mock
+import pytest
+
+from textwrap import dedent
+
+from uaclient.pip import update_pip_conf
+
+
+class TestPipConfUpdate:
+    def test_config_dict(self):
+        """
+        Create a base config dict to be used on tests. This
+        config is based on the possible config that will
+        be used by the esm-apps-python service.
+        """
+        index_url = "http://bearer:token@python.esm.ubuntu.com/simple"
+        index = index_url
+
+        return {"global": {"index-url": index_url, "index": index}}
+
+    @pytest.mark.parametrize(
+        "file_content,expected",
+        (
+            (
+                "",
+                dedent(
+                    """\
+                [global]
+                index-url = http://bearer:token@python.esm.ubuntu.com/simple
+                index = http://bearer:token@python.esm.ubuntu.com/simple
+                """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                [freeze]
+                timeout = 10
+                """
+                ),
+                dedent(
+                    """\
+                [freeze]
+                timeout = 10
+
+                [global]
+                index-url = http://bearer:token@python.esm.ubuntu.com/simple
+                index = http://bearer:token@python.esm.ubuntu.com/simple
+                """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                [global]
+                index-url = www.mypip.com
+                """
+                ),
+                dedent(
+                    """\
+                [global]
+                index-url = http://bearer:token@python.esm.ubuntu.com/simple
+                index = http://bearer:token@python.esm.ubuntu.com/simple
+                """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                [global]
+                index-url = www.mypip.com
+
+                [freeze]
+                timeout = 10
+                """
+                ),
+                dedent(
+                    """\
+                [global]
+                index-url = http://bearer:token@python.esm.ubuntu.com/simple
+                index = http://bearer:token@python.esm.ubuntu.com/simple
+
+                [freeze]
+                timeout = 10
+                """
+                ),
+            ),
+            (
+                None,
+                dedent(
+                    """\
+                [global]
+                index-url = http://bearer:token@python.esm.ubuntu.com/simple
+                index = http://bearer:token@python.esm.ubuntu.com/simple
+                """
+                ),
+            ),
+        ),
+    )
+    def test_update_pip_conf(self, tmpdir, file_content, expected):
+        file_path = tmpdir / "pip.conf"
+
+        if file_content:
+            file_path.write_text(file_content, encoding=None)
+
+        with mock.patch("uaclient.pip.PIP_CONFIG_FILE", file_path.strpath):
+            update_pip_conf(self.test_config_dict())
+
+        assert file_path.read_text(encoding=None).strip() == expected.strip()


### PR DESCRIPTION
This PR creates the pip module in ua-client. This module will be used when we deploy `esm-python` service. This service will need to configure the `/etc/pip.conf` file with some extra configuration.

Right now we make the following considerations regarding `/etc/pip.conf`:

* If the file exists and has extra configuration on it, we maintain them
* If the file has configuration that conflicts with the configuration we want to use, we override the existing configuration with the new one.