### PR TITLE
Update beta flag name

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -130,7 +130,7 @@ Feature: Command behaviour when attached to an UA subscription
             Updating package lists
             This machine is now detached
             """
-       When I run `ua status --beta` as non-root
+       When I run `ua status --all` as non-root
        Then stdout matches regexp:
            """
            SERVICE       AVAILABLE  DESCRIPTION
@@ -298,7 +298,7 @@ Feature: Command behaviour when attached to an UA subscription
             Updating package lists
             This machine is now detached
             """
-       When I run `ua status --beta` as non-root
+       When I run `ua status --all` as non-root
        Then stdout matches regexp:
            """
            SERVICE       AVAILABLE  DESCRIPTION

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -14,7 +14,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --beta` as non-root
+        When I run `ua status --all` as non-root
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -39,7 +39,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --beta` with sudo
+        When I run `ua status --all` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -54,7 +54,6 @@ Feature: Unattached status
             See https://ubuntu.com/advantage
             """ 
     
-    @wip
     @series.focal
     Scenario: Unattached status in a focal lxd container
         Given a `focal` lxd container with ubuntu-advantage-tools installed
@@ -69,7 +68,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --beta` as non-root
+        When I run `ua status --all` as non-root
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
@@ -94,7 +93,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status --beta` with sudo
+        When I run `ua status --all` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -233,7 +233,7 @@ def status_parser(parser):
         ),
     )
     parser.add_argument(
-        "--beta",
+        "--all",
         action="store_true",
         help="Allow the visualization of beta services",
     )
@@ -628,7 +628,7 @@ def action_status(args, cfg):
             status["expires"] = str(status["expires"])
         print(json.dumps(status))
     else:
-        show_beta = args.beta if args else False
+        show_beta = args.all if args else False
         output = ua_status.format_tabular(cfg.status(show_beta))
         # Replace our Unicode dash with an ASCII dash if we aren't going to be
         # writing to a utf-8 output; see


### PR DESCRIPTION
Currently, to show all services in uaclient, we must run `ua status --beta`. We are now updating the `beta`flag to `all`, meaning that the command is now `ua status --all`. 

Fixes: #1091