### PR TITLE
Disable beta services to be show/enabled without flag

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -18,10 +18,35 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: Un-supported services in containers
-           | service      | title        | flag          |
-           | livepatch    | Livepatch    |               |
-           | fips         | FIPS         | --assume-yes  |
-           | fips-updates | FIPS Updates | --assume-yes  |
+           | service      | title        | flag                 |
+           | livepatch    | Livepatch    |                      |
+           | fips         | FIPS         | --assume-yes --beta  |
+           | fips-updates | FIPS Updates | --assume-yes --beta  |
+
+    @series.trusty
+    Scenario Outline:  Attached enable of non-container beta services in a trusty lxd container
+        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable <service> <flag>` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable <service> <flag>` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And I will see the following on stderr:
+            """
+            Cannot enable '<service>'
+            For a list of services see: sudo ua status
+            """
+
+        Examples: beta services in containers
+           | service      | flag         |
+           | fips         | --assume-yes |
+           | fips-updates | --assume-yes |
 
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty lxd container
@@ -40,38 +65,26 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached enable CIS Audit service in a trusty lxd container
+    Scenario Outline: Attached enable not entitled service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable cis-audit` as non-root
+        And I run `ua enable <service>` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable cis-audit` with sudo
+        When I run `ua enable <service>` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            This subscription is not entitled to CIS Audit.
+            This subscription is not entitled to <title>.
             For more information see: https://ubuntu.com/advantage
             """
 
-    @series.trusty
-    Scenario: Attached enable UA Apps service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable esm-apps` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable esm-apps` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            This subscription is not entitled to ESM Apps.
-            For more information see: https://ubuntu.com/advantage
-            """
+        Examples: not entitled services
+           | service      | title        |
+           | cis-audit    | CIS Audit    |
+           | esm-apps     | ESM Apps     |
 
     @series.trusty
     Scenario: Attached enable of an unknown service in a trusty lxd container
@@ -123,12 +136,36 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: Un-supported services in containers
-           | service      | title        | flag          |
-           | livepatch    | Livepatch    |               |
-           | fips         | FIPS         | --assume-yes  |
-           | fips-updates | FIPS Updates | --assume-yes  |
+           | service      | title        | flag                 |
+           | livepatch    | Livepatch    |                      |
+           | fips         | FIPS         | --assume-yes --beta  |
+           | fips-updates | FIPS Updates | --assume-yes --beta  |
 
+    @wip
+    @series.focal
+    Scenario Outline:  Attached enable of non-container beta services in a focal lxd container
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable <service> <flag>` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable <service> <flag>` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable '<service>'
+            For a list of services see: sudo ua status
+            """
 
+        Examples: beta services in containers
+           | service      | flag         |
+           | fips         | --assume-yes |
+           | fips-updates | --assume-yes |
 
     @series.focal
     Scenario: Attached enable Common Criteria service in a focal lxd container
@@ -147,39 +184,26 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached enable CIS Audit service in a focal lxd container
+    Scenario Outline: Attached enable not entitled service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable cis-audit` as non-root
+        And I run `ua enable <service>` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable cis-audit` with sudo
+        When I run `ua enable <service>` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            This subscription is not entitled to CIS Audit.
+            This subscription is not entitled to <title>.
             For more information see: https://ubuntu.com/advantage
             """
 
-    @series.focal
-    Scenario: Attached enable UA Apps service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable esm-apps` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable esm-apps` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            This subscription is not entitled to ESM Apps.
-            For more information see: https://ubuntu.com/advantage
-            """
-
+        Examples: not entitled services
+           | service      | title        |
+           | cis-audit    | CIS Audit    |
+           | esm-apps     | ESM Apps     |
 
     @series.focal
     Scenario: Attached enable of an unknown service in a focal lxd container
@@ -213,4 +237,3 @@ Feature: Enable command behaviour when attached to an UA subscription
             ESM Infra is already enabled.
             See: sudo ua status
             """
-

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,6 +1,5 @@
 Feature: Unattached status
 
-    @wip
     @series.trusty
     Scenario: Unattached status in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
@@ -8,7 +7,6 @@ Feature: Unattached status
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      no         UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
@@ -34,7 +32,6 @@ Feature: Unattached status
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      no         UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
@@ -57,6 +54,7 @@ Feature: Unattached status
             See https://ubuntu.com/advantage
             """ 
     
+    @wip
     @series.focal
     Scenario: Unattached status in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
@@ -64,7 +62,6 @@ Feature: Unattached status
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      yes        UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
@@ -90,7 +87,6 @@ Feature: Unattached status
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      yes        UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -10,6 +10,18 @@ Feature: Unattached status
             cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      no         UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+        When I run `ua status --show-beta` as non-root
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      no         UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
             fips-updates  no         Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
@@ -18,6 +30,18 @@ Feature: Unattached status
             See https://ubuntu.com/advantage
             """
         When I run `ua status` with sudo
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      no         UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+        When I run `ua status --show-beta` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -42,6 +66,18 @@ Feature: Unattached status
             cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      yes        UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+        When I run `ua status --show-beta` as non-root
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      yes        UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
             fips-updates  no         Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
@@ -56,10 +92,22 @@ Feature: Unattached status
             cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      yes        UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+        When I run `ua status --show-beta` with sudo
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      yes        UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
             fips-updates  no         Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
-            """           
+            """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,5 +1,6 @@
 Feature: Unattached status
 
+    @wip
     @series.trusty
     Scenario: Unattached status in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
@@ -15,7 +16,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --show-beta` as non-root
+        When I run `ua status --beta` as non-root
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -41,7 +42,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --show-beta` with sudo
+        When I run `ua status --beta` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -71,7 +72,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --show-beta` as non-root
+        When I run `ua status --beta` as non-root
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -97,7 +98,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --show-beta` with sudo
+        When I run `ua status --beta` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -244,6 +244,11 @@ def status_parser(parser):
             )
         ),
     )
+    parser.add_argument(
+        "--show-beta",
+        action="store_true",
+        help="Allow the visualization of beta services",
+    )
     parser._optionals.title = "Flags"
     return parser
 
@@ -558,7 +563,8 @@ def action_status(args, cfg):
             status["expires"] = str(status["expires"])
         print(json.dumps(status))
     else:
-        output = ua_status.format_tabular(cfg.status())
+        show_beta = args.show_beta if args else False
+        output = ua_status.format_tabular(cfg.status(show_beta))
         # Replace our Unicode dash with an ASCII dash if we aren't going to be
         # writing to a utf-8 output; see
         # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/859

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -291,6 +291,7 @@ def _perform_enable(
     :param silent_if_inapplicable:
         don't output messages when determining if an entitlement can be
         enabled on this system
+    :param allow_beta: Allow enabling beta services
 
     @return: True on success, False otherwise
     """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -245,7 +245,7 @@ def status_parser(parser):
         ),
     )
     parser.add_argument(
-        "--show-beta",
+        "--beta",
         action="store_true",
         help="Allow the visualization of beta services",
     )
@@ -563,7 +563,7 @@ def action_status(args, cfg):
             status["expires"] = str(status["expires"])
         print(json.dumps(status))
     else:
-        show_beta = args.show_beta if args else False
+        show_beta = args.beta if args else False
         output = ua_status.format_tabular(cfg.status(show_beta))
         # Replace our Unicode dash with an ASCII dash if we aren't going to be
         # writing to a utf-8 output; see

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 
 from uaclient import status, util
 from uaclient.defaults import CONFIG_DEFAULTS, DEFAULT_CONFIG_FILE
-from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 from uaclient import exceptions
 
 try:
@@ -201,6 +200,8 @@ class UAConfig:
         util.write_file(filepath, content, mode=mode)
 
     def _remove_beta_resources(self, response, show_beta):
+        from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
+
         if show_beta:
             return
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -199,7 +199,8 @@ class UAConfig:
                 mode = 0o644
         util.write_file(filepath, content, mode=mode)
 
-    def _remove_beta_resources(self, response, show_beta):
+    def _remove_beta_resources(self, response, show_beta) -> None:
+        """ Remove beta services from response dict if show_beta is False"""
         from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
         if show_beta:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 
 from uaclient import status, util
 from uaclient.defaults import CONFIG_DEFAULTS, DEFAULT_CONFIG_FILE
+from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 from uaclient import exceptions
 
 try:
@@ -199,6 +200,32 @@ class UAConfig:
                 mode = 0o644
         util.write_file(filepath, content, mode=mode)
 
+    def _remove_beta_resources(self, response, show_beta):
+        if show_beta:
+            return
+
+        if response.get("services"):
+            released_resources = []
+
+            for resource in response["services"]:
+                resource_name = resource["name"]
+                ent_cls = ENTITLEMENT_CLASS_BY_NAME.get(resource_name)
+
+                if ent_cls is None:
+                    """
+                    Here we cannot know the status of a service,
+                    since it is not listed as a valid entitlement.
+                    Therefore, we keep this service in the list, since
+                    we cannot validate if it is a beta service or not.
+                    """
+                    released_resources.append(resource)
+                    continue
+
+                if not ent_cls.is_beta:
+                    released_resources.append(resource)
+
+            response["services"] = released_resources
+
     def _unattached_status(self) -> "Dict[str, Any]":
         """Return unattached status as a dict."""
         from uaclient.contract import get_available_resources
@@ -206,12 +233,14 @@ class UAConfig:
 
         response = copy.deepcopy(DEFAULT_STATUS)
         resources = get_available_resources(self)
+
         for resource in sorted(resources, key=lambda x: x["name"]):
             if resource["available"]:
                 available = status.UserFacingAvailability.AVAILABLE.value
             else:
                 available = status.UserFacingAvailability.UNAVAILABLE.value
             ent_cls = ENTITLEMENT_CLASS_BY_NAME.get(resource["name"])
+
             if not ent_cls:
                 LOG.debug(
                     "Ignoring availability of unknown service %s"
@@ -219,6 +248,7 @@ class UAConfig:
                     resource["name"],
                 )
                 continue
+
             response["services"].append(
                 {
                     "name": resource["name"],
@@ -276,6 +306,7 @@ class UAConfig:
         resources = self.machine_token.get("availableResources")
         if not resources:
             resources = get_available_resources(self)
+
         inapplicable_resources = {
             resource["name"]: resource.get("description")
             for resource in sorted(resources, key=lambda x: x["name"])
@@ -295,7 +326,7 @@ class UAConfig:
             response["techSupportLevel"] = supportLevel
         return response
 
-    def status(self) -> "Dict[str, Any]":
+    def status(self, show_beta=False) -> "Dict[str, Any]":
         """Return status as a dict, using a cache for non-root users
 
         When unattached, get available resources from the contract service
@@ -314,6 +345,8 @@ class UAConfig:
             response = self._attached_status()
         if os.getuid() == 0:
             self.write_cache("status-cache", response)
+
+        self._remove_beta_resources(response, show_beta)
         return response
 
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -35,6 +35,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     #  Whether to assume yes to any messaging prompts
     assume_yes = False
 
+    # Wheter that entitlement is in beta stage
+    is_beta = False
+
     @property
     @abc.abstractmethod
     def name(self) -> str:

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -16,6 +16,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     title = "CC EAL2"
     description = "Common Criteria EAL2 Provisioning Packages"
     repo_key_file = "ubuntu-cc-keyring.gpg"
+    is_beta = True
 
     @property
     def messaging(

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -8,3 +8,4 @@ class CISEntitlement(repo.RepoEntitlement):
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"
     repo_key_file = "ubuntu-securitybenchmarks-keyring.gpg"
+    is_beta = True

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -15,6 +15,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     repo_pin_priority = 1001
     fips_required_packages = frozenset({"fips-initramfs", "linux-fips"})
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
+    is_beta = True
 
     @property
     def packages(self) -> "List[str]":

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -78,7 +78,7 @@ class TestActionEnable:
         """assume-yes parameter is passed to entitlement instantiation."""
         m_getuid.return_value = 0
 
-        m_entitlement_cls = mock.Mock()
+        m_entitlement_cls = mock.MagicMock()
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "testitlement": m_entitlement_cls
         }
@@ -106,6 +106,9 @@ class TestPerformEnable:
         with pytest.raises(KeyError):
             _perform_enable("entitlement", mock.Mock())
 
+    @pytest.mark.parametrize(
+        "allow_beta, beta_call_count", ((True, 0), (False, 1))
+    )
     @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
     @mock.patch("uaclient.contract.get_available_resources", return_value={})
     @mock.patch("uaclient.cli.entitlements")
@@ -114,14 +117,19 @@ class TestPerformEnable:
         m_entitlements,
         _m_get_available_resources,
         silent_if_inapplicable,
+        allow_beta,
+        beta_call_count,
     ):
         m_entitlement_cls = mock.Mock()
         m_cfg = mock.Mock()
+        m_is_beta = mock.PropertyMock(return_value=allow_beta)
+        type(m_entitlement_cls).is_beta = m_is_beta
+
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "testitlement": m_entitlement_cls
         }
 
-        kwargs = {}
+        kwargs = {"allow_beta": allow_beta}
         if silent_if_inapplicable is not None:
             kwargs["silent_if_inapplicable"] = silent_if_inapplicable
         ret = _perform_enable("testitlement", m_cfg, **kwargs)
@@ -139,3 +147,27 @@ class TestPerformEnable:
         assert ret == m_entitlement.enable.return_value
 
         assert 1 == m_cfg.status.call_count
+        assert beta_call_count == m_is_beta.call_count
+
+    @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
+    @mock.patch("uaclient.cli.entitlements")
+    def test_beta_entitlement_not_enabled(
+        self, m_entitlements, silent_if_inapplicable
+    ):
+        m_entitlement_cls = mock.Mock()
+        m_cfg = mock.Mock()
+        m_is_beta = mock.PropertyMock(return_value=True)
+        type(m_entitlement_cls).is_beta = m_is_beta
+
+        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            "testitlement": m_entitlement_cls
+        }
+
+        kwargs = {"allow_beta": False}
+        if silent_if_inapplicable is not None:
+            kwargs["silent_if_inapplicable"] = silent_if_inapplicable
+
+        with pytest.raises(exceptions.UserFacingError):
+            _perform_enable("testitlement", m_cfg, **kwargs)
+
+        assert 1 == m_is_beta.call_count


### PR DESCRIPTION
Right now, services that are in a beta stage, such as `fips` are shown normally when an user run `ua status`. We are now changing that behavior for `ua status` to only show production ready services. If the user wants to see all services, the command to run will be `ua status --beta`.

Also, if the user tries to enable a beta service using: `ua enable fips`, ua-client will raise an error saying that the service could not be found. To enable beta services, users will need to run the following command: `ua enable fips --beta`

Fixes: #1079