### PR TITLE
Update package version on dev tools

### DIFF
--- a/tools/ua-dev-cloud-config.yaml
+++ b/tools/ua-dev-cloud-config.yaml
@@ -9,4 +9,4 @@ runcmd:
  - make deps
  - dpkg-buildpackage -us -uc
  - apt-get remove ubuntu-advantage-tools
- - dpkg -i /var/tmp/ubuntu-advantage-tools_20.4_amd64.deb
+ - dpkg -i /var/tmp/ubuntu-advantage-tools_25.0_amd64.deb

--- a/tools/ua-dev-cloud-config.yaml
+++ b/tools/ua-dev-cloud-config.yaml
@@ -8,5 +8,5 @@ runcmd:
  - cd /var/tmp/uac/
  - make deps
  - dpkg-buildpackage -us -uc
- - apt-get remove ubuntu-advantage-tools
- - dpkg -i /var/tmp/ubuntu-advantage-tools_25.0_amd64.deb
+ - apt-get remove ubuntu-advantage-tools --assume-yes
+ - dpkg -i /var/tmp/ubuntu-advantage-*deb


### PR DESCRIPTION
When creating a new development environment for ua-client, there is an error when installing the deb package. Since we are now in version 25.0, we need to update this version on the `ua-dev-cloud-config` file as well.