### PR TITLE
tests: add lxd vm support for behave tests.

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -2,7 +2,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
          Advantage subscription using an invalid token
 
     @series.trusty
-    Scenario: Attach command in a trusty lxd container
+    Scenario: Attach command in a trusty machine
        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua attach INVALID_TOKEN` with sudo
         Then I will see the following on stderr:
@@ -16,7 +16,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              """
 
     @series.focal
-    Scenario: Attach command in a focal lxd container
+    Scenario: Attach command in a focal machine
        Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua attach INVALID_TOKEN` with sudo
         Then stderr matches regexp:

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -3,7 +3,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
 
     @series.trusty
     Scenario: Attach command in a trusty lxd container
-       Given a `trusty` lxd container with ubuntu-advantage-tools installed
+       Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua attach INVALID_TOKEN` with sudo
         Then I will see the following on stderr:
             """
@@ -17,7 +17,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
 
     @series.focal
     Scenario: Attach command in a focal lxd container
-       Given a `focal` lxd container with ubuntu-advantage-tools installed
+       Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua attach INVALID_TOKEN` with sudo
         Then stderr matches regexp:
             """

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -3,6 +3,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         subscription using a valid token
 
     @series.trusty
+    @uses.config.machine_type.lxd.container
     Scenario: Attach command in a trusty lxd container
        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -31,6 +32,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
 
     @series.focal
+    @uses.config.machine_type.lxd.container
     Scenario: Attach command in a focal lxd container
        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -4,7 +4,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
     @series.trusty
     Scenario: Attach command in a trusty lxd container
-       Given a `trusty` lxd container with ubuntu-advantage-tools installed
+       Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
@@ -32,7 +32,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
     @series.focal
     Scenario: Attach command in a focal lxd container
-       Given a `focal` lxd container with ubuntu-advantage-tools installed
+       Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -2,7 +2,7 @@
 Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
-    Scenario: Attached refresh in a trusty lxd container
+    Scenario: Attached refresh in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
@@ -17,7 +17,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached disable of an already disabled service in a trusty lxd container
+    Scenario: Attached disable of an already disabled service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
@@ -33,7 +33,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached disable of an unknown service in a trusty lxd container
+    Scenario: Attached disable of an unknown service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
@@ -49,8 +49,8 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached disable of different services in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+    Scenario: Attached disable of different services in a trusty machine
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra livepatch foobar` as non-root
         Then I will see the following on stderr:
@@ -85,7 +85,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached disable of an already enabled service in a trusty lxd container
+    Scenario: Attached disable of an already enabled service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
@@ -114,7 +114,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached detach in a trusty lxd container
+    Scenario: Attached detach in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua detach` as non-root
@@ -147,7 +147,7 @@ Feature: Command behaviour when attached to an UA subscription
           """
 
     @series.trusty
-    Scenario: Attached auto-attach in a trusty lxd container
+    Scenario: Attached auto-attach in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua auto-attach` as non-root
@@ -162,7 +162,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached show version in a trusty lxd container
+    Scenario: Attached show version in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua version` as non-root
@@ -187,7 +187,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
    @series.focal
-   Scenario: Attached refresh in a focal lxd container
+   Scenario: Attached refresh in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
@@ -202,7 +202,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached disable of an already disabled service in a focal lxd container
+    Scenario: Attached disable of an already disabled service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
@@ -219,7 +219,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached disable of an already disabled, enabled and not found services
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch esm-infra foobar` as non-root
         Then I will see the following on stderr:
@@ -245,7 +245,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached disable of an unknown service in a focal lxd container
+    Scenario: Attached disable of an unknown service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
@@ -262,7 +262,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached disable of an already enabled service in a focal lxd container
+    Scenario: Attached disable of an already enabled service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
@@ -282,7 +282,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached detach in a focal lxd container
+    Scenario: Attached detach in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua detach` as non-root
@@ -315,7 +315,7 @@ Feature: Command behaviour when attached to an UA subscription
           """
 
     @series.focal
-    Scenario: Attached auto-attach in a focal lxd container
+    Scenario: Attached auto-attach in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua auto-attach` as non-root
@@ -330,7 +330,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached show version in a focal lxd container
+    Scenario: Attached show version in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua version` as non-root

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -3,7 +3,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached refresh in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
         Then I will see the following on stderr:
@@ -18,7 +18,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached disable of an already disabled service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
         Then I will see the following on stderr:
@@ -34,7 +34,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached disable of an unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
         Then I will see the following on stderr:
@@ -86,7 +86,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached disable of an already enabled service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
         Then I will see the following on stderr:
@@ -115,7 +115,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached detach in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua detach` as non-root
         Then I will see the following on stderr:
@@ -148,7 +148,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached auto-attach in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
@@ -163,7 +163,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached show version in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua version` as non-root
         Then I will see the following on stdout:
@@ -188,7 +188,7 @@ Feature: Command behaviour when attached to an UA subscription
 
    @series.focal
    Scenario: Attached refresh in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
         Then I will see the following on stderr:
@@ -203,7 +203,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached disable of an already disabled service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
         Then I will see the following on stderr:
@@ -246,7 +246,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached disable of an unknown service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
         Then I will see the following on stderr:
@@ -263,7 +263,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached disable of an already enabled service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
         Then I will see the following on stderr:
@@ -283,7 +283,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached detach in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua detach` as non-root
         Then I will see the following on stderr:
@@ -316,7 +316,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached auto-attach in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
@@ -331,7 +331,7 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached show version in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua version` as non-root
         Then I will see the following on stdout:

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -3,7 +3,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario Outline:  Attached enable of non-container services in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
@@ -25,7 +25,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario Outline:  Attached enable of non-container beta services in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
@@ -50,7 +50,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable cc-eal` as non-root
         Then I will see the following on stderr:
@@ -66,7 +66,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario Outline: Attached enable not entitled service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service>` as non-root
         Then I will see the following on stderr:
@@ -88,7 +88,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable of an unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable foobar` as non-root
         Then I will see the following on stderr:
@@ -108,7 +108,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
     Scenario: Attached enable of a known service already enabled (UA Infra) in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable esm-infra` as non-root
         Then I will see the following on stderr:
@@ -170,7 +170,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     @uses.config.machine_type.lxd.vm
     Scenario: Attached enable of vm-based services in a focal lxd vm
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
@@ -191,7 +191,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @series.focal
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable of vm-based services in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
@@ -212,7 +212,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | FIPS Updates | --assume-yes --beta  |
 
     @series.focal
-    Scenario:  Attached enable of vm-only beta services in a focal machine
+    Scenario Outline:  Attached enable of vm-only beta services in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
@@ -238,7 +238,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached enable Common Criteria service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable cc-eal` as non-root
         Then I will see the following on stderr:
@@ -254,7 +254,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario Outline: Attached enable not entitled service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service>` as non-root
         Then I will see the following on stderr:
@@ -276,7 +276,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached enable of an unknown service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable foobar` as non-root
         Then I will see the following on stderr:
@@ -292,7 +292,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.focal
     Scenario: Attached enable of a known service already enabled (UA Infra) in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable esm-infra` as non-root
         Then I will see the following on stderr:

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -44,9 +44,9 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: beta services in containers
-           | service      | flag         |
-           | fips         | --assume-yes |
-           | fips-updates | --assume-yes |
+           | service      | flag                |
+           | fips         | --assume-yes --beta |
+           | fips-updates | --assume-yes --beta |
 
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty lxd container
@@ -165,6 +165,29 @@ Feature: Enable command behaviour when attached to an UA subscription
             Cannot enable 'foobar, fips'
             For a list of services see: sudo ua status
             """
+
+    @wip
+    @series.focal
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attached enable of non-container services in a focal lxd vm
+        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable <service> <flag>` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable <service> <flag>` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            <title> is already enabled.
+            See: sudo ua status
+            """
+
+        Examples: Un-supported services in containers
+           | service | title   | flag          |
+           | fips    | FIPS    | --assume-yes  |
 
     @series.focal
     Scenario Outline: Attached enable of non-container services in a focal lxd container
@@ -325,4 +348,4 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             Cannot enable 'foobar, fips'
             For a list of services see: sudo ua status
-            """
+	    """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -169,7 +169,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @wip
     @series.focal
     @uses.config.machine_type.lxd.vm
-    Scenario Outline: Attached enable of non-container services in a focal lxd vm
+    Scenario: Attached enable of vm-based services in a focal lxd vm
         Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
@@ -177,20 +177,20 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable <service> <flag>` with sudo
-        Then I will see the following on stdout:
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then stdout matches regexp:6
             """
-            One moment, checking your subscription first
-            <title> is already enabled.
-            See: sudo ua status
+            FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
-
-        Examples: Un-supported services in containers
-           | service | title   | flag          |
-           | fips    | FIPS    | --assume-yes  |
+        When I run `ua enable fips-updates --assume-yes --beta` with sudo
+        Then stdout matches regexp:
+            """
+            FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            """
 
     @series.focal
-    Scenario Outline: Attached enable of non-container services in a focal lxd container
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached enable of vm-based services in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
@@ -212,8 +212,8 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | FIPS Updates | --assume-yes --beta  |
 
     @series.focal
-    Scenario Outline:  Attached enable of non-container beta services in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+    Scenario:  Attached enable of vm-only beta services in a focal machine
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -2,6 +2,7 @@
 Feature: Enable command behaviour when attached to an UA subscription
 
     @series.trusty
+    @uses.config.machine_type.lxd.container
     Scenario Outline:  Attached enable of non-container services in a trusty lxd container
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -24,7 +25,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | FIPS Updates | --assume-yes --beta  |
 
     @series.trusty
-    Scenario Outline:  Attached enable of non-container beta services in a trusty lxd container
+    Scenario Outline:  Attached enable of non-container beta services in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
@@ -49,7 +50,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | --assume-yes --beta |
 
     @series.trusty
-    Scenario: Attached enable Common Criteria service in a trusty lxd container
+    Scenario: Attached enable Common Criteria service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable cc-eal` as non-root
@@ -65,7 +66,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario Outline: Attached enable not entitled service in a trusty lxd container
+    Scenario Outline: Attached enable not entitled service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service>` as non-root
@@ -87,7 +88,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | esm-apps     | ESM Apps     |
 
     @series.trusty
-    Scenario: Attached enable of an unknown service in a trusty lxd container
+    Scenario: Attached enable of an unknown service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable foobar` as non-root
@@ -107,7 +108,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached enable of a known service already enabled (UA Infra) in a trusty lxd container
+    Scenario: Attached enable of a known service already enabled (UA Infra) in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable esm-infra` as non-root
@@ -124,8 +125,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached enable a disabled, enable and unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+    Scenario: Attached enable a disabled, enable and unknown service in a trusty machine
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable livepatch esm-infra foobar` as non-root
         Then I will see the following on stderr:
@@ -147,8 +148,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.trusty
-    Scenario: Attached enable a disabled beta service and unknown service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+    Scenario: Attached enable a disabled beta service and unknown service in a trusty machine
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable fips foobar` as non-root
         Then I will see the following on stderr:
@@ -260,7 +261,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | --assume-yes |
 
     @series.focal
-    Scenario: Attached enable Common Criteria service in a focal lxd container
+    Scenario: Attached enable Common Criteria service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable cc-eal` as non-root
@@ -276,7 +277,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario Outline: Attached enable not entitled service in a focal lxd container
+    Scenario Outline: Attached enable not entitled service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service>` as non-root
@@ -298,7 +299,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | esm-apps     | ESM Apps     |
 
     @series.focal
-    Scenario: Attached enable of an unknown service in a focal lxd container
+    Scenario: Attached enable of an unknown service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable foobar` as non-root
@@ -314,7 +315,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached enable of a known service already enabled (UA Infra) in a focal lxd container
+    Scenario: Attached enable of a known service already enabled (UA Infra) in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable esm-infra` as non-root
@@ -331,8 +332,9 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.focal
+    @uses.config.machine_type.lxd.container
     Scenario: Attached enable a disabled, enabled and unknown service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable livepatch esm-infra foobar` as non-root
         Then I will see the following on stderr:
@@ -354,8 +356,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached enable a disabled beta service and unknown service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+    Scenario: Attached enable a disabled beta service and unknown service in a focal machine
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable fips foobar` as non-root
         Then I will see the following on stderr:

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -166,19 +166,13 @@ Feature: Enable command behaviour when attached to an UA subscription
             For a list of services see: sudo ua status
             """
 
-    @wip
     @series.focal
     @uses.config.machine_type.lxd.vm
     Scenario: Attached enable of vm-based services in a focal lxd vm
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable <service> <flag>` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
         When I run `ua enable fips --assume-yes --beta` with sudo
-        Then stdout matches regexp:6
+        Then stdout matches regexp:
             """
             FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
@@ -186,6 +180,20 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stdout matches regexp:
             """
             FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            """
+
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario: Attached enable of vm-based services in a bionic lxd vm
+        Given a `bionic` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing FIPS packages
+            FIPS enabled
+            A reboot is required to complete install
             """
 
     @series.focal

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -182,6 +182,21 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
 
+    @wip
+    @series.xenial
+    @uses.config.machine_type.lxd.vm
+    Scenario: Attached enable of vm-based services in a bionic lxd vm
+        Given a `xenial` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing FIPS packages
+            FIPS enabled
+            A reboot is required to complete install
+            """
+
     @series.bionic
     @uses.config.machine_type.lxd.vm
     Scenario: Attached enable of vm-based services in a bionic lxd vm

--- a/features/environment.py
+++ b/features/environment.py
@@ -11,7 +11,7 @@ from behave.runner import Context
 from features.util import (
     launch_lxd_container,
     lxc_exec,
-    lxc_get_series,
+    lxc_get_property,
     lxc_build_deb,
 )
 
@@ -119,7 +119,16 @@ def before_all(context: Context) -> None:
     context.config = UAClientBehaveConfig.from_environ()
 
     if context.config.reuse_image:
-        series = lxc_get_series(context.config.reuse_image, image=True)
+        series = lxc_get_property(
+            context.config.reuse_image, property_name="series", image=True
+        )
+        machine_type = lxc_get_property(
+            context.config.reuse_image,
+            property_name="machine_type",
+            image=True
+        )
+        if machine_type:
+            print("Found machine_type: {vm_type}".format(vm_type=machine_type))
         if series is not None:
             context.series_reuse_image = series
             context.series_image_name[series] = context.config.reuse_image
@@ -128,7 +137,14 @@ def before_all(context: Context) -> None:
             context.config.reuse_image = None
 
     if userdata.get("reuse_container"):
-        series = lxc_get_series(userdata.get("reuse_container"))
+        series = lxc_get_property(
+            userdata.get("reuse_container"), property_name="series"
+        )
+        machine_type = lxc_get_property(
+            userdata.get("reuse_container"), property_name="machine_type"
+        )
+        if machine_type:
+            print("Found type: {vm_type}".format(vm_type=machine_type))
         context.reuse_container = {series: userdata.get("reuse_container")}
         print(
             textwrap.dedent(

--- a/features/environment.py
+++ b/features/environment.py
@@ -53,7 +53,7 @@ class UAClientBehaveConfig:
         "contract_token",
         "contract_token_staging",
         "machine_type",
-        "reuse_image"
+        "reuse_image",
     ]
     redact_options = ["contract_token", "contract_token_staging"]
 
@@ -134,7 +134,7 @@ def before_all(context: Context) -> None:
         machine_type = lxc_get_property(
             context.config.reuse_image,
             property_name="machine_type",
-            image=True
+            image=True,
         )
         if machine_type:
             print("Found machine_type: {vm_type}".format(vm_type=machine_type))
@@ -177,12 +177,14 @@ def _should_skip_tags(context: Context, tags: "List") -> str:
                 if val is None:
                     return "Skipped because tag value was None: {}".format(tag)
                 if attr == "machine_type":
-                    machine_type = ".".join(parts[idx + 1:])
+                    machine_type = ".".join(parts[idx + 1 :])
                     if val == machine_type:
                         break
                     return "Skipped machine_type {} != {}".format(
                         val, machine_type
                     )
+    return ""
+
 
 def before_feature(context: Context, feature: Feature):
     reason = _should_skip_tags(context, feature.tags)
@@ -278,7 +280,8 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         lxc_build_deb(build_container_name, output_deb_file=deb_file)
 
     build_container_name = "behave-image-build%s-%s" % (
-        "-vm" if is_vm else "", series + now.strftime("%s%f")
+        "-vm" if is_vm else "",
+        series + now.strftime("%s%f"),
     )
 
     launch_lxd_container(

--- a/features/environment.py
+++ b/features/environment.py
@@ -224,14 +224,24 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         build_container_name = (
             "behave-image-pre-build-%s-" % series + now.strftime("%s%f")
         )
-        launch_lxd_container(context, ubuntu_series, build_container_name)
+        launch_lxd_container(
+            context,
+            ubuntu_series,
+            build_container_name,
+            series=series
+        )
         lxc_build_deb(build_container_name, output_deb_file=deb_file)
 
     build_container_name = "behave-image-build-%s-" % series + now.strftime(
         "%s%f"
     )
 
-    launch_lxd_container(context, ubuntu_series, build_container_name)
+    launch_lxd_container(
+        context,
+        ubuntu_series,
+        build_container_name,
+        series=series
+    )
 
     # if build_pr it will install new built .deb
     _install_uat_in_container(build_container_name, deb_file=deb_file)

--- a/features/environment.py
+++ b/features/environment.py
@@ -272,8 +272,8 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         )
         lxc_build_deb(build_container_name, output_deb_file=deb_file)
 
-    build_container_name = "behave-image-build-%s-" % series + now.strftime(
-        "%s%f"
+    build_container_name = "behave-image-build%s-%s-" % (
+        "-vm" if is_vm else "", series + now.strftime("%s%f")
     )
 
     launch_lxd_container(

--- a/features/environment.py
+++ b/features/environment.py
@@ -204,6 +204,11 @@ def before_scenario(context: Context, scenario: Scenario):
         parts = tag.split(".")
         if parts[0] == "series":
             series = parts[1]
+            if series == "trusty" and context.config.machine_type == "lxd.vm":
+                scenario.skip(
+                    reason="TODO: cannot test trusty using lxd.vm GH: #1088"
+                )
+                return
             if series not in context.series_image_name:
                 create_uat_lxd_image(context, series)
 
@@ -272,7 +277,7 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         )
         lxc_build_deb(build_container_name, output_deb_file=deb_file)
 
-    build_container_name = "behave-image-build%s-%s-" % (
+    build_container_name = "behave-image-build%s-%s" % (
         "-vm" if is_vm else "", series + now.strftime("%s%f")
     )
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -261,9 +261,14 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         )
         return
     now = datetime.datetime.now()
-    ubuntu_series = "ubuntu-daily:%s" % series
     deb_file = None
     is_vm = bool(context.config.machine_type == "lxd.vm")
+    if is_vm and series == "xenial":
+        # FIXME: use lxd custom cloud images which containt HWE kernel for
+        # vhost-vsock support
+        ubuntu_series = "images:ubuntu/16.04/cloud"
+    else:
+        ubuntu_series = "ubuntu-daily:%s" % series
     if context.config.build_pr:
         # create a dirty development image which installs build depends
         deb_file = PR_DEB_FILE

--- a/features/environment.py
+++ b/features/environment.py
@@ -234,6 +234,7 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
     now = datetime.datetime.now()
     ubuntu_series = "ubuntu-daily:%s" % series
     deb_file = None
+    is_vm = bool(context.config.machine_type == "lxd.vm")
     if context.config.build_pr:
         # create a dirty development image which installs build depends
         deb_file = PR_DEB_FILE
@@ -244,7 +245,8 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
             context,
             ubuntu_series,
             build_container_name,
-            series=series
+            series=series,
+            is_vm=is_vm,
         )
         lxc_build_deb(build_container_name, output_deb_file=deb_file)
 
@@ -256,7 +258,8 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         context,
         ubuntu_series,
         build_container_name,
-        series=series
+        series=series,
+        is_vm=is_vm,
     )
 
     # if build_pr it will install new built .deb

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -3,7 +3,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
 
     @series.xenial
     Scenario: Attached enable CC EAL service in a xenial lxd container
-        Given a `xenial` lxd container with ubuntu-advantage-tools installed
+        Given a `xenial` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
         And I run `ua enable cc-eal` as non-root
         Then I will see the following on stderr:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -12,7 +12,7 @@ from uaclient.defaults import DEFAULT_CONFIG_FILE
 CONTAINER_PREFIX = "behave-test-"
 
 
-@given("a `{series}` lxd container with ubuntu-advantage-tools installed")
+@given("a `{series}` machine with ubuntu-advantage-tools installed")
 def given_a_machine(context, series):
     if series in context.reuse_container:
         context.container_name = context.reuse_container[series]

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -19,8 +19,9 @@ def given_a_machine(context, series):
     else:
         is_vm = bool(context.config.machine_type == "lxd.vm")
         now = datetime.datetime.now()
+        vm_prefix = "vm-" if is_vm else ""
         context.container_name = (
-            CONTAINER_PREFIX + series + now.strftime("-%s%f")
+            CONTAINER_PREFIX + vm_prefix + series + now.strftime("-%s%f")
         )
         launch_lxd_container(
             context,

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -22,7 +22,10 @@ def given_a_lxd_container(context, series):
             CONTAINER_PREFIX + series + now.strftime("-%s%f")
         )
         launch_lxd_container(
-            context, context.series_image_name[series], context.container_name
+            context,
+            context.series_image_name[series],
+            context.container_name,
+            series=series,
         )
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -13,10 +13,11 @@ CONTAINER_PREFIX = "behave-test-"
 
 
 @given("a `{series}` lxd container with ubuntu-advantage-tools installed")
-def given_a_lxd_container(context, series):
+def given_a_machine(context, series):
     if series in context.reuse_container:
         context.container_name = context.reuse_container[series]
     else:
+        is_vm = bool(context.config.machine_type == "lxd.vm")
         now = datetime.datetime.now()
         context.container_name = (
             CONTAINER_PREFIX + series + now.strftime("-%s%f")
@@ -26,6 +27,7 @@ def given_a_lxd_container(context, series):
             context.series_image_name[series],
             context.container_name,
             series=series,
+            is_vm=is_vm,
         )
 
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -2,7 +2,7 @@ Feature: Command behaviour when unattached
 
     @series.trusty
     Scenario Outline: Unattached commands that requires enabled user in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua <command>` as non-root
         Then I will see the following on stderr:
             """
@@ -22,7 +22,7 @@ Feature: Command behaviour when unattached
 
     @series.trusty
     Scenario Outline: Unattached command of a known service in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
             """
@@ -37,13 +37,33 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command | service     | message     |
-           | enable  | livepatch   | livepatch   |
-           | disable | foobar foo  | foo, foobar |
+           | command |
+           | enable  |
+           | disable |
+
+    @series.trusty
+    Scenario Outline: Unattached command of an unknown service in a trusty lxd container
+        Given a `trusty` machine with ubuntu-advantage-tools installed
+        When I run `ua <command> foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua <command> foobar` with sudo
+        Then I will see the following on stderr:
+            """
+            Cannot <command> 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+        Examples: ua commands
+           | command |
+           | enable  |
+           | disable |
 
     @series.trusty
     Scenario: Unattached auto-attach does nothing in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
             """
@@ -58,7 +78,7 @@ Feature: Command behaviour when unattached
 
     @series.focal
     Scenario Outline: Unattached commands that requires enabled user in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua <command>` as non-root
         Then I will see the following on stderr:
             """
@@ -79,7 +99,7 @@ Feature: Command behaviour when unattached
 
     @series.focal
     Scenario Outline: Unattached command of a known service in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
             """
@@ -94,13 +114,33 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command | service     | message     |
-           | disable | livepatch   | livepatch   |
-           | enable  | foobar foo  | foo, foobar |
+           | command |
+           | disable |
+           | enable  |
+
+    @series.focal
+    Scenario Outline: Unattached command of an unknown service in a focal lxd container
+        Given a `focal` machine with ubuntu-advantage-tools installed
+        When I run `ua <command> foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua <command> foobar` with sudo
+        Then stderr matches regexp:
+            """
+            Cannot <command> 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+        Examples: ua commands
+           | command |
+           | disable |
+           | enable  |
 
     @series.focal
     Scenario: Unattached auto-attach does nothing in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
             """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,7 +1,7 @@
 Feature: Command behaviour when unattached
 
     @series.trusty
-    Scenario Outline: Unattached commands that requires enabled user in a trusty lxd container
+    Scenario Outline: Unattached commands that requires enabled user in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua <command>` as non-root
         Then I will see the following on stderr:
@@ -21,7 +21,7 @@ Feature: Command behaviour when unattached
            | refresh |
 
     @series.trusty
-    Scenario Outline: Unattached command of a known service in a trusty lxd container
+    Scenario Outline: Unattached command of a known service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
@@ -42,7 +42,7 @@ Feature: Command behaviour when unattached
            | disable |
 
     @series.trusty
-    Scenario Outline: Unattached command of an unknown service in a trusty lxd container
+    Scenario Outline: Unattached command of an unknown service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua <command> foobar` as non-root
         Then I will see the following on stderr:
@@ -62,7 +62,7 @@ Feature: Command behaviour when unattached
            | disable |
 
     @series.trusty
-    Scenario: Unattached auto-attach does nothing in a trusty lxd container
+    Scenario: Unattached auto-attach does nothing in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua auto-attach` as non-root
         Then I will see the following on stderr:
@@ -77,7 +77,7 @@ Feature: Command behaviour when unattached
             """
 
     @series.focal
-    Scenario Outline: Unattached commands that requires enabled user in a focal lxd container
+    Scenario Outline: Unattached commands that requires enabled user in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua <command>` as non-root
         Then I will see the following on stderr:
@@ -98,7 +98,7 @@ Feature: Command behaviour when unattached
 
 
     @series.focal
-    Scenario Outline: Unattached command of a known service in a focal lxd container
+    Scenario Outline: Unattached command of a known service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
@@ -119,7 +119,7 @@ Feature: Command behaviour when unattached
            | enable  |
 
     @series.focal
-    Scenario Outline: Unattached command of an unknown service in a focal lxd container
+    Scenario Outline: Unattached command of an unknown service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua <command> foobar` as non-root
         Then I will see the following on stderr:
@@ -139,7 +139,7 @@ Feature: Command behaviour when unattached
            | enable  |
 
     @series.focal
-    Scenario: Unattached auto-attach does nothing in a focal lxd container
+    Scenario: Unattached auto-attach does nothing in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua auto-attach` as non-root
         Then I will see the following on stderr:

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -37,10 +37,10 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command |
            | enable  |
            | disable |
 
+    @wip
     @series.trusty
     Scenario Outline: Unattached command of an unknown service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
@@ -52,14 +52,14 @@ Feature: Command behaviour when unattached
         When I run `ua <command> foobar` with sudo
         Then I will see the following on stderr:
             """
-            Cannot <command> 'foobar'
+            Cannot <command> '<service>'
             For a list of services see: sudo ua status
             """
 
         Examples: ua commands
-           | command |
-           | enable  |
-           | disable |
+           | command | service     |
+           | enable  | livepatch   |
+           | disable | foobar foo  |
 
     @series.trusty
     Scenario: Unattached auto-attach does nothing in a trusty machine

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -21,45 +21,27 @@ Feature: Command behaviour when unattached
            | refresh |
 
     @series.trusty
-    Scenario Outline: Unattached command of a known service in a trusty machine
+    Scenario Outline: Unattached command known and unknown services in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua <command> livepatch` with sudo
+        When I run `ua <command> <service>` with sudo
         Then I will see the following on stderr:
             """
-            To use 'livepatch' you need an Ubuntu Advantage subscription
+            To use '<service>' you need an Ubuntu Advantage subscription
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
             """
 
         Examples: ua commands
-           | enable  |
-           | disable |
-
-    @wip
-    @series.trusty
-    Scenario Outline: Unattached command of an unknown service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I run `ua <command> foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua <command> foobar` with sudo
-        Then I will see the following on stderr:
-            """
-            Cannot <command> '<service>'
-            For a list of services see: sudo ua status
-            """
-
-        Examples: ua commands
-           | command | service     |
-           | enable  | livepatch   |
-           | disable | foobar foo  |
+           | command  | service   | 
+           | enable   | livepatch |
+           | disable  | livepatch |
+           | enable   | unknown   |
+           | disable  | unknown   |
 
     @series.trusty
     Scenario: Unattached auto-attach does nothing in a trusty machine
@@ -105,38 +87,20 @@ Feature: Command behaviour when unattached
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua <command> livepatch` with sudo
+        When I run `ua <command> <service>` with sudo
         Then stderr matches regexp:
             """
-            To use 'livepatch' you need an Ubuntu Advantage subscription
+            To use '<service>' you need an Ubuntu Advantage subscription
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
             """
 
         Examples: ua commands
-           | command |
-           | disable |
-           | enable  |
-
-    @series.focal
-    Scenario Outline: Unattached command of an unknown service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I run `ua <command> foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua <command> foobar` with sudo
-        Then stderr matches regexp:
-            """
-            Cannot <command> 'foobar'
-            For a list of services see: sudo ua status
-            """
-
-        Examples: ua commands
-           | command |
-           | disable |
-           | enable  |
+           | command | service   |
+           | disable | livepatch |
+           | enable  | livepatch |
+           | disable | unknown   |
+           | enable  | unknown   |
 
     @series.focal
     Scenario: Unattached auto-attach does nothing in a focal machine

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,7 +1,7 @@
 Feature: Unattached status
 
     @series.trusty
-    Scenario: Unattached status in a trusty lxd container
+    Scenario: Unattached status in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua status` as non-root
         Then I will see the following on stdout:
@@ -74,7 +74,7 @@ Feature: Unattached status
             """ 
     
     @series.focal
-    Scenario: Unattached status in a focal lxd container
+    Scenario: Unattached status in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua status` as non-root
         Then I will see the following on stdout:

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -2,7 +2,7 @@ Feature: Unattached status
 
     @series.trusty
     Scenario: Unattached status in a trusty lxd container
-        Given a `trusty` lxd container with ubuntu-advantage-tools installed
+        Given a `trusty` machine with ubuntu-advantage-tools installed
         When I run `ua status` as non-root
         Then I will see the following on stdout:
             """
@@ -75,7 +75,7 @@ Feature: Unattached status
     
     @series.focal
     Scenario: Unattached status in a focal lxd container
-        Given a `focal` lxd container with ubuntu-advantage-tools installed
+        Given a `focal` machine with ubuntu-advantage-tools installed
         When I run `ua status` as non-root
         Then I will see the following on stdout:
             """

--- a/features/util.py
+++ b/features/util.py
@@ -41,7 +41,6 @@ LXC_SETUP_VENDORDATA = textwrap.dedent(
 )
 
 
-
 def launch_lxd_container(
     context: Context,
     image_name: str,
@@ -186,6 +185,7 @@ def lxc_create_vm_profile(series: str):
             ["lxc", "profile", "edit", profile_name], stdin=subprocess.PIPE
         )
         proc.communicate(content.encode())
+
 
 def wait_for_boot(
     container_name: str, series: str, is_vm: bool = False

--- a/features/util.py
+++ b/features/util.py
@@ -17,7 +17,11 @@ VM_PROFILE_NAME = "behave-vm"
 
 
 def launch_lxd_container(
-    context: Context, image_name: str, container_name: str, series: str
+    context: Context,
+    image_name: str,
+    container_name: str,
+    series: str,
+    is_vm: bool
 ) -> None:
     """Launch a container from an image and wait for it to boot
 
@@ -26,13 +30,19 @@ def launch_lxd_container(
 
     :param context:
         A `behave.runner.Context`; used only for registering cleanups.
-
+    :param image_name:
+        The name of the lxd image to launch as base image for the container
     :param container_name:
         The name to be used for the launched container.
-
     :param series: A string representing the series of the vm to create
+    :param is_vm:
+        Boolean as to whether or not to launch KVM type container
     """
-    subprocess.run(["lxc", "launch", image_name, container_name])
+    command = ["lxc", "launch", image_name, container_name]
+    if is_vm:
+        lxc_create_vm_profile()
+        command.extend(["--profile", VM_PROFILE_NAME, "--vm"])
+    subprocess.run(command)
 
     def cleanup_container() -> None:
         if not context.config.destroy_instances:

--- a/features/util.py
+++ b/features/util.py
@@ -21,7 +21,7 @@ def launch_lxd_container(
     image_name: str,
     container_name: str,
     series: str,
-    is_vm: bool
+    is_vm: bool,
 ) -> None:
     """Launch a container from an image and wait for it to boot
 


### PR DESCRIPTION
Allow the ability to drive behave tests on either lxd containers or kvm-based machines.

This toggle is set via environement variabe UACLIENT_BEHAVE_MACHINE_TYPE which can
be either `lxd.container` or `lxd.vm`. In the future I'd expect we may grow `machine_type` to include Ubuntu PRO instances like `aws.pro` or `azure.pro` etc.

The following work was necessary to support this:
 - Add feature.util.lxc_create_vm_profile which creates a profile which attaches a cloud-init:config
   drive to a kvm instance that is booting
 - features.util.wait_for_boot() retry changes
      - vms take a while to boot, so change our retry logic on Xenial and later to block on
         `cloud-init status --wait` until cloud-init is done
      - Adjust retry backoff seconds because lxd VM instances take about 15 seconds to be able to connect to the lxd agent. Otherwise we see "Error: Failed to connect to lxd-agent"
 - Adding machine_type to UAClientBehaveConfig in features/environment.py
 - Allowing for @uses.config.machine_type.(lxd.container|lxd.vm) to declare a specific scenario
    requires a certain machine_type to run
 - consolidate _should_skip_tags function for use at both before_feature and before_scenario
   in order to skip invalid @uses conditions
 - skip any @series.trusty scenarios if machine_type is lxd.vm
 - change steps.steps.given_a_lxd_container -> given_a_machine


To test:
```
Grab your contract token from auth.contracts.canonical.com

cat >test.patch <<EOF

diff --git a/features/attached_enable.feature b/features/attached_enable.feature
index 35d52b8..3fb80a8 100644                                                   
--- a/features/attached_enable.feature                                          
+++ b/features/attached_enable.feature                                          
@@ -135,7 +135,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).  
             """                                                                
                                                                                
-    @wip                                                                       
     @series.bionic                                                             
     @uses.config.machine_type.lxd.vm                                           
     Scenario: Attached enable of vm-based services in a bionic lxd vm   
EOF


# to run a bionic vm test
make clean
cd ..
tar -zcvf /tmp/pr_source.tar.gz ubuntu-advantage-client

UACLIENT_BEHAVE_CONTRACT_TOKEN=<YOUR_TOKEN> UACLIENT_BEHAVE_MACHINE_TYPE=lxd.vm tox -e behave -- -w -k

# Check your lxc profile
lxc profile show behave-vm-bionic

```

Fixes: #1089