### PR TITLE
tests: create /tmp/pr_source.tgz when not in travis and build_pr=1

### DIFF
--- a/features/util.py
+++ b/features/util.py
@@ -178,6 +178,13 @@ def lxc_build_deb(container_name: str, output_deb_file: str) -> None:
     """
 
     print("\n\n\n LXC file push {}".format(SOURCE_PR_TGZ))
+    if not os.environ.get("TRAVIS"):
+        print("\n\n\n Assuming non-travis build. Creating: {}".format(SOURCE_PR_TGZ))
+        os.chdir("..")
+        subprocess.run(
+            ["tar", "-zcvf", SOURCE_PR_TGZ, "ubuntu-advantage-client"]
+        )
+        os.chdir("ubuntu-advantage-client")
     subprocess.run(
         ["lxc", "file", "push", SOURCE_PR_TGZ, container_name + "/tmp/"]
     )

--- a/features/util.py
+++ b/features/util.py
@@ -179,7 +179,11 @@ def lxc_build_deb(container_name: str, output_deb_file: str) -> None:
 
     print("\n\n\n LXC file push {}".format(SOURCE_PR_TGZ))
     if not os.environ.get("TRAVIS"):
-        print("\n\n\n Assuming non-travis build. Creating: {}".format(SOURCE_PR_TGZ))
+        print(
+            "\n\n\n Assuming non-travis build. Creating: {}".format(
+                SOURCE_PR_TGZ
+            )
+        )
         os.chdir("..")
         subprocess.run(
             ["tar", "-zcvf", SOURCE_PR_TGZ, "ubuntu-advantage-client"]


### PR DESCRIPTION
    When specifying UACLIENT_BEHAVE_BUILD_PR=1 in developer environment
    the behave tests expect to find a compressed copy of the current
    source tree at /tmp/pr_source.tgz because .travis.yml does this.
    
    If running locally, and no TRAVIS environment variable is present,
    tar the current working dir to /tmp/pr_source.tgz so the integration
    tests will build a deb in and use it.
