### PR TITLE
Override ua config for beta services

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -52,6 +52,15 @@ def when_i_attach_staging_token(context, token_type, user_spec):
     when_i_run_command(context, "ua attach %s" % token, user_spec)
 
 
+@when("I append the following on uaclient config")
+def when_i_append_to_uaclient_config(context):
+    # command = "echo -e '{}' | sudo tee -a {}".format(
+    #    context.text, DEFAULT_CONFIG_FILE)
+    cmd = "sed -i '$s/$/text/' {}".format(DEFAULT_CONFIG_FILE)
+    print(cmd)
+    when_i_run_command(context, cmd, "with sudo")
+
+
 @then("I will see the following on stdout")
 def then_i_will_see_on_stdout(context):
     assert_that(context.process.stdout.strip(), equal_to(context.text))

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -54,10 +54,12 @@ def when_i_attach_staging_token(context, token_type, user_spec):
 
 @when("I append the following on uaclient config")
 def when_i_append_to_uaclient_config(context):
-    # command = "echo -e '{}' | sudo tee -a {}".format(
-    #    context.text, DEFAULT_CONFIG_FILE)
-    cmd = "sed -i '$s/$/text/' {}".format(DEFAULT_CONFIG_FILE)
-    print(cmd)
+    cmd = "printf '{}\n' > /tmp/uaclient.conf".format(context.text)
+    cmd = 'sh -c "{}"'.format(cmd)
+    when_i_run_command(context, cmd, "as non-root")
+
+    cmd = "cat /tmp/uaclient.conf >> {}".format(DEFAULT_CONFIG_FILE)
+    cmd = 'sh -c "{}"'.format(cmd)
     when_i_run_command(context, cmd, "with sudo")
 
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -77,7 +77,6 @@ Feature: Command behaviour when unattached
            | refresh |
 
 
-    @wip
     @series.focal
     Scenario Outline: Unattached command of a known service in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -53,6 +53,25 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """ 
+        When I append the following on uaclient config:
+            """
+            features:
+              fips:
+                is_beta: false
+            """
+        And I run `ua status` as non-root
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-apps      no         UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
+            fips          no         NIST-certified FIPS modules
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """ 
     
     @series.focal
     Scenario: Unattached status in a focal lxd container

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,6 +1,5 @@
 Feature: Unattached status
 
-    @wip
     @series.trusty
     Scenario: Unattached status in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,5 +1,6 @@
 Feature: Unattached status
 
+    @wip
     @series.trusty
     Scenario: Unattached status in a trusty lxd container
         Given a `trusty` lxd container with ubuntu-advantage-tools installed
@@ -56,16 +57,17 @@ Feature: Unattached status
         When I append the following on uaclient config:
             """
             features:
-              fips:
-                is_beta: false
+              allow_beta: true
             """
         And I run `ua status` as non-root
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      no         UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
+            fips-updates  no         Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
@@ -128,16 +130,17 @@ Feature: Unattached status
         When I append the following on uaclient config:
             """
             features:
-              fips:
-                is_beta: false
+              allow_beta: true
             """
         And I run `ua status` as non-root
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      yes        UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
+            fips-updates  no         Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -63,7 +63,6 @@ Feature: Unattached status
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
             esm-apps      no         UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
@@ -121,6 +120,24 @@ Feature: Unattached status
             esm-infra     yes        UA Infra: Extended Security Maintenance
             fips          no         NIST-certified FIPS modules
             fips-updates  no         Uncertified security updates to FIPS modules
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+        When I append the following on uaclient config:
+            """
+            features:
+              fips:
+                is_beta: false
+            """
+        And I run `ua status` as non-root
+        Then I will see the following on stdout:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            esm-apps      yes        UA Apps: Extended Security Maintenance
+            esm-infra     yes        UA Infra: Extended Security Maintenance
+            fips          no         NIST-certified FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -327,7 +327,9 @@ def _perform_enable(
     @return: True on success, False otherwise
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
-    config_allow_beta = util.get_allow_beta_value_from_config(cfg.cfg)
+    config_allow_beta = util.is_config_value_true(
+        config=cfg.cfg, path_to_value="features.allow_beta"
+    )
     allow_beta |= config_allow_beta
     if not allow_beta and ent_cls.is_beta:
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -327,7 +327,8 @@ def _perform_enable(
     @return: True on success, False otherwise
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
-    allow_beta |= cfg.cfg.get("features", {}).get("allow_beta", False)
+    config_allow_beta = util.get_allow_beta_value_from_config(cfg.cfg)
+    allow_beta |= config_allow_beta
     if not allow_beta and ent_cls.is_beta:
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
         raise exceptions.UserFacingError(

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -327,18 +327,12 @@ def _perform_enable(
     @return: True on success, False otherwise
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
+    allow_beta |= cfg.cfg.get("features", {}).get("beta", False)
     if not allow_beta and ent_cls.is_beta:
-        cfg_beta_override = (
-            cfg.cfg.get("features", {})
-            .get(ent_cls.name, {})
-            .get("is_beta", True)
+        tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
+        raise exceptions.UserFacingError(
+            tmpl.format(operation="enable", name=entitlement_name)
         )
-
-        if cfg_beta_override:
-            tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
-            raise exceptions.UserFacingError(
-                tmpl.format(operation="enable", name=entitlement_name)
-            )
 
     entitlement = ent_cls(cfg, assume_yes=assume_yes)
     ret = entitlement.enable(silent_if_inapplicable=silent_if_inapplicable)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -328,10 +328,17 @@ def _perform_enable(
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
     if not allow_beta and ent_cls.is_beta:
-        tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
-        raise exceptions.UserFacingError(
-            tmpl.format(operation="enable", name=entitlement_name)
+        cfg_beta_override = (
+            cfg.cfg.get("features", {})
+            .get(ent_cls.name, {})
+            .get("is_beta", True)
         )
+
+        if cfg_beta_override:
+            tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
+            raise exceptions.UserFacingError(
+                tmpl.format(operation="enable", name=entitlement_name)
+            )
 
     entitlement = ent_cls(cfg, assume_yes=assume_yes)
     ret = entitlement.enable(silent_if_inapplicable=silent_if_inapplicable)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -327,7 +327,7 @@ def _perform_enable(
     @return: True on success, False otherwise
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
-    allow_beta |= cfg.cfg.get("features", {}).get("beta", False)
+    allow_beta |= cfg.cfg.get("features", {}).get("allow_beta", False)
     if not allow_beta and ent_cls.is_beta:
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
         raise exceptions.UserFacingError(

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -348,7 +348,7 @@ class UAConfig:
         if os.getuid() == 0:
             self.write_cache("status-cache", response)
 
-        show_beta |= self.cfg.get("features", {}).get("beta", False)
+        show_beta |= self.cfg.get("features", {}).get("allow_beta", False)
         if not show_beta:
             response = self._remove_beta_resources(response)
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -210,12 +210,6 @@ class UAConfig:
             resource_name = resource["name"]
             ent_cls = ENTITLEMENT_CLASS_BY_NAME.get(resource_name)
 
-            feat_cfg_beta_override = (
-                self.cfg.get("features", {})
-                .get(resource_name, {})
-                .get("is_beta", True)
-            )
-
             if ent_cls is None:
                 """
                 Here we cannot know the status of a service,
@@ -226,7 +220,7 @@ class UAConfig:
                 released_resources.append(resource)
                 continue
 
-            if not ent_cls.is_beta or not feat_cfg_beta_override:
+            if not ent_cls.is_beta:
                 released_resources.append(resource)
 
         if released_resources:
@@ -354,6 +348,7 @@ class UAConfig:
         if os.getuid() == 0:
             self.write_cache("status-cache", response)
 
+        show_beta |= self.cfg.get("features", {}).get("beta", False)
         if not show_beta:
             response = self._remove_beta_resources(response)
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -210,6 +210,12 @@ class UAConfig:
             resource_name = resource["name"]
             ent_cls = ENTITLEMENT_CLASS_BY_NAME.get(resource_name)
 
+            feat_cfg_beta_override = (
+                self.cfg.get("features", {})
+                .get(resource_name, {})
+                .get("is_beta", True)
+            )
+
             if ent_cls is None:
                 """
                 Here we cannot know the status of a service,
@@ -220,7 +226,7 @@ class UAConfig:
                 released_resources.append(resource)
                 continue
 
-            if not ent_cls.is_beta:
+            if not ent_cls.is_beta or not feat_cfg_beta_override:
                 released_resources.append(resource)
 
         if released_resources:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -348,7 +348,7 @@ class UAConfig:
         if os.getuid() == 0:
             self.write_cache("status-cache", response)
 
-        show_beta |= self.cfg.get("features", {}).get("allow_beta", False)
+        show_beta |= util.get_allow_beta_value_from_config(self.cfg)
         if not show_beta:
             response = self._remove_beta_resources(response)
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -348,7 +348,10 @@ class UAConfig:
         if os.getuid() == 0:
             self.write_cache("status-cache", response)
 
-        show_beta |= util.get_allow_beta_value_from_config(self.cfg)
+        config_allow_beta = util.is_config_value_true(
+            config=self.cfg, path_to_value="features.allow_beta"
+        )
+        show_beta |= config_allow_beta
         if not show_beta:
             response = self._remove_beta_resources(response)
 

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -82,7 +82,7 @@ def logging_sandbox():
 @pytest.fixture
 def FakeConfig(tmpdir):
     class _FakeConfig(UAConfig):
-        def __init__(self) -> None:
+        def __init__(self, features_override=None) -> None:
             super().__init__({"data_dir": tmpdir.strpath})
 
         @classmethod
@@ -107,5 +107,8 @@ def FakeConfig(tmpdir):
             config = cls()
             config.write_cache("machine-token", machine_token)
             return config
+
+        def override_features(self, features_override):
+            self.cfg.update(features_override)
 
     return _FakeConfig

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -109,6 +109,7 @@ def FakeConfig(tmpdir):
             return config
 
         def override_features(self, features_override):
-            self.cfg.update(features_override)
+            if features_override is not None:
+                self.cfg.update({"features": features_override})
 
     return _FakeConfig

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -233,10 +233,9 @@ MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"
 MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
-ERROR_ON_ALLOW_BETA_KEY = """\
-Misspelled value for allow_beta key: {user_key} in \
-/etc/ubuntu-advantage/uaclient.conf. \
-This value must represent a boolean string."""
+ERROR_INVALID_CONFIG_VALUE = """\
+Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \
+Expected {expected_value}, found {value}."""
 
 
 def colorize(string: str) -> str:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -233,6 +233,11 @@ MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"
 MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
+ERROR_ON_ALLOW_BETA_KEY = """\
+Misspelled value for allow_beta key: {user_key} in \
+/etc/ubuntu-advantage/uaclient.conf. \
+This value must represent a boolean string."""
+
 
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -373,7 +373,7 @@ class TestPerformEnable:
         silent_if_inapplicable,
     ):
         ent_name = "testitlement"
-        cfg_dict = {"features": {"beta": True}}
+        cfg_dict = {"features": {"allow_beta": True}}
         m_entitlement_cls = mock.Mock()
         m_cfg = mock.Mock()
         m_cfg_dict = mock.PropertyMock(return_value=cfg_dict)

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -307,6 +307,8 @@ class TestPerformEnable:
     ):
         m_entitlement_cls = mock.Mock()
         m_cfg = mock.Mock()
+        m_user_cfg = mock.PropertyMock(return_value={})
+        type(m_cfg).cfg = m_user_cfg
         m_is_beta = mock.PropertyMock(return_value=allow_beta)
         type(m_entitlement_cls).is_beta = m_is_beta
 
@@ -332,6 +334,7 @@ class TestPerformEnable:
         assert ret == m_entitlement.enable.return_value
 
         assert 1 == m_cfg.status.call_count
+        assert 1 == m_user_cfg.call_count
         assert beta_call_count == m_is_beta.call_count
 
     @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
@@ -341,6 +344,8 @@ class TestPerformEnable:
     ):
         m_entitlement_cls = mock.Mock()
         m_cfg = mock.Mock()
+        m_user_cfg = mock.PropertyMock(return_value={})
+        type(m_cfg).cfg = m_user_cfg
         m_is_beta = mock.PropertyMock(return_value=True)
         type(m_entitlement_cls).is_beta = m_is_beta
 
@@ -356,6 +361,7 @@ class TestPerformEnable:
             _perform_enable("testitlement", m_cfg, **kwargs)
 
         assert 1 == m_is_beta.call_count
+        assert 1 == m_user_cfg.call_count
 
     @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
     @mock.patch("uaclient.contract.get_available_resources", return_value={})
@@ -367,7 +373,7 @@ class TestPerformEnable:
         silent_if_inapplicable,
     ):
         ent_name = "testitlement"
-        cfg_dict = {"features": {ent_name: {"is_beta": False}}}
+        cfg_dict = {"features": {"beta": True}}
         m_entitlement_cls = mock.Mock()
         m_cfg = mock.Mock()
         m_cfg_dict = mock.PropertyMock(return_value=cfg_dict)
@@ -375,8 +381,6 @@ class TestPerformEnable:
 
         m_is_beta = mock.PropertyMock(return_value=True)
         type(m_entitlement_cls).is_beta = m_is_beta
-        m_name = mock.PropertyMock(return_value=ent_name)
-        type(m_entitlement_cls).name = m_name
 
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             ent_name: m_entitlement_cls
@@ -400,6 +404,5 @@ class TestPerformEnable:
         assert ret == m_entitlement.enable.return_value
 
         assert 1 == m_cfg.status.call_count
-        assert 1 == m_is_beta.call_count
-        assert 1 == m_name.call_count
+        assert 0 == m_is_beta.call_count
         assert 1 == m_cfg_dict.call_count

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -390,13 +390,9 @@ class TestStatus:
     def check_beta(self, cls, show_beta, uacfg=None):
         if not show_beta:
             if uacfg:
-                is_beta = (
-                    uacfg.cfg.get("features", {})
-                    .get(cls.name, {})
-                    .get("is_beta", True)
-                )
+                allow_beta = uacfg.cfg.get("features", {}).get("beta", False)
 
-                if not is_beta:
+                if allow_beta:
                     return False
 
             return cls.is_beta
@@ -455,8 +451,7 @@ class TestStatus:
 
     @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
-        "features_override",
-        ((None), ({"features": {"fips": {"is_beta": False}}})),
+        "features_override", ((None), ({"features": {"beta": True}}))
     )
     @pytest.mark.parametrize(
         "avail_res,entitled_res,uf_entitled,uf_status",
@@ -628,8 +623,7 @@ class TestStatus:
 
     @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
-        "features_override",
-        ((None), ({"features": {"fips": {"is_beta": False}}})),
+        "features_override", ((None), ({"features": {"beta": False}}))
     )
     @pytest.mark.parametrize(
         "entitlements",

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -390,7 +390,9 @@ class TestStatus:
     def check_beta(self, cls, show_beta, uacfg=None):
         if not show_beta:
             if uacfg:
-                allow_beta = uacfg.cfg.get("features", {}).get("beta", False)
+                allow_beta = uacfg.cfg.get("features", {}).get(
+                    "allow_beta", False
+                )
 
                 if allow_beta:
                     return False
@@ -451,7 +453,7 @@ class TestStatus:
 
     @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
-        "features_override", ((None), ({"features": {"beta": True}}))
+        "features_override", ((None), ({"features": {"allow_beta": True}}))
     )
     @pytest.mark.parametrize(
         "avail_res,entitled_res,uf_entitled,uf_status",
@@ -623,7 +625,7 @@ class TestStatus:
 
     @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
-        "features_override", ((None), ({"features": {"beta": False}}))
+        "features_override", ((None), ({"features": {"allow_beta": False}}))
     )
     @pytest.mark.parametrize(
         "entitlements",

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -453,7 +453,7 @@ class TestStatus:
 
     @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
-        "features_override", ((None), ({"features": {"allow_beta": True}}))
+        "features_override", ((None), ({"allow_beta": True}))
     )
     @pytest.mark.parametrize(
         "avail_res,entitled_res,uf_entitled,uf_status",
@@ -625,7 +625,7 @@ class TestStatus:
 
     @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
-        "features_override", ((None), ({"features": {"allow_beta": False}}))
+        "features_override", ((None), ({"allow_beta": False}))
     )
     @pytest.mark.parametrize(
         "entitlements",

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -560,7 +560,7 @@ class TestPromptForConfirmation:
         assert input_calls == m_input.call_args_list
 
 
-class TestGetAllowBetaValueFromConfig:
+class TestIsConfigValueTrue:
     @pytest.mark.parametrize(
         "config_dict, return_val",
         [
@@ -572,8 +572,10 @@ class TestGetAllowBetaValueFromConfig:
             ({"features": {"allow_beta": "False"}}, False),
         ],
     )
-    def test_get_allow_beta_value_from_config(self, config_dict, return_val):
-        actual_val = util.get_allow_beta_value_from_config(config_dict)
+    def test_is_config_value_true(self, config_dict, return_val):
+        actual_val = util.is_config_value_true(
+            config=config_dict, path_to_value="features.allow_beta"
+        )
         assert return_val == actual_val
 
     @pytest.mark.parametrize(
@@ -585,11 +587,16 @@ class TestGetAllowBetaValueFromConfig:
             ({"features": {"allow_beta": "Fale"}}, "Fale"),
         ],
     )
-    def test_exception_get_allow_beta_value_from_config(
-        self, config_dict, key_val
-    ):
+    def test_exception_is_config_value_true(self, config_dict, key_val):
+        path_to_value = "features.allow_beta"
         with pytest.raises(exceptions.UserFacingError) as excinfo:
-            util.get_allow_beta_value_from_config(config_dict)
+            util.is_config_value_true(
+                config=config_dict, path_to_value=path_to_value
+            )
 
-        expected_msg = status.ERROR_ON_ALLOW_BETA_KEY.format(user_key=key_val)
+        expected_msg = status.ERROR_INVALID_CONFIG_VALUE.format(
+            path_to_value=path_to_value,
+            expected_value="boolean string: true or false",
+            value=key_val,
+        )
         assert expected_msg == str(excinfo.value)

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -565,33 +565,39 @@ class TestIsConfigValueTrue:
         "config_dict, return_val",
         [
             ({}, False),
-            ({"features": {}}, False),
-            ({"features": {"allow_beta": "true"}}, True),
-            ({"features": {"allow_beta": "True"}}, True),
-            ({"features": {"allow_beta": "false"}}, False),
-            ({"features": {"allow_beta": "False"}}, False),
+            ({}, False),
+            ({"allow_beta": "true"}, True),
+            ({"allow_beta": "True"}, True),
+            ({"allow_beta": "false"}, False),
+            ({"allow_beta": "False"}, False),
         ],
     )
-    def test_is_config_value_true(self, config_dict, return_val):
+    def test_is_config_value_true(self, config_dict, return_val, FakeConfig):
+        cfg = FakeConfig()
+        cfg.override_features(config_dict)
         actual_val = util.is_config_value_true(
-            config=config_dict, path_to_value="features.allow_beta"
+            config=cfg.cfg, path_to_value="features.allow_beta"
         )
         assert return_val == actual_val
 
     @pytest.mark.parametrize(
         "config_dict, key_val",
         [
-            ({"features": {"allow_beta": "tru"}}, "tru"),
-            ({"features": {"allow_beta": "Tre"}}, "Tre"),
-            ({"features": {"allow_beta": "flse"}}, "flse"),
-            ({"features": {"allow_beta": "Fale"}}, "Fale"),
+            ({"allow_beta": "tru"}, "tru"),
+            ({"allow_beta": "Tre"}, "Tre"),
+            ({"allow_beta": "flse"}, "flse"),
+            ({"allow_beta": "Fale"}, "Fale"),
         ],
     )
-    def test_exception_is_config_value_true(self, config_dict, key_val):
+    def test_exception_is_config_value_true(
+        self, config_dict, key_val, FakeConfig
+    ):
         path_to_value = "features.allow_beta"
+        cfg = FakeConfig()
+        cfg.override_features(config_dict)
         with pytest.raises(exceptions.UserFacingError) as excinfo:
             util.is_config_value_true(
-                config=config_dict, path_to_value=path_to_value
+                config=cfg.cfg, path_to_value=path_to_value
             )
 
         expected_msg = status.ERROR_INVALID_CONFIG_VALUE.format(

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from functools import wraps
 from http.client import HTTPMessage  # noqa: F401
 
+from uaclient import exceptions
 from uaclient import status
 
 try:
@@ -576,3 +577,18 @@ def write_file(filename: str, content: str, mode: int = 0o644) -> None:
         fh.write(content.encode("utf-8"))
         fh.flush()
     os.chmod(filename, mode)
+
+
+def get_allow_beta_value_from_config(config_dict):
+    allow_beta_str = str(
+        config_dict.get("features", {}).get("allow_beta", False)
+    )
+
+    if allow_beta_str.lower() == "true":
+        return True
+    elif allow_beta_str.lower() == "false":
+        return False
+    else:
+        raise exceptions.UserFacingError(
+            status.ERROR_ON_ALLOW_BETA_KEY.format(user_key=allow_beta_str)
+        )


### PR DESCRIPTION
As stated in #1080, we need a way to override some configurations for uaclient. This is an initial step in that direction, by allowing users to override the `beta` behavior in uaclient. This PR allows for users to visualize all beta service by adding the following lines to `uaclient.conf`:

```yaml
features:
  allow_beta: true
```