### PR TITLE
Do not enable services if blocking services is active

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -226,21 +226,29 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.focal
     @uses.config.machine_type.lxd.vm
-    Scenario Outline: Attached enable of vm-based services in a focal lxd vm
+    Scenario: Attached enable of vm-based services in a focal lxd vm
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` with sudo
-        And I run `ua enable <service> --assume-yes --beta` with sudo
+        And I run `ua enable fips --assume-yes --beta` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            <title> is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
 
-        Examples: ubuntu service
-        | service      | title        |
-        | fips         | FIPS         |
-        | fips-updates | FIPS Updates |
+    @series.focal
+    @uses.config.machine_type.lxd.vm
+    Scenario: Attached enable of vm-based services in a focal lxd vm
+        Given a `focal` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua disable livepatch` with sudo
+        And I run `ua enable fips-updates --assume-yes --beta` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            """
 
     @series.xenial
     @uses.config.machine_type.lxd.vm
@@ -270,7 +278,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS enabled
             A reboot is required to complete install
             """
-<<<<<<< HEAD
         When I run `ua status --all` with sudo
         Then stdout matches regexp:
             """
@@ -319,7 +326,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | release |
            | xenial  |
            | bionic  |
-=======
 
     @series.bionic
     @uses.config.machine_type.lxd.vm
@@ -338,6 +344,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             Removing canonical-livepatch snap
             """
+        Then I verify that the `canonical-livepatch` command is not found
         When I run `ua enable fips --assume-yes --beta` with sudo
         Then I will see the following on stdout:
             """
@@ -372,4 +379,3 @@ Feature: Enable command behaviour when attached to an UA subscription
             One moment, checking your subscription first
             Cannot enable FIPS when Livepatch is enabled
             """
->>>>>>> Add behave tests

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -132,6 +132,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | trusty  |
            | xenial  |
 
+
     @series.all
     @uses.config.machine_type.lxd.container
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
@@ -267,6 +268,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS enabled
             A reboot is required to complete install
             """
+<<<<<<< HEAD
         When I run `ua status --all` with sudo
         Then stdout matches regexp:
             """
@@ -315,3 +317,57 @@ Feature: Enable command behaviour when attached to an UA subscription
            | release |
            | xenial  |
            | bionic  |
+=======
+
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario: Attached enable fips on a machine with livepatch active
+        Given a `bionic` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            ESM Infra enabled
+            Installing canonical-livepatch snap
+            Canonical livepatch enabled
+            """
+        When I run `ua disable livepatch` with sudo
+        Then I will see the following on stdout:
+            """
+            Removing canonical-livepatch snap
+            """
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Updating package lists
+            Installing FIPS packages
+            FIPS enabled
+            A reboot is required to complete install
+            """
+        When I run `ua enable livepatch` with sudo
+        Then I will see the following on stdout
+            """
+            One moment, checking your subscription first
+            Failed to enable livepatch because the following services are enabled: fips.
+            """
+
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario: Attached enable livepatch on a machine with fips active
+        Given a `bionic` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            ESM Infra enabled
+            Installing canonical-livepatch snap
+            Canonical livepatch enabled
+            """
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then I will see the following on stdout
+            """
+            One moment, checking your subscription first
+            Failed to enable fips because the following services are enabled: livepatch.
+            """
+>>>>>>> Add behave tests

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -226,19 +226,21 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.focal
     @uses.config.machine_type.lxd.vm
-    Scenario: Attached enable of vm-based services in a focal lxd vm
+    Scenario Outline: Attached enable of vm-based services in a focal lxd vm
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        When I run `ua enable fips --assume-yes --beta` with sudo
-        Then stdout matches regexp:
+        And I run `ua disable livepatch` with sudo
+        And I run `ua enable <service> --assume-yes --beta` with sudo
+        Then I will see the following on stdout:
             """
-            FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
+            One moment, checking your subscription first
+            <title> is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
-        When I run `ua enable fips-updates --assume-yes --beta` with sudo
-        Then stdout matches regexp:
-            """
-            FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
-            """
+
+        Examples: ubuntu service
+        | service      | title        |
+        | fips         | FIPS         |
+        | fips-updates | FIPS Updates |
 
     @series.xenial
     @uses.config.machine_type.lxd.vm

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -349,7 +349,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout
             """
             One moment, checking your subscription first
-            Failed to enable livepatch because the following services are enabled: fips.
+            Cannot enable Livepatch when FIPS is enabled
             """
 
     @series.bionic
@@ -368,6 +368,6 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout
             """
             One moment, checking your subscription first
-            Failed to enable fips because the following services are enabled: livepatch.
+            Cannot enable FIPS when Livepatch is enabled
             """
 >>>>>>> Add behave tests

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -146,6 +146,17 @@ def then_i_will_see_the_uaclient_version_with_overlay_info(context):
     )
 
 
+@then("I verify that the `{cmd_name}` command is not found")
+def then_i_should_see_that_the_command_is_not_found(context, cmd_name):
+    cmd = "which {} || echo FAILURE".format(cmd_name)
+    cmd = 'sh -c "{}"'.format(cmd)
+    when_i_run_command(context, cmd, "as non-root")
+
+    expected_return = "FAILURE"
+    actual_return = context.process.stdout.strip()
+    assert_that(expected_return, equal_to(actual_return))
+
+
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
     if user_spec == "with sudo":

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -38,9 +38,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # Wheter that entitlement is in beta stage
     is_beta = False
 
-    # List of services that if enabled, will block enabling the service
-    blocking_entitlements = []  # type: List[str]
-
     @property
     @abc.abstractmethod
     def name(self) -> str:
@@ -62,7 +59,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # A tuple of 3-tuples with (failure_message, functor, expected_results)
     # If any static_affordance does not match expected_results fail with
     # <failure_message>. Overridden in livepatch and fips
-    static_affordances = ()  # type: Tuple[StaticAffordance, ...]
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        return ()
 
     def __init__(
         self, cfg: "Optional[config.UAConfig]" = None, assume_yes: bool = False
@@ -105,32 +104,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             return False
         return True
 
-    def check_for_blocking_entitlements(self):
-        """
-        Check whether a blocking entitlements for the entitlement
-        we are trying to enable is already enable. We will iterate
-        over all blocking entitlements of a service and return all
-        of the ones that are active in the user machine.
-
-        @return: List containing the name of the enabled blocking
-                 entitlements.
-        """
-        from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
-
-        enabled_blocking_ents = []
-
-        for ent_name in self.blocking_entitlements:
-            ent_cls = ENTITLEMENT_CLASS_BY_NAME.get(ent_name)
-
-            if ent_cls is not None:
-                ent_obj = ent_cls()
-                ent_status, _ = ent_obj.application_status()
-
-                if ent_status == status.ApplicationStatus.ENABLED:
-                    enabled_blocking_ents.append(ent_name)
-
-        return enabled_blocking_ents
-
     def can_enable(self, silent: bool = False) -> bool:
         """
         Report whether or not enabling is possible for the entitlement.
@@ -142,17 +115,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 "Updating contract on service '%s' expiry", self.name
             )
             contract.request_updated_contract(self.cfg)
-        if len(self.blocking_entitlements):
-            enabled_blocking_ents = self.check_for_blocking_entitlements()
-
-            if len(enabled_blocking_ents) > 0:
-                print(
-                    status.MESSAGE_BLOCKING_ENTITLEMENT_IS_ENABLED.format(
-                        ent_name=self.name,
-                        blocking_ents=", ".join(enabled_blocking_ents),
-                    )
-                )
-                return False
         if not self.contract_status() == ContractStatus.ENTITLED:
             if not silent:
                 print(status.MESSAGE_UNENTITLED_TMPL.format(title=self.title))

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -4,7 +4,9 @@ from uaclient.entitlements import repo
 from uaclient import apt, status, util
 
 try:
-    from typing import Callable, Dict, List, Set, Tuple, Union  # noqa
+    from typing import Any, Callable, Dict, List, Set, Tuple, Union  # noqa
+
+    StaticAffordance = Tuple[str, Callable[[], Any], bool]
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -16,12 +18,38 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     fips_required_packages = frozenset({"fips-initramfs", "linux-fips"})
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
     is_beta = True
-    blocking_entitlements = ["livepatch"]
 
     # RELEASE_BLOCKER GH: #104, don't prompt for conf differences in FIPS
     # Review this fix to see if we want more general functionality for all
     # services. And security/CPC signoff on expected conf behavior.
     apt_noninteractive = True
+
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        # Use a lambda so we can mock util.is_container in tests
+        from uaclient.entitlements.livepatch import LivepatchEntitlement
+
+        livepatch_ent = LivepatchEntitlement(self.cfg)
+        enabled_status = status.ApplicationStatus.ENABLED
+
+        is_livepatch_enabled = bool(
+            livepatch_ent.application_status()[0] == enabled_status
+        )
+
+        return (
+            (
+                "Cannot install {} on a container".format(self.title),
+                lambda: util.is_container(),
+                False,
+            ),
+            (
+                "Cannot enable {} when Livepatch is enabled".format(
+                    self.title
+                ),
+                lambda: is_livepatch_enabled,
+                False,
+            ),
+        )
 
     @property
     def packages(self) -> "List[str]":
@@ -71,9 +99,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     title = "FIPS"
     description = "NIST-certified FIPS modules"
     origin = "UbuntuFIPS"
-    static_affordances = (
-        ("Cannot install FIPS on a container", util.is_container, False),
-    )
 
     @property
     def messaging(
@@ -117,13 +142,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
     title = "FIPS Updates"
     origin = "UbuntuFIPSUpdates"
     description = "Uncertified security updates to FIPS modules"
-    static_affordances = (
-        (
-            "Cannot install FIPS Updates on a container",
-            util.is_container,
-            False,
-        ),
-    )
 
     @property
     def messaging(

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -16,6 +16,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     fips_required_packages = frozenset({"fips-initramfs", "linux-fips"})
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
     is_beta = True
+    blocking_entitlements = ["livepatch"]
 
     # RELEASE_BLOCKER GH: #104, don't prompt for conf differences in FIPS
     # Review this fix to see if we want more general functionality for all

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -26,6 +26,7 @@ class LivepatchEntitlement(base.UAEntitlement):
     name = "livepatch"
     title = "Livepatch"
     description = "Canonical Livepatch service"
+    blocking_entitlements = ["fips", "fips-update"]
 
     # Use a lambda so we can mock util.is_container in tests
     static_affordances = (

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -9,7 +9,9 @@ SNAP_CMD = "/usr/bin/snap"
 SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
 
 try:
-    from typing import Any, Dict, Tuple  # noqa: F401
+    from typing import Any, Callable, Dict, Tuple  # noqa: F401
+
+    StaticAffordance = Tuple[str, Callable[[], Any], bool]
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -26,16 +28,41 @@ class LivepatchEntitlement(base.UAEntitlement):
     name = "livepatch"
     title = "Livepatch"
     description = "Canonical Livepatch service"
-    blocking_entitlements = ["fips", "fips-update"]
 
-    # Use a lambda so we can mock util.is_container in tests
-    static_affordances = (
-        (
-            "Cannot install Livepatch on a container",
-            lambda: util.is_container(),
-            False,
-        ),
-    )
+    @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        # Use a lambda so we can mock util.is_container in tests
+        from uaclient.entitlements.fips import FIPSEntitlement
+        from uaclient.entitlements.fips import FIPSUpdatesEntitlement
+
+        fips_ent = FIPSEntitlement(self.cfg)
+        fips_update_ent = FIPSUpdatesEntitlement(self.cfg)
+        enabled_status = ApplicationStatus.ENABLED
+
+        is_fips_enabled = bool(
+            fips_ent.application_status()[0] == enabled_status
+        )
+        is_fips_updates_enabled = bool(
+            fips_update_ent.application_status()[0] == enabled_status
+        )
+
+        return (
+            (
+                "Cannot install Livepatch on a container",
+                lambda: util.is_container(),
+                False,
+            ),
+            (
+                "Cannot enable Livepatch when FIPS is enabled",
+                lambda: is_fips_enabled,
+                False,
+            ),
+            (
+                "Cannot enable Livepatch when FIPS Updates is enabled",
+                lambda: is_fips_updates_enabled,
+                False,
+            ),
+        )
 
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -23,7 +23,6 @@ class TestCISEntitlementCanEnable:
     ):
         """When entitlement is INACTIVE, can_enable returns True."""
         # Unset static affordance container check
-        entitlement.static_affordances = ()
         with mock.patch.object(
             entitlement,
             "application_status",
@@ -49,8 +48,6 @@ class TestCISEntitlementEnable:
 
         m_platform_info.side_effect = fake_platform
         m_subp.return_value = ("fakeout", "")
-        # Unset static affordance container check
-        entitlement.static_affordances = ()
 
         with mock.patch(
             M_REPOPATH + "os.path.exists", mock.Mock(return_value=True)

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -340,8 +340,9 @@ class TestFIPSEntitlementEnable:
             assert "remove" not in call[0][0]
 
     @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_blocking_service_is_enabled(
-        self, m_handle_message_op, entitlement
+        self, m_is_container, m_handle_message_op, entitlement
     ):
         m_handle_message_op.return_value = True
         base_path = "uaclient.entitlements.livepatch.LivepatchEntitlement"

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import copy
+import io
 import itertools
 import mock
 from functools import partial
@@ -13,6 +14,7 @@ from uaclient import defaults
 from uaclient import status, util
 from uaclient.entitlements.fips import FIPSEntitlement, FIPSUpdatesEntitlement
 from uaclient import exceptions
+from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
 
 M_PATH = "uaclient.entitlements.fips."
@@ -337,6 +339,37 @@ class TestFIPSEntitlementEnable:
 
         for call in m_subp.call_args_list:
             assert "remove" not in call[0][0]
+
+    @pytest.mark.parametrize("blocking_entitlements", [(["livepatch"])])
+    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    def test_enable_fails_when_blocking_service_is_enabled(
+        self, m_handle_message_op, entitlement, blocking_entitlements
+    ):
+        entitlement_return_value = {}
+        for ent_name in blocking_entitlements:
+            m_entitlement_cls = mock.MagicMock()
+            entitlement_return_value[ent_name] = m_entitlement_cls
+            m_entitlement_obj = m_entitlement_cls.return_value
+            m_entitlement_obj.application_status.return_value = (
+                status.ApplicationStatus.ENABLED,
+                "",
+            )
+
+        with mock.patch.dict(
+            ENTITLEMENT_CLASS_BY_NAME, entitlement_return_value, clear=True
+        ):
+            m_handle_message_op.return_value = True
+
+            fake_stdout = io.StringIO()
+            with contextlib.redirect_stdout(fake_stdout):
+                entitlement.enable()
+
+            msg_tmpl = status.MESSAGE_BLOCKING_ENTITLEMENT_IS_ENABLED
+            expected_msg = msg_tmpl.format(
+                ent_name=entitlement.name,
+                blocking_ents=", ".join(blocking_entitlements),
+            )
+            assert expected_msg.strip() == fake_stdout.getvalue().strip()
 
 
 def _fips_pkg_combinations():

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -646,8 +646,14 @@ class TestLivepatchEntitlementEnable:
         ),
     )
     @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_blocking_service_is_enabled(
-        self, m_handle_message_op, cls_name, cls_title, entitlement
+        self,
+        m_is_container,
+        m_handle_message_op,
+        cls_name,
+        cls_title,
+        entitlement,
     ):
         m_handle_message_op.return_value = True
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -162,6 +162,9 @@ This machine is not attached to a UA subscription.
 See https://ubuntu.com/advantage"""
 MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
+MESSAGE_BLOCKING_ENTITLEMENT_IS_ENABLED = """\
+Failed to enable {ent_name} because the following services are \
+enabled: {blocking_ents}."""
 
 PROMPT_YES_NO = """Are you sure? (y/N) """
 PROMPT_FIPS_PRE_ENABLE = (

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -162,9 +162,6 @@ This machine is not attached to a UA subscription.
 See https://ubuntu.com/advantage"""
 MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
-MESSAGE_BLOCKING_ENTITLEMENT_IS_ENABLED = """\
-Failed to enable {ent_name} because the following services are \
-enabled: {blocking_ents}."""
 
 PROMPT_YES_NO = """Are you sure? (y/N) """
 PROMPT_FIPS_PRE_ENABLE = (


### PR DESCRIPTION
Users should not be able to enable `livepatch` if `fips` is active or `fips` if `livepatch` is active as stated in #1029 . We are now add the possibility for verifying if `blocking services` are enabled before activating a service. If this happens, we will not enable the service and show the user which services are responsible for that behavior.

Furthermore, we are only testing this feature now in `Bionic`. Although there are some improvements we can achieve for testing that feature, there are some potential issues that I have found (#1111 and #1112) that are posing a difficult for developing vm tests

Fixes: #1029 