### PR TITLE
fips-only: force apt noninteractive prompts during package installs

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -84,14 +84,25 @@ def assert_valid_apt_credentials(repo_url, username, password):
         )
 
 
-def run_apt_command(cmd, error_msg) -> str:
+def run_apt_command(
+    cmd: 'List[str]',
+    error_msg: str,
+    env: "Optional[Dict[str, str]]" = None,
+) -> str:
     """Run an apt command, retrying upon failure APT_RETRIES times.
+
+    :param cmd: List containing the apt command to run, passed to subp.
+    :param error_msg: The string to raise as UserFacingError when all retries
+       are exhausted in failure.
+    :param env: Optional dictionary of environment variables to pass to subp.
 
     :return: stdout from successful run of the apt command.
     :raise UserFacingError: on issues running apt-cache policy.
     """
     try:
-        out, _err = util.subp(cmd, capture=True, retry_sleeps=APT_RETRIES)
+        out, _err = util.subp(
+            cmd, capture=True, retry_sleeps=APT_RETRIES, env=env
+        )
     except util.ProcessExecutionError as e:
         if "Could not get lock /var/lib/dpkg/lock" in str(e.stderr):
             error_msg += " Another process is running APT."

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -11,7 +11,7 @@ from uaclient import status
 from uaclient import util
 
 try:
-    from typing import List  # noqa
+    from typing import Dict, List, Optional  # noqa
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -85,9 +85,7 @@ def assert_valid_apt_credentials(repo_url, username, password):
 
 
 def run_apt_command(
-    cmd: 'List[str]',
-    error_msg: str,
-    env: "Optional[Dict[str, str]]" = None,
+    cmd: "List[str]", error_msg: str, env: "Optional[Dict[str, str]]" = {}
 ) -> str:
     """Run an apt command, retrying upon failure APT_RETRIES times.
 

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -17,6 +17,11 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
     is_beta = True
 
+    # RELEASE_BLOCKER GH: #104, don't prompt for conf differences in FIPS
+    # Review this fix to see if we want more general functionality for all
+    # services. And security/CPC signoff on expected conf behavior.
+    apt_noninteractive = True
+
     @property
     def packages(self) -> "List[str]":
         packages = []  # type: List[str]

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -110,10 +110,11 @@ class RepoEntitlement(base.UAEntitlement):
                         '-o Dpkg::Options::="--force-confold"',
                     ]
                 else:
-                    env = None
+                    env = {}
                     apt_options = []
                 apt.run_apt_command(
-                    ["apt-get", "install", "--assume-yes"] + apt_options
+                    ["apt-get", "install", "--assume-yes"]
+                    + apt_options
                     + self.packages,
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
                         title=self.title

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -166,6 +166,7 @@ class TestCommonCriteriaEntitlementEnable:
                 ["apt-cache", "policy"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             )
         ]
 
@@ -184,6 +185,7 @@ class TestCommonCriteriaEntitlementEnable:
                     ["apt-get", "install", "--assume-yes"] + prerequisite_pkgs,
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
+                    env=None,
                 )
             )
         else:
@@ -195,12 +197,14 @@ class TestCommonCriteriaEntitlementEnable:
                     ["apt-get", "update"],
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
+                    env=None,
                 ),
                 mock.call(
                     ["apt-get", "install", "--assume-yes"]
                     + entitlement.packages,
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
+                    env=None,
                 ),
             ]
         )

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -166,7 +166,7 @@ class TestCommonCriteriaEntitlementEnable:
                 ["apt-cache", "policy"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             )
         ]
 
@@ -185,7 +185,7 @@ class TestCommonCriteriaEntitlementEnable:
                     ["apt-get", "install", "--assume-yes"] + prerequisite_pkgs,
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env=None,
+                    env={},
                 )
             )
         else:
@@ -197,14 +197,14 @@ class TestCommonCriteriaEntitlementEnable:
                     ["apt-get", "update"],
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env=None,
+                    env={},
                 ),
                 mock.call(
                     ["apt-get", "install", "--assume-yes"]
                     + entitlement.packages,
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env=None,
+                    env={},
                 ),
             ]
         )

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -74,16 +74,19 @@ class TestCISEntitlementEnable:
                 ["apt-cache", "policy"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             ),
             mock.call(
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             ),
             mock.call(
                 ["apt-get", "install", "--assume-yes"] + entitlement.packages,
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             ),
         ]
 

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -74,19 +74,19 @@ class TestCISEntitlementEnable:
                 ["apt-cache", "policy"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             ),
             mock.call(
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             ),
             mock.call(
                 ["apt-get", "install", "--assume-yes"] + entitlement.packages,
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             ),
         ]
 

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -140,7 +140,7 @@ class TestESMInfraEntitlementEnable:
             ["apt-get", "install", "--assume-yes"] + patched_packages,
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
-            env=None,
+            env={},
         )
 
         subp_calls = [
@@ -148,7 +148,7 @@ class TestESMInfraEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             ),
             install_cmd,
         ]
@@ -185,7 +185,7 @@ class TestESMInfraEntitlementEnable:
                 return True
             return original_exists(path)
 
-        def fake_subp(cmd, capture=None, retry_sleeps=None, env=None):
+        def fake_subp(cmd, capture=None, retry_sleeps=None, env={}):
             if cmd == ["apt-get", "update"]:
                 raise util.ProcessExecutionError(
                     "Failure", stderr="Could not get lock /var/lib/dpkg/lock"
@@ -241,7 +241,7 @@ class TestESMInfraEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             )
         ]
 

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -140,6 +140,7 @@ class TestESMInfraEntitlementEnable:
             ["apt-get", "install", "--assume-yes"] + patched_packages,
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
+            env=None,
         )
 
         subp_calls = [
@@ -147,6 +148,7 @@ class TestESMInfraEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             ),
             install_cmd,
         ]
@@ -183,7 +185,7 @@ class TestESMInfraEntitlementEnable:
                 return True
             return original_exists(path)
 
-        def fake_subp(cmd, capture=None, retry_sleeps=None):
+        def fake_subp(cmd, capture=None, retry_sleeps=None, env=None):
             if cmd == ["apt-get", "update"]:
                 raise util.ProcessExecutionError(
                     "Failure", stderr="Could not get lock /var/lib/dpkg/lock"
@@ -239,6 +241,7 @@ class TestESMInfraEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             )
         ]
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -209,9 +209,17 @@ class TestFIPSEntitlementEnable:
             )
         ]
         install_cmd = mock.call(
-            ["apt-get", "install", "--assume-yes"] + patched_packages,
+            [
+                "apt-get",
+                "install",
+                "--assume-yes",
+                '-o Dpkg::Options::="--force-confdef"',
+                '-o Dpkg::Options::="--force-confold"',
+            ]
+            + patched_packages,
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
+            env={"DEBIAN_FRONTEND": "noninteractive"},
         )
 
         subp_calls = [
@@ -219,6 +227,7 @@ class TestFIPSEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             ),
             install_cmd,
         ]

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -227,7 +227,7 @@ class TestFIPSEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             ),
             install_cmd,
         ]

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -452,7 +452,7 @@ class TestRepoEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env=None,
+                env={},
             )
         ]
         expected_output = dedent(
@@ -473,7 +473,7 @@ class TestRepoEnable:
                         ],
                         capture=True,
                         retry_sleeps=apt.APT_RETRIES,
-                        env=None,
+                        env={},
                     )
                 )
                 expected_output = (

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -452,6 +452,7 @@ class TestRepoEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
+                env=None,
             )
         ]
         expected_output = dedent(
@@ -472,6 +473,7 @@ class TestRepoEnable:
                         ],
                         capture=True,
                         retry_sleeps=apt.APT_RETRIES,
+                        env=None,
                     )
                 )
                 expected_output = (

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -445,6 +445,7 @@ def _subp(
     rcs: "Optional[List[int]]" = None,
     capture: bool = False,
     timeout: "Optional[float]" = None,
+    env: "Optional[Dict[str, str]]" = None,
 ) -> "Tuple[str, str]":
     """Run a command and return a tuple of decoded stdout, stderr.
 
@@ -454,6 +455,7 @@ def _subp(
     @param capture: Boolean set True to log the command and response.
     @param timeout: Optional float indicating number of seconds to wait for
         subp to return.
+    @param env: Optional dictionary of environment variable to pass to Popen.
 
     @return: Tuple of utf-8 decoded stdout, stderr
     @raises ProcessExecutionError on invalid command or returncode not in rcs.
@@ -467,7 +469,7 @@ def _subp(
         rcs = [0]
     try:
         proc = subprocess.Popen(
-            bytes_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            bytes_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
         )
         (out, err) = proc.communicate(timeout=timeout)
     except OSError:
@@ -503,6 +505,7 @@ def subp(
     capture: bool = False,
     timeout: "Optional[float]" = None,
     retry_sleeps: "Optional[List[float]]" = None,
+    env: "Optional[Dict[str, str]]" = None,
 ) -> "Tuple[str, str]":
     """Run a command and return a tuple of decoded stdout, stderr.
 
@@ -516,6 +519,8 @@ def subp(
         retries. Specifying a list of [0.5, 1] instructs subp to retry twice
         on failure; sleeping half a second before the first retry and 1 second
         before the next retry.
+     @param env: Optional dictionary of environment variables to provide to
+        subp.
 
     @return: Tuple of utf-8 decoded stdout, stderr
     @raises ProcessExecutionError on invalid command or returncode not in rcs.
@@ -525,7 +530,7 @@ def subp(
     retry_sleeps = retry_sleeps.copy() if retry_sleeps is not None else None
     while True:
         try:
-            out, err = _subp(args, rcs, capture, timeout)
+            out, err = _subp(args, rcs, capture, timeout, env=env)
             break
         except ProcessExecutionError as e:
             if capture:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -465,6 +465,8 @@ def _subp(
     bytes_args = [
         x if isinstance(x, bytes) else x.encode("utf-8") for x in args
     ]
+    if env:
+        env.update(os.environ)
     if rcs is None:
         rcs = [0]
     try:


### PR DESCRIPTION
Since we currently expect FIPS* package installs to run into local config customization prompts on cloud-images, emit the appropriate apt commandline options to avoid prompting to the console, and preserve the locally modified config files for openssh-server and /boot/grub/menu.lst.

Since we hope to address this config file difference properly in the openssh-server package and fips-metapackage, add a RELEASE_BLOCKER comment to fips.py to ensure we address this with the security and cloud images team before fully supporting FIPS.

Inspired by  jaredledvina's PR #1086
Fixes: #1084 