### PR TITLE
Update postinst to check if esm is already enabled

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -26,12 +26,26 @@ SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enab
 SYSTEMD_HELPER_ENABLED_WANTS_LINK="/var/lib/systemd/deb-systemd-helper-enabled/multi-user.target.wants/ua-auto-attach.service"
 
 
-unconfigure_esm() {
-    rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
-    rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY
-    rm -f $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
-    rm -f $ESM_APT_PREF_FILE_TRUSTY $ESM_INFRA_APT_PREF_FILE_TRUSTY
+check_esm_infra_is_installed() {
+    expected_output="enabled"
+    actual_output=$(ua status | grep esm-infra | awk '{print $3}')
+
+    if [ "$expected_output" = "$actual_output" ]; then
+        return 0
+    else
+        return 1
+    fi
 }
+
+unconfigure_esm() {
+    if ! check_esm_infra_is_installed; then
+        rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
+        rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY
+        rm -f $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
+        rm -f $ESM_APT_PREF_FILE_TRUSTY $ESM_INFRA_APT_PREF_FILE_TRUSTY
+    fi
+}
+
 
 configure_esm() {
     rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys

--- a/debian/postinst
+++ b/debian/postinst
@@ -26,19 +26,12 @@ SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enab
 SYSTEMD_HELPER_ENABLED_WANTS_LINK="/var/lib/systemd/deb-systemd-helper-enabled/multi-user.target.wants/ua-auto-attach.service"
 
 
-check_esm_infra_is_installed() {
-    expected_output="enabled"
-    actual_output=$(ua status | grep esm-infra | awk '{print $3}')
-
-    if [ "$expected_output" = "$actual_output" ]; then
-        return 0
-    else
-        return 1
-    fi
+check_esm_infra_is_enabled() {
+    ua status | egrep -q 'esm-infra.*enabled' && return 0 || return 1
 }
 
 unconfigure_esm() {
-    if ! check_esm_infra_is_installed; then
+    if ! check_esm_infra_is_enabled; then
         rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
         rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY
         rm -f $ESM_INFRA_APT_SOURCE_FILE_TRUSTY


### PR DESCRIPTION
As stated on #1095, when we upgrade ua-client with esm-infra enabled, we end up removing the `ubuntu-advantage-esm-infra-trusty.gpg` file, which puts the system in an incorrect state, since ua-client will state that `esm-infra` will be enabled, but we cannot update its packages.

To fix that, we have updated the `postinst` script to check if `esm-infra` is already enable and only if it is not we let the unconfigure step run.

To test that feature, the following script was used:

```
#!/bin/sh

UA_ACCESS_KEY="UNSET"

check_esm_key() {
    name=$1
    lxc exec $name -- sudo apt update
    lxc exec $name -- ls /etc/apt/trusted.gpg.d/
}

replicate_issue() {
    cat > config_error.yaml <<EOF
#cloud-config
# Setup an ubuntu-advantage-tools development environment with cloud-init
packages:
 - git
 - make
runcmd:
 - sudo ua attach $UA_ACCESS_KEY
 - sudo ua enable esm-infra
 - git clone https://github.com/lucasmoura/ubuntu-advantage-client.git /var/tmp/uac
 - cd /var/tmp/uac/
 - git fetch
 - make deps
 - dpkg-buildpackage -us -uc
 - apt-get remove ubuntu-advantage-tools --assume-yes
 - dpkg -i /var/tmp/ubuntu-advantage-tools_25.0_amd64.deb
EOF

 name=dev-f-bug
 lxc delete $name --force > /dev/null
 lxc launch ubuntu-daily:focal $name -c user.user-data="$(cat config_error.yaml)"
 lxc exec $name -- cloud-init status --wait
 lxc exec $name -- cloud-init query userdata
 check_esm_key $name
 rm config_error.yaml
}

verify_issue() {
    cat > config_fix.yaml <<EOF
#cloud-config
# Setup an ubuntu-advantage-tools development environment with cloud-init
packages:
 - git
 - make
runcmd:
 - sudo ua attach $UA_ACCESS_KEY
 - sudo ua enable esm-infra
 - git clone https://github.com/lucasmoura/ubuntu-advantage-client.git /var/tmp/uac
 - cd /var/tmp/uac/
 - git fetch
 - git checkout fix-postinst-for-esm 
 - make deps
 - dpkg-buildpackage -us -uc
 - apt-get remove ubuntu-advantage-tools --assume-yes
 - dpkg -i /var/tmp/ubuntu-advantage-tools_25.0_amd64.deb
EOF

 name=dev-f-fix
 lxc delete $name --force > /dev/null
 lxc launch ubuntu-daily:focal $name -c user.user-data="$(cat config_fix.yaml)"
 lxc exec $name -- cloud-init status --wait
 lxc exec $name -- cloud-init query userdata
 check_esm_key $name
 rm config_fix.yaml
}

replicate_issue
verify_issue
```