### PR TITLE
Release 24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (24.2) groovy; urgency=medium
+
+  * New bug-fix-only release 24.2:
+    - uaclient.version bump to 24.2
+    - pro: Add AWS China and GovCloud partitions support (GH #1077)
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Jun 2020 16:12:41 -0600
+
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -65,6 +65,8 @@ def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
 
     cloud_instance_map = {
         "aws": aws.UAAutoAttachAWSInstance,
+        "aws-china": aws.UAAutoAttachAWSInstance,
+        "aws-gov": aws.UAAutoAttachAWSInstance,
         "azure": azure.UAAutoAttachAzureInstance,
     }
 

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -143,3 +143,27 @@ class TestCloudInstanceFactory:
                 cloud_instance_factory()
         error_msg = status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
         assert error_msg == str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "cloud_type", ("aws", "aws-gov", "aws-china", "azure")
+    )
+    def test_return_cloud_instance_on_viable_clouds(
+        self, m_get_cloud_type, cloud_type
+    ):
+        """Return UAAutoAttachInstance when matching cloud_type is viable."""
+        m_get_cloud_type.return_value = cloud_type
+
+        fake_instance = mock.Mock()
+        fake_instance.is_viable = True
+
+        def fake_viable_instance():
+            return fake_instance
+
+        if cloud_type == "azure":
+            M_INSTANCE_PATH = "uaclient.clouds.azure.UAAutoAttachAzureInstance"
+        else:
+            M_INSTANCE_PATH = "uaclient.clouds.aws.UAAutoAttachAWSInstance"
+
+        with mock.patch(M_INSTANCE_PATH) as m_instance:
+            m_instance.side_effect = fake_viable_instance
+            assert fake_instance == cloud_instance_factory()

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from uaclient import util
 
 
-__VERSION__ = "24.1"
+__VERSION__ = "24.2"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
Cherry-pick a bug fix from master for detecting aws-gov and aws-china as valid platforms.
Bump pkg release version from 24.1 -> 24.2



How I created the branch:
```
 git checkout upstream/release-24 -B release-24
  git cherry-pick 1d75bc84e6c42c42e7d9b6221a68d4fcaf4c3142
  git cherry-pick 8a080cb946507a7e9954804ec54fb17f7e65ed01
  cat > 1.patch <<EOF
diff --git a/debian/changelog b/debian/changelog
index 6d37794..af0a6ef 100644
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (24.2) groovy; urgency=medium
+
+  * New bug-fix-only release 24.2:
+    - uaclient.version bump to 24.2
+    - pro: Add AWS China and GovCloud partitions support (GH #1077)
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Jun 2020 16:12:41 -0600
+
 ubuntu-advantage-tools (24.1) groovy; urgency=medium
 
   * New bug-fix-only release 24.1:
diff --git a/uaclient/version.py b/uaclient/version.py
index ab0555b..ca57da0 100644
--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from uaclient import util
 
 
-__VERSION__ = "24.1"
+__VERSION__ = "24.2"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
EOF

patch -p1 < 1.patch
