### PR TITLE
Ensure we don't prompt for configuration file diff

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -77,16 +77,15 @@ class RepoEntitlement(base.UAEntitlement):
         pass
     
     @property 
-    def dpkg_options(self) -> str:
+    def dpkg_options(self) -> "List[str]":
         """
-        Returns a string of dpkg options to pass to apt
+        Returns a list of dpkg options to pass to apt
         """
         options_list = ['force-confdef', 'force-confold']
-        dpkg_options = ""
-        for dpkg_option in options_list:
-            dpkg_options = '%s -o "Dpkg::Options::=--%s"' \
-                           % (dpkg_options, dpkg_option)
-        return dpkg_options.strip()    
+        dpkg_options = []
+        for option in options_list:
+            dpkg_options.append('-o "Dpkg::Options::=--{}".format(option)')
+        return dpkg_options    
     
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -28,6 +28,7 @@ from uaclient.status import ApplicationStatus
 
 APT_DISABLED_PIN = "-32768"
 
+
 class RepoEntitlement(base.UAEntitlement):
 
     repo_list_file_tmpl = "/etc/apt/sources.list.d/ubuntu-{name}-{series}.list"
@@ -75,8 +76,8 @@ class RepoEntitlement(base.UAEntitlement):
     @abc.abstractmethod
     def repo_key_file(self) -> str:
         pass
-    
-    @property 
+
+    @property
     def dpkg_options(self) -> "List[str]":
         """
         Returns a list of dpkg options to pass to apt
@@ -84,9 +85,9 @@ class RepoEntitlement(base.UAEntitlement):
         options_list = ['force-confdef', 'force-confold']
         dpkg_options = []
         for option in options_list:
-            dpkg_options.append('-o "Dpkg::Options::=--{}"'.format(option))
-        return dpkg_options    
-    
+            dpkg_options.append('-o="Dpkg::Options::=--{}"'.format(option))
+        return dpkg_options
+
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.
 

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -84,7 +84,7 @@ class RepoEntitlement(base.UAEntitlement):
         options_list = ['force-confdef', 'force-confold']
         dpkg_options = []
         for option in options_list:
-            dpkg_options.append('-o "Dpkg::Options::=--{}".format(option)')
+            dpkg_options.append('-o "Dpkg::Options::=--{}"'.format(option))
         return dpkg_options    
     
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -468,8 +468,8 @@ class TestRepoEnable:
                             "apt-get",
                             "install",
                             "--assume-yes",
-                            '-o "Dpkg::Options::=--force-confdef"',
-                            '-o "Dpkg::Options::=--force-confold"',
+                            '-o="Dpkg::Options::=--force-confdef"',
+                            '-o="Dpkg::Options::=--force-confold"',
                             " ".join(packages),
                         ],
                         capture=True,
@@ -540,7 +540,7 @@ class TestRepoEnable:
 
         assert "Could not enable Repo Test Class." == excinfo.value.msg
         expected_call = mock.call(
-            ["apt-get", "remove", "--assume-yes", '-o "Dpkg::Options::=--force-confdef"','-o "Dpkg::Options::=--force-confold"',] + packages
+            ["apt-get", "remove", "--assume-yes", '-o="Dpkg::Options::=--force-confdef"','-o =Dpkg::Options::=--force-confold"',] + packages
         )
         assert expected_call in m_subp.call_args_list
         assert 1 == m_rac.call_count
@@ -749,8 +749,8 @@ class TestSetupAptConfig:
                 "apt-get",
                 "install",
                 "--assume-yes",
-                '-o "Dpkg::Options::=--force-confdef"',
-                '-o "Dpkg::Options::=--force-confold"',
+                '-o="Dpkg::Options::=--force-confdef"',
+                '-o="Dpkg::Options::=--force-confold"',
                 "apt-transport-https",
                 "ca-certificates",
             ],

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -468,6 +468,8 @@ class TestRepoEnable:
                             "apt-get",
                             "install",
                             "--assume-yes",
+                            '-o "Dpkg::Options::=--force-confdef"',
+                            '-o "Dpkg::Options::=--force-confold"',
                             " ".join(packages),
                         ],
                         capture=True,
@@ -538,7 +540,7 @@ class TestRepoEnable:
 
         assert "Could not enable Repo Test Class." == excinfo.value.msg
         expected_call = mock.call(
-            ["apt-get", "remove", "--assume-yes"] + packages
+            ["apt-get", "remove", "--assume-yes", '-o "Dpkg::Options::=--force-confdef"','-o "Dpkg::Options::=--force-confold"',] + packages
         )
         assert expected_call in m_subp.call_args_list
         assert 1 == m_rac.call_count
@@ -747,6 +749,8 @@ class TestSetupAptConfig:
                 "apt-get",
                 "install",
                 "--assume-yes",
+                '-o "Dpkg::Options::=--force-confdef"',
+                '-o "Dpkg::Options::=--force-confold"',
                 "apt-transport-https",
                 "ca-certificates",
             ],


### PR DESCRIPTION
The client can become blocked if APT prompts for a configuration file difference for the user to select. 
This commit ensures we pass through force-confdef and force-confold to avoid such prompts

Closes https://github.com/canonical/ubuntu-advantage-client/issues/1084


The logic is partially copied from how Ansible currently avoids this situation: https://github.com/ansible/ansible/blob/062e780a68f9acd2ee6f824f252458b8a0351f24/lib/ansible/modules/apt.py#L517-L523 