### PR TITLE
Release 24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,11 @@
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:
-      - livepatch: run snap wait system snap.seeded before trying to install
-        (GH: #1049)
+    - livepatch: run snap wait system snap.seeded before trying to install
+      (GH: #1049)
+    - version: return debian/changelog version when git describe fails to
+      match upstream <major>.<minor> tags for git-ubuntu workflow
+      (GH: #1058)
 
  -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:07:17 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (24.2) groovy; urgency=medium
+
+  * New bug-fix-only release 24.2:
+    - uaclient.version bump to 24.2
+    - pro: Add AWS China and GovCloud partitions support (GH #1077)
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Jun 2020 16:12:41 -0600
+
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (24.1) groovy; urgency=medium
+
+  * New bug-fix-only release 24.1:
+      - livepatch: run snap wait system snap.seeded before trying to install
+        (GH: #1049)
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:07:17 -0600
+
 ubuntu-advantage-tools (24.0) groovy; urgency=medium
 
   * bump version to 24.0 for new versioninig scheme

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (24.0) groovy; urgency=medium
+
+  * bump version to 24.0 for new versioninig scheme
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 18 May 2020 15:04:33 -0600
+
 ubuntu-advantage-tools (20.3) focal; urgency=medium
 
   * New upstream release 20.3:

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -65,6 +65,8 @@ def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
 
     cloud_instance_map = {
         "aws": aws.UAAutoAttachAWSInstance,
+        "aws-china": aws.UAAutoAttachAWSInstance,
+        "aws-gov": aws.UAAutoAttachAWSInstance,
         "azure": azure.UAAutoAttachAzureInstance,
     }
 

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -143,3 +143,27 @@ class TestCloudInstanceFactory:
                 cloud_instance_factory()
         error_msg = status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
         assert error_msg == str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "cloud_type", ("aws", "aws-gov", "aws-china", "azure")
+    )
+    def test_return_cloud_instance_on_viable_clouds(
+        self, m_get_cloud_type, cloud_type
+    ):
+        """Return UAAutoAttachInstance when matching cloud_type is viable."""
+        m_get_cloud_type.return_value = cloud_type
+
+        fake_instance = mock.Mock()
+        fake_instance.is_viable = True
+
+        def fake_viable_instance():
+            return fake_instance
+
+        if cloud_type == "azure":
+            M_INSTANCE_PATH = "uaclient.clouds.azure.UAAutoAttachAzureInstance"
+        else:
+            M_INSTANCE_PATH = "uaclient.clouds.aws.UAAutoAttachAWSInstance"
+
+        with mock.patch(M_INSTANCE_PATH) as m_instance:
+            m_instance.side_effect = fake_viable_instance
+            assert fake_instance == cloud_instance_factory()

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -66,14 +66,14 @@ class LivepatchEntitlement(base.UAEntitlement):
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
                 )
-                util.subp(
-                    [SNAP_CMD, "wait", "system", "seed.loaded"], capture=True
-                )
             elif "snapd" not in apt.get_installed_packages():
                 raise exceptions.UserFacingError(
                     "/usr/bin/snap is present but snapd is not installed;"
                     " cannot enable {}".format(self.title)
                 )
+            util.subp(
+                [SNAP_CMD, "wait", "system", "seed.loaded"], capture=True
+            )
             print("Installing canonical-livepatch snap")
             try:
                 util.subp(

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -404,10 +404,12 @@ class TestLivepatchEntitlementEnable:
             ["apt-get", "install", "--assume-yes", "snapd"],
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
-        ),
+        )
+    ]
+    mocks_snap_wait_seed = [
         mock.call(
             ["/usr/bin/snap", "wait", "system", "seed.loaded"], capture=True
-        ),
+        )
     ]
     mocks_livepatch_install = [
         mock.call(
@@ -416,7 +418,9 @@ class TestLivepatchEntitlementEnable:
             retry_sleeps=[0.5, 1, 5],
         )
     ]
-    mocks_install = mocks_snapd_install + mocks_livepatch_install
+    mocks_install = (
+        mocks_snapd_install + mocks_snap_wait_seed + mocks_livepatch_install
+    )
     mocks_config = [
         mock.call(
             [
@@ -535,7 +539,9 @@ class TestLivepatchEntitlementEnable:
         m_app_status.return_value = application_status, "enabled"
         assert entitlement.enable()
         assert (
-            self.mocks_livepatch_install + self.mocks_config
+            self.mocks_snap_wait_seed
+            + self.mocks_livepatch_install
+            + self.mocks_config
             in m_subp.call_args_list
         )
         msg = (

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -1,0 +1,61 @@
+import mock
+
+import os.path
+
+from uaclient import util
+from uaclient.version import get_version
+
+
+@mock.patch("uaclient.util.subp")
+class TestGetVersion:
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "24.1~18.04.1")
+    def test_get_version_returns_packaged_version(self, m_subp):
+        assert "24.1~18.04.1" == get_version()
+        assert 0 == m_subp.call_count
+
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_get_version_returns_matching_git_describe_long(
+        self, m_exists, m_subp
+    ):
+        m_subp.return_value = ("24.1-5-g12345678", "")
+        assert "24.1-5-g12345678" == get_version()
+        assert [
+            mock.call(
+                ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
+            )
+        ] == m_subp.call_args_list
+        top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        top_dir_git = os.path.join(top_dir, ".git")
+        assert [mock.call(top_dir_git)] == m_exists.call_args_list
+
+    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_returns_dpkg_parsechangelog_on_git_ubuntu_pkg_branch(
+        self, m_exists, m_subp
+    ):
+        """Call dpkg-parsechangelog if git describe fails to --match=[0-9]*"""
+
+        def fake_subp(cmd):
+            if cmd[0] == "git":
+                # Not matching tag on git-ubuntu pkg branches
+                raise util.ProcessExecutionError(
+                    "fatal: No names found, cannot describe anything."
+                )
+            if cmd[0] == "dpkg-parsechangelog":
+                return ("24.1\n", "")
+            assert False, "Unexpected subp cmd {}".format(cmd)
+
+        m_subp.side_effect = fake_subp
+
+        assert "24.1" == get_version()
+        expected_calls = [
+            mock.call(
+                ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
+            ),
+            mock.call(["dpkg-parsechangelog", "-S", "version"]),
+        ]
+        assert expected_calls == m_subp.call_args_list
+        top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        top_dir_git = os.path.join(top_dir, ".git")
+        assert [mock.call(top_dir_git)] == m_exists.call_args_list

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from subprocess import check_output
 
 
-__VERSION__ = "24.0"
+__VERSION__ = "24.1"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from subprocess import check_output
 
 
-__VERSION__ = "20.3"
+__VERSION__ = "24.0"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -5,7 +5,7 @@ These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
 import os.path
-from subprocess import check_output
+from uaclient import util
 
 
 __VERSION__ = "24.1"
@@ -13,11 +13,28 @@ PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 
 def get_version(_args=None):
-    """Return the package version if set, otherwise return git describe."""
+    """Return the packaged version as a string
+
+         Prefer the binary PACKAGED_VESION set by debian/rules to DEB_VERSION.
+         If unavailable, check for a .git development environments:
+           a. If run in our upstream repo `git describe` will gives a leading
+              XX.Y so return the --long version to allow daily build recipes
+              to count commit offset from upstream's XX.Y signed tag.
+           b. If run in a git-ubuntu pkg repo, upstream tags aren't visible,
+              parse the debian/changelog in that case
+    """
     if not PACKAGED_VERSION.startswith("@@PACKAGED_VERSION"):
         return PACKAGED_VERSION
     topdir = os.path.dirname(os.path.dirname(__file__))
     if os.path.exists(os.path.join(topdir, ".git")):
         cmd = ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
-        return check_output(cmd, universal_newlines=True).strip()
+        try:
+            out, _ = util.subp(cmd)
+            return out.strip()
+        except util.ProcessExecutionError:
+            # Rely on debian/changelog because we are in a git-ubuntu or other
+            # packaging repo
+            cmd = ["dpkg-parsechangelog", "-S", "version"]
+            out, _ = util.subp(cmd)
+            return out.strip()
     return __VERSION__

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from uaclient import util
 
 
-__VERSION__ = "24.1"
+__VERSION__ = "24.2"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
Cherry-pick a bug fix from master for detecting aws-gov and aws-china as valid platforms.
Bump pkg release version from 24.1 -> 24.2



How I created the branch:
```
 git checkout upstream/release-24 -B release-24
  git cherry-pick 1d75bc84e6c42c42e7d9b6221a68d4fcaf4c3142
  git cherry-pick 8a080cb946507a7e9954804ec54fb17f7e65ed01
  cat > 1.patch <<EOF
diff --git a/debian/changelog b/debian/changelog
index 6d37794..af0a6ef 100644
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (24.2) groovy; urgency=medium
+
+  * New bug-fix-only release 24.2:
+    - uaclient.version bump to 24.2
+    - pro: Add AWS China and GovCloud partitions support (GH #1077)
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Jun 2020 16:12:41 -0600
+
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:
diff --git a/uaclient/version.py b/uaclient/version.py
index ab0555b..ca57da0 100644
--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from uaclient import util
 
 
-__VERSION__ = "24.1"
+__VERSION__ = "24.2"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
EOF

patch -p1 < 1.patch
git commit -m 'update version to 24.2 for bug-fix-release' uaclient/version.py
git commit -m 'changelog: update 24.2 version for bug-fix-release' debian/changelog
```
