### PR TITLE
Contract token test

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -18,12 +18,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
-        cc-eal       +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-        cis-audit    +no       +—        +Center for Internet Security Audit Tools
         esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
-        fips         +yes      +n/a      +NIST-certified FIPS modules
-        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
         livepatch    +yes      +n/a      +Canonical Livepatch service
         """
         And I will see the following on stderr:
@@ -47,12 +43,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
-        cc-eal       +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-        cis-audit    +no       +—        +Center for Internet Security Audit Tools
         esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
-        fips         +yes      +n/a      +NIST-certified FIPS modules
-        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
         livepatch    +yes      +n/a      +Canonical Livepatch service
         """
         And stderr matches regexp:

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -166,25 +166,13 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
         When I run `ua version` with sudo
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
         When I run `ua --version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
         When I run `ua --version` with sudo
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
 
     @series.trusty
     Scenario: Unattached status in a trusty machine with machine token overlay
@@ -217,15 +205,9 @@ Feature: Command behaviour when attached to an UA subscription
             cc-eal        no
             """
         When I run `ua --version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0 +machine-token-overlay
-            """
+        Then I will see the uaclient version on stdout with overlay info
         When I run `ua version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0 +machine-token-overlay
-            """
+        Then I will see the uaclient version on stdout with overlay info
 
    @series.focal
    Scenario: Attached refresh in a focal machine
@@ -375,25 +357,13 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
         When I run `ua version` with sudo
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
         When I run `ua --version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
         When I run `ua --version` with sudo
-        Then I will see the following on stdout:
-            """
-            25.0
-            """
+        Then I will see the uaclient version on stdout
 
     @series.focal
     Scenario: Unattached status in a focal machine with machine token overlay
@@ -426,12 +396,6 @@ Feature: Command behaviour when attached to an UA subscription
             cc-eal        no
             """
         When I run `ua --version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0 +machine-token-overlay
-            """
+        Then I will see the uaclient version on stdout with overlay info
         When I run `ua version` as non-root
-        Then I will see the following on stdout:
-            """
-            25.0 +machine-token-overlay
-            """
+        Then I will see the uaclient version on stdout with overlay info

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -168,22 +168,22 @@ Feature: Command behaviour when attached to an UA subscription
         And I run `ua version` as non-root
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
         When I run `ua version` with sudo
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
         When I run `ua --version` as non-root
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
         When I run `ua --version` with sudo
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
 
     @series.trusty
@@ -377,22 +377,22 @@ Feature: Command behaviour when attached to an UA subscription
         And I run `ua version` as non-root
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
         When I run `ua version` with sudo
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
         When I run `ua --version` as non-root
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
         When I run `ua --version` with sudo
         Then I will see the following on stdout:
             """
-            20.4
+            25.0
             """
 
     @series.focal

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -45,9 +45,9 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: beta services in containers
-           | service      | flag                |
-           | fips         | --assume-yes --beta |
-           | fips-updates | --assume-yes --beta |
+           | service      | flag         |
+           | fips         | --assume-yes |
+           | fips-updates | --assume-yes |
 
     @series.trusty
     Scenario: Attached enable Common Criteria service in a trusty machine

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -7,7 +7,6 @@ from hamcrest import assert_that, equal_to, matches_regexp
 from features.util import launch_lxd_container, lxc_exec
 
 from uaclient.defaults import DEFAULT_CONFIG_FILE
-from uaclient.version import get_version
 
 
 CONTAINER_PREFIX = "behave-test-"
@@ -100,17 +99,29 @@ def then_i_will_see_on_stderr(context):
 
 
 @then("I will see the uaclient version on stdout")
-def then_i_will_see_the_uaclient_version_on_stdout(context):
-    assert_that(context.process.stdout.strip(), equal_to(get_version()))
+def then_i_will_see_the_uaclient_version_on_stdout(context, overlay_str=None):
+    python_import = "from uaclient.version import get_version"
+
+    if overlay_str is not None:
+        python_cmd = 'get_version(machine_token_overlay_str="{}")'.format(
+            overlay_str
+        )
+    else:
+        python_cmd = "get_version()"
+
+    cmd = "python3 -c '{}; print({})'".format(python_import, python_cmd)
+
+    actual_version = context.process.stdout.strip()
+    when_i_run_command(context, cmd, "as non-root")
+    expected_version = context.process.stdout.strip()
+
+    assert_that(expected_version, equal_to(actual_version))
 
 
 @then("I will see the uaclient version on stdout with overlay info")
 def then_i_will_see_the_uaclient_version_with_overlay_info(context):
-    assert_that(
-        context.process.stdout.strip(),
-        equal_to(
-            get_version(machine_token_overlay_str=" +machine_token_overlay")
-        ),
+    then_i_will_see_the_uaclient_version_on_stdout(
+        context, " +machine-token-overlay"
     )
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -7,6 +7,7 @@ from hamcrest import assert_that, equal_to, matches_regexp
 from features.util import launch_lxd_container, lxc_exec
 
 from uaclient.defaults import DEFAULT_CONFIG_FILE
+from uaclient.version import get_version
 
 
 CONTAINER_PREFIX = "behave-test-"
@@ -96,6 +97,21 @@ def then_stderr_matches_regexp(context):
 @then("I will see the following on stderr")
 def then_i_will_see_on_stderr(context):
     assert_that(context.process.stderr.strip(), equal_to(context.text))
+
+
+@then("I will see the uaclient version on stdout")
+def then_i_will_see_the_uaclient_version_on_stdout(context):
+    assert_that(context.process.stdout.strip(), equal_to(get_version()))
+
+
+@then("I will see the uaclient version on stdout with overlay info")
+def then_i_will_see_the_uaclient_version_with_overlay_info(context):
+    assert_that(
+        context.process.stdout.strip(),
+        equal_to(
+            get_version(machine_token_overlay_str=" +machine_token_overlay")
+        ),
+    )
 
 
 def get_command_prefix_for_user_spec(user_spec):


### PR DESCRIPTION
Testing `UACLIENT_BEHAVE_CONTRACT_TOKEN` use in travis while also fixing some behave tests.

There is sill on scenario failing, that is is related to the problem in #1104, where the `ua enable INVALID_TOKEN` command does not raise the expected errror because the server is returning a different error than the one expected.