### PR TITLE
Test against staging

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -5,7 +5,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     @series.trusty
     Scenario: Attach command in a trusty lxd container
        Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
         ESM Infra enabled
@@ -33,7 +33,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     @series.focal
     Scenario: Attach command in a focal lxd container
        Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
         ESM Infra enabled

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -4,7 +4,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached refresh in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
         Then I will see the following on stderr:
             """
@@ -19,7 +19,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached disable of an already disabled service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
         Then I will see the following on stderr:
             """
@@ -35,7 +35,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached disable of an unknown service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -51,7 +51,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached disable of an already enabled service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
         Then I will see the following on stderr:
             """
@@ -80,7 +80,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached detach in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua detach` as non-root
         Then I will see the following on stderr:
             """
@@ -113,7 +113,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached auto-attach in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
             """
@@ -127,7 +127,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached show version in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua version` as non-root
         Then I will see the following on stdout:
             """
@@ -152,7 +152,7 @@ Feature: Command behaviour when attached to an UA subscription
    @series.focal
    Scenario: Attached refresh in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
         Then I will see the following on stderr:
             """
@@ -167,7 +167,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached disable of an already disabled service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
         Then I will see the following on stderr:
             """
@@ -183,7 +183,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached disable of an unknown service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -200,7 +200,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached disable of an already enabled service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
         Then I will see the following on stderr:
             """
@@ -220,7 +220,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached detach in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua detach` as non-root
         Then I will see the following on stderr:
             """
@@ -253,7 +253,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached auto-attach in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
             """
@@ -268,7 +268,7 @@ Feature: Command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached show version in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua version` as non-root
         Then I will see the following on stdout:
             """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -4,7 +4,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario Outline:  Attached enable of non-container services in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
             """
@@ -26,7 +26,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable cc-eal` as non-root
         Then I will see the following on stderr:
             """
@@ -42,7 +42,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached enable CIS Audit service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable cis-audit` as non-root
         Then I will see the following on stderr:
             """
@@ -59,7 +59,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached enable UA Apps service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable esm-apps` as non-root
         Then I will see the following on stderr:
             """
@@ -76,7 +76,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached enable of an unknown service in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -92,7 +92,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.trusty
     Scenario: Attached enable of a known service already enabled (UA Infra) in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable esm-infra` as non-root
         Then I will see the following on stderr:
             """
@@ -109,7 +109,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     Scenario Outline: Attached enable of non-container services in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
             """
@@ -133,7 +133,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached enable Common Criteria service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable cc-eal` as non-root
         Then I will see the following on stderr:
             """
@@ -149,7 +149,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached enable CIS Audit service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable cis-audit` as non-root
         Then I will see the following on stderr:
             """
@@ -166,7 +166,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached enable UA Apps service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable esm-apps` as non-root
         Then I will see the following on stderr:
             """
@@ -184,7 +184,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached enable of an unknown service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable foobar` as non-root
         Then I will see the following on stderr:
             """
@@ -200,7 +200,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     Scenario: Attached enable of a known service already enabled (UA Infra) in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
-        When I attach contract_token with sudo
+        When I attach `contract_token` with sudo
         And I run `ua enable esm-infra` as non-root
         Then I will see the following on stderr:
             """

--- a/features/environment.py
+++ b/features/environment.py
@@ -27,6 +27,8 @@ class UAClientBehaveConfig:
 
     :param contract_token:
         A valid contract token to use during attach scenarios
+    :param contract_token_staging:
+        A valid staging contract token to use during attach scenarios
     :param image_clean:
         This indicates whether the image created for this test run should be
         cleaned up when all tests are complete.
@@ -44,9 +46,9 @@ class UAClientBehaveConfig:
     # These variables are used in .from_environ() to convert the string
     # environment variable input to the appropriate Python types for use within
     # the test framework
-    boolean_options = ["build_pr", "image_clean", "destroy_instances"]
-    str_options = ["contract_token", "reuse_image"]
-    redact_options = ["contract_token"]
+    boolean_options = ["image_clean", "destroy_instances"]
+    str_options = ["contract_token", "contract_token_staging", "reuse_image"]
+    redact_options = ["contract_token", "contract_token_staging"]
 
     # This variable is used in .from_environ() but also to emit the "Config
     # options" stanza in __init__
@@ -59,11 +61,13 @@ class UAClientBehaveConfig:
         image_clean: bool = True,
         destroy_instances: bool = True,
         reuse_image: str = None,
-        contract_token: str = None
+        contract_token: str = None,
+        contract_token_staging: str = None
     ) -> None:
         # First, store the values we've detected
         self.build_pr = build_pr
         self.contract_token = contract_token
+        self.contract_token_staging = contract_token_staging
         self.image_clean = image_clean
         self.destroy_instances = destroy_instances
         self.reuse_image = reuse_image

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -1,0 +1,17 @@
+@uses.config.contract_token_staging
+Feature: Enable command behaviour when attached to an UA staging subscription
+
+    @series.xenial
+    Scenario: Attached enable CC EAL service in a xenial lxd container
+        Given a `xenial` lxd container with ubuntu-advantage-tools installed
+        When I attach `contract_token_staging` with sudo
+        And I run `ua enable cc-eal` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable cc-eal` with sudo
+        Then I will see the following on stderr:
+            """
+            GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found
+            """

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -6,6 +6,8 @@ from hamcrest import assert_that, equal_to, matches_regexp
 
 from features.util import launch_lxd_container, lxc_exec
 
+from uaclient.defaults import DEFAULT_CONFIG_FILE
+
 
 CONTAINER_PREFIX = "behave-test-"
 
@@ -36,9 +38,17 @@ def when_i_run_command(context, command, user_spec):
     context.process = process
 
 
-@when("I attach contract_token {user_spec}")
-def when_i_attach_token(context, user_spec):
-    token = context.config.contract_token
+@when("I attach `{token_type}` {user_spec}")
+def when_i_attach_staging_token(context, token_type, user_spec):
+    token = getattr(context.config, token_type)
+    if token_type == "contract_token_staging":
+        when_i_run_command(
+            context,
+            "sed -i 's/contracts.can/contracts.staging.can/' {}".format(
+                DEFAULT_CONFIG_FILE
+            ),
+            user_spec,
+        )
     when_i_run_command(context, "ua attach %s" % token, user_spec)
 
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -118,7 +118,6 @@ Feature: Command behaviour when unattached
            | disable |
            | enable  |
 
-    @wip
     @series.focal
     Scenario Outline: Unattached command of an unknown service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed


### PR DESCRIPTION
Add the ability to pass a UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING environment variable into behave tests to exercise staging service cc-eal.

To test:
Grab your staging credentials from https://auth.contracts.staging.canonical.com/
```
UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING=<yourtoken> tox -e behave features/staging_commands.feature
```

The intent is to provide a mechinism for ease of test for services which only have proper service
definitions on contracts.staging.canonical.com

Fixes: #1074 