### PR TITLE
Add missing build_pr command to environment

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -46,7 +46,7 @@ class UAClientBehaveConfig:
     # These variables are used in .from_environ() to convert the string
     # environment variable input to the appropriate Python types for use within
     # the test framework
-    boolean_options = ["image_clean", "destroy_instances"]
+    boolean_options = ["build_pr", "image_clean", "destroy_instances"]
     str_options = ["contract_token", "contract_token_staging", "reuse_image"]
     redact_options = ["contract_token", "contract_token_staging"]
 


### PR DESCRIPTION
Right now we are missing the `build_pr` command created by #1057 . Because of that, the behave test  for PR #1069 are failing, since we are not building the ua-client from the PR source code.

We are adding the command back in this PR.