### PR TITLE
[WIP] Add feature to override machine-token info

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -160,7 +160,7 @@ class UAConfig:
             )
 
             return json.loads(machine_token_overlay_content)
-        except json.JSONDecodeError:
+        except ValueError:
             raise exceptions.UserFacingError(
                 status.ERROR_JSON_DECODING_IN_FILE.format(
                     file_path=machine_token_overlay_path

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -233,6 +233,11 @@ MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"
 MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
+INVALID_PATH_FOR_MACHINE_TOKEN_OVERLAY = """\
+Failed to find the machine token overlay file: {file_path}"""
+ERROR_JSON_DECODING_IN_FILE = """\
+Failed to read the following json file: {file_path}"""
+
 
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -844,3 +844,82 @@ class TestParseConfig:
                 parse_config()
         expected_msg = "Invalid url in config. contract_url: htp://contract"
         assert expected_msg == excinfo.value.msg
+
+
+class TestMachineTokenOverlay:
+    machine_token_dict = {
+        "type": "livepatch",
+        "affordances": {"series": ["trusty", "focal"], "tier": "stable"},
+        "directives": {
+            "caCerts": "",
+            "remoteServer": "https://livepatch.canonical.com",
+        },
+    }
+
+    @mock.patch("uaclient.util.load_file")
+    @mock.patch("uaclient.config.UAConfig.read_cache")
+    @mock.patch("uaclient.config.os.path.exists", return_value=True)
+    def test_machine_token_update_with_overlay(
+        self, m_path, m_read_cache, m_load_file
+    ):
+        user_cfg = {
+            "features": {"machine_token_overlay": "machine-token-path"}
+        }
+        m_read_cache.return_value = self.machine_token_dict
+
+        remote_server_overlay = "overlay"
+        json_str = '{"type": "t", "directives": {"remoteServer": "overlay"}}'
+        m_load_file.return_value = json_str
+
+        expected = copy.deepcopy(self.machine_token_dict)
+        expected["directives"]["remoteServer"] = remote_server_overlay
+        expected["type"] = "t"
+
+        cfg = UAConfig(cfg=user_cfg)
+        assert expected == cfg.machine_token
+
+    @mock.patch("uaclient.config.UAConfig.read_cache")
+    def test_machine_token_without_overlay(self, m_read_cache):
+        user_cfg = {}
+        m_read_cache.return_value = self.machine_token_dict
+        cfg = UAConfig(cfg=user_cfg)
+        assert self.machine_token_dict == cfg.machine_token
+
+    @mock.patch("uaclient.config.UAConfig.read_cache")
+    @mock.patch("uaclient.config.os.path.exists", return_value=False)
+    def test_machine_token_overlay_file_not_found(self, m_path, m_read_cache):
+        invalid_path = "machine-token-path"
+        user_cfg = {"features": {"machine_token_overlay": invalid_path}}
+        m_read_cache.return_value = self.machine_token_dict
+
+        cfg = UAConfig(cfg=user_cfg)
+        expected_msg = status.INVALID_PATH_FOR_MACHINE_TOKEN_OVERLAY.format(
+            file_path=invalid_path
+        )
+
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            cfg.machine_token
+
+        assert expected_msg == str(excinfo.value)
+
+    @mock.patch("uaclient.util.load_file")
+    @mock.patch("uaclient.config.UAConfig.read_cache")
+    @mock.patch("uaclient.config.os.path.exists", return_value=True)
+    def test_machine_token_overlay_json_decode_error(
+        self, m_path, m_read_cache, m_load_file
+    ):
+        invalid_json_path = "machine-token-path"
+        user_cfg = {"features": {"machine_token_overlay": invalid_json_path}}
+        m_read_cache.return_value = self.machine_token_dict
+
+        json_str = '{"directives": {"remoteServer": "overlay"}'
+        m_load_file.return_value = json_str
+        expected_msg = status.ERROR_JSON_DECODING_IN_FILE.format(
+            file_path=invalid_json_path
+        )
+
+        cfg = UAConfig(cfg=user_cfg)
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            cfg.machine_token
+
+        assert expected_msg == str(excinfo.value)

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -558,3 +558,29 @@ class TestPromptForConfirmation:
         util.prompt_for_confirmation(msg=message, assume_yes=assume_yes)
 
         assert input_calls == m_input.call_args_list
+
+
+class TestDepthFirstMergeDict:
+    @pytest.mark.parametrize(
+        "base_dict, other_dict, expected_dict",
+        [
+            ({"a": 1, "b": 2}, {"c": 3}, {"a": 1, "b": 2, "c": 3}),
+            (
+                {"a": 1, "b": {"c": 2, "d": 3}},
+                {"a": 1, "b": {"c": 10}},
+                {"a": 1, "b": {"c": 10, "d": 3}},
+            ),
+            (
+                {"a": 1, "b": {"c": 2, "d": 3}},
+                {"d": {"f": 20}},
+                {"a": 1, "b": {"c": 2, "d": 3}, "d": {"f": 20}},
+            ),
+            ({"a": 1, "b": 2}, {}, {"a": 1, "b": 2}),
+            ({}, {"a": 1, "b": 2}, {"a": 1, "b": 2}),
+        ],
+    )
+    def test_depth_first_merge_dict(
+        self, base_dict, other_dict, expected_dict
+    ):
+        util.depth_first_merge_dict(base_dict, other_dict)
+        assert expected_dict == base_dict

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -576,3 +576,25 @@ def write_file(filename: str, content: str, mode: int = 0o644) -> None:
         fh.write(content.encode("utf-8"))
         fh.flush()
     os.chmod(filename, mode)
+
+
+def depth_first_merge_dict(base_dict, other_dict):
+    """Merge the contents of other dict into base_dict not only on top-level
+    keys, but on all on the depths of the other_dict object. For example,
+    using these values as entries for the function:
+
+    base_dict = {"a": 1, "b": {"c": 2, "d": 3}}
+    other_dict = {"b": {"c": 10}}
+
+    Should update base_dict into:
+
+    {"a": 1, "b": {"c": 10, "d": 3}}
+
+    @param base_dict: The dict to be updated
+    @param other_dict: The dict with information to be added into base_dict
+    """
+    for key, value in other_dict.items():
+        if type(base_dict.get(key)) == dict and type(value) == dict:
+            depth_first_merge_dict(base_dict[key], value)
+        else:
+            base_dict[key] = value


### PR DESCRIPTION
Currently, there is no way to override configurations in uaclient provided by the machine-token received by the uaclient server. We are now adding the feature to allow for an user to override such configs. To do that, the user will need to provided the following lines on the `uaclient.conf` file:

```yaml
features:
  machine_token_overlay:  PATH_TO_FILE
```

Where `PATH_TO_FILE` is must be a path to a `json` file with the configurations that should be override.

 There are still lacking some behave tests for this feature, since the abstraction to write lines into `uaclient.conf` is provided by #1100, but once this PR lands, I will update this PR with the necessary behave tests