### PR TITLE
Adapt behave test to use xenial and bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,79 @@ matrix:
   fast_finish: true
   include:
     - python: 3.7
-      env: TOXENV=behave
+      env: TOXENV=behave-14.04
+      script:
+          # bionic has lxd from deb installed, remove it first to avoid
+          # confusion over versions
+          - echo $TRAVIS_BRANCH
+          - echo $TRAVIS_BUILD_DIR
+          - BUILD_PR=1
+          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
+          - >
+                  if [ "$BUILD_PR" -eq "1" ]; then
+                     cd $TRAVIS_BUILD_DIR/..
+                     tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                     cp pr_source.tar.gz /tmp
+                     ls -lh /tmp
+                     cd $TRAVIS_BUILD_DIR
+                     pwd
+                  fi
+              - sudo apt-get remove --yes --purge lxd lxd-client
+              - sudo rm -Rf /var/lib/lxd
+              - sudo snap install lxd
+              - sudo lxd init --auto
+              - sudo usermod -a -G lxd $USER
+              - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+    - python: 3.7
+      env: TOXENV=behave-16.04
+      script:
+          # bionic has lxd from deb installed, remove it first to avoid
+          # confusion over versions
+          - echo $TRAVIS_BRANCH
+          - echo $TRAVIS_BUILD_DIR
+          - BUILD_PR=1
+          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
+          - >
+                  if [ "$BUILD_PR" -eq "1" ]; then
+                      cd $TRAVIS_BUILD_DIR/..
+                      tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                      cp pr_source.tar.gz /tmp
+                      ls -lh /tmp
+                      cd $TRAVIS_BUILD_DIR
+                      pwd
+                  fi
+              - sudo apt-get remove --yes --purge lxd lxd-client
+              - sudo rm -Rf /var/lib/lxd
+              - sudo snap install lxd
+              - sudo lxd init --auto
+              - sudo usermod -a -G lxd $USER
+              - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+    - python: 3.7
+      env: TOXENV=behave-18.04
+      script:
+          # bionic has lxd from deb installed, remove it first to avoid
+          # confusion over versions
+          - echo $TRAVIS_BRANCH
+          - echo $TRAVIS_BUILD_DIR
+          - BUILD_PR=1
+          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
+          - >
+                  if [ "$BUILD_PR" -eq "1" ]; then
+                      cd $TRAVIS_BUILD_DIR/..
+                      tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                      cp pr_source.tar.gz /tmp
+                      ls -lh /tmp
+                      cd $TRAVIS_BUILD_DIR
+                      pwd
+                  fi
+              - sudo apt-get remove --yes --purge lxd lxd-client
+              - sudo rm -Rf /var/lib/lxd
+              - sudo snap install lxd
+              - sudo lxd init --auto
+              - sudo usermod -a -G lxd $USER
+              - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+    - python: 3.7
+      env: TOXENV=behave-20.04
       script:
           # bionic has lxd from deb installed, remove it first to avoid
           # confusion over versions

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -1,23 +1,9 @@
 Feature: Command behaviour when trying to attach a machine to an Ubuntu
          Advantage subscription using an invalid token
 
-    @series.trusty
-    Scenario: Attach command in a trusty machine
-       Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I run `ua attach INVALID_TOKEN` with sudo
-        Then I will see the following on stderr:
-            """
-            Invalid token. See https://ubuntu.com/advantage
-            """
-        When I run `ua attach INVALID_TOKEN` as non-root
-        Then I will see the following on stderr:
-             """
-             This command must be run as root (try using sudo)
-             """
-
-    @series.focal
-    Scenario: Attach command in a focal machine
-       Given a `focal` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Attach command in a machine
+       Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua attach INVALID_TOKEN` with sudo
         Then stderr matches regexp:
             """
@@ -28,3 +14,10 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              """
              This command must be run as root (try using sudo)
              """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -17,7 +17,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -29,7 +29,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -2,35 +2,10 @@
 Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         subscription using a valid token
 
-    @series.trusty
+    @series.all
     @uses.config.machine_type.lxd.container
-    Scenario: Attach command in a trusty lxd container
-       Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then stdout matches regexp:
-        """
-        ESM Infra enabled
-        """
-        And stdout matches regexp:
-        """
-        This machine is now attached to
-        """
-        And stdout matches regexp:
-        """
-        SERVICE       ENTITLED  STATUS    DESCRIPTION
-        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
-        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
-        livepatch    +yes      +n/a      +Canonical Livepatch service
-        """
-        And I will see the following on stderr:
-        """
-        Enabling default service esm-infra
-        """
-
-    @series.focal
-    @uses.config.machine_type.lxd.container
-    Scenario: Attach command in a focal lxd container
-       Given a `focal` machine with ubuntu-advantage-tools installed
+    Scenario Outline: Attach command in a ubuntu lxd container
+       Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
@@ -51,3 +26,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Enabling default service esm-infra
         """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -18,10 +18,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
@@ -41,10 +41,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached disable of an unknown service in a ubuntu machine
@@ -64,10 +64,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached detach in a trusty machine
@@ -104,10 +104,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release | esm-apps | cc-eal | fips | fips-update |
-           | bionic  | yes      | no     | yes  | yes         |
-           | focal   | yes      | no     | no   | no          |
            | trusty  | no       | no     | no   | no          |
            | xenial  | yes      | yes    | yes  | yes         |
+           | bionic  | yes      | no     | yes  | yes         |
+           | focal   | yes      | no     | no   | no          |
 
     @series.all
     Scenario Outline: Attached auto-attach in a ubuntu machine
@@ -126,10 +126,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached show version in a ubuntu machine
@@ -146,10 +146,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Unattached status in a ubuntu machine with machine token overlay
@@ -188,10 +188,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached disable of different services in a ubuntu machine
@@ -222,10 +222,10 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached disable of an already enabled service in a ubuntu machine
@@ -249,7 +249,7 @@ Feature: Command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -193,9 +193,9 @@ Feature: Command behaviour when attached to an UA subscription
            | trusty  |
            | xenial  |
 
-    @series.trusty
-    Scenario: Attached disable of different services in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Attached disable of different services in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra livepatch foobar` as non-root
         Then I will see the following on stderr:
@@ -219,19 +219,17 @@ Feature: Command behaviour when attached to an UA subscription
             """
             esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
             """
-        When I run `apt-cache policy` with sudo
-        Then stdout matches regexp:
-            """
-            -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-updates/main amd64 Packages
-            """
-        And stdout matches regexp:
-            """
-            -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-security/main amd64 Packages
-            """
 
-    @series.trusty
-    Scenario: Attached disable of an already enabled service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached disable of an already enabled service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` as non-root
         Then I will see the following on stderr:
@@ -248,59 +246,10 @@ Feature: Command behaviour when attached to an UA subscription
             """
             esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
             """
-        When I run `apt-cache policy` with sudo
-        Then stdout matches regexp:
-            """
-            -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-updates/main amd64 Packages
-            """
-        And stdout matches regexp:
-            """
-            -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-security/main amd64 Packages
-            """
 
-    @series.focal
-    Scenario: Attached disable of an already disabled, enabled and not found services
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua disable livepatch esm-infra foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable livepatch esm-infra foobar` with sudo
-        Then I will see the following on stdout:
-            """
-            Livepatch is not currently enabled
-            See: sudo ua status
-            Updating package lists
-            """
-        And stderr matches regexp:
-            """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
-            """
-        When I run `ua status` with sudo
-        Then stdout matches regexp:
-            """
-            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
-            """
-
-    @series.focal
-    Scenario: Attached disable of an already enabled service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua disable esm-infra` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable esm-infra` with sudo
-        Then I will see the following on stdout:
-            """
-            Updating package lists
-            """
-        When I run `ua status` with sudo
-        Then stdout matches regexp:
-            """
-            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
-            """
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -1,9 +1,9 @@
 @uses.config.contract_token
 Feature: Command behaviour when attached to an UA subscription
 
-    @series.trusty
-    Scenario: Attached refresh in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Attached refresh in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua refresh` as non-root
         Then I will see the following on stderr:
@@ -16,9 +16,16 @@ Feature: Command behaviour when attached to an UA subscription
             Successfully refreshed your subscription
             """
 
-    @series.trusty
-    Scenario: Attached disable of an already disabled service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` as non-root
         Then I will see the following on stderr:
@@ -32,9 +39,16 @@ Feature: Command behaviour when attached to an UA subscription
             See: sudo ua status
             """
 
-    @series.trusty
-    Scenario: Attached disable of an unknown service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached disable of an unknown service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable foobar` as non-root
         Then I will see the following on stderr:
@@ -42,11 +56,142 @@ Feature: Command behaviour when attached to an UA subscription
             This command must be run as root (try using sudo)
             """
         When I run `ua disable foobar` with sudo
-        Then I will see the following on stderr:
+        Then stderr matches regexp:
             """
             Cannot disable 'foobar'
             For a list of services see: sudo ua status
             """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached detach in a trusty machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua detach` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua detach --assume-yes` with sudo
+        Then I will see the following on stdout:
+            """
+            Detach will disable the following service:
+                esm-infra
+            Updating package lists
+            This machine is now detached
+            """
+       When I run `ua status --all` as non-root
+       Then stdout matches regexp:
+           """
+           SERVICE       AVAILABLE  DESCRIPTION
+           cc-eal        +<cc-eal>   +Common Criteria EAL2 Provisioning Packages
+           esm-apps      +<esm-apps> +UA Apps: Extended Security Maintenance
+           esm-infra     +yes        +UA Infra: Extended Security Maintenance
+           fips          +<fips>     +NIST-certified FIPS modules
+           fips-updates  +<fips>     +Uncertified security updates to FIPS modules
+           livepatch     +yes        +Canonical Livepatch service
+           """
+       And stdout matches regexp:
+          """
+          This machine is not attached to a UA subscription.
+          """
+
+        Examples: ubuntu release
+           | release | esm-apps | cc-eal | fips | fips-update |
+           | bionic  | yes      | no     | yes  | yes         |
+           | focal   | yes      | no     | no   | no          |
+           | trusty  | no       | no     | no   | no          |
+           | xenial  | yes      | yes    | yes  | yes         |
+
+    @series.all
+    Scenario Outline: Attached auto-attach in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua auto-attach` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua auto-attach` with sudo
+        Then stderr matches regexp:
+            """
+            This machine is already attached
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached show version in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua version` as non-root
+        Then I will see the uaclient version on stdout
+        When I run `ua version` with sudo
+        Then I will see the uaclient version on stdout
+        When I run `ua --version` as non-root
+        Then I will see the uaclient version on stdout
+        When I run `ua --version` with sudo
+        Then I will see the uaclient version on stdout
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Unattached status in a ubuntu machine with machine token overlay
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        """
+        {
+            "machineTokenInfo": {
+                "contractInfo": {
+                    "resourceEntitlements": [
+                        {
+                            "type": "cc-eal",
+                            "entitled": false
+                        }
+                    ]
+                }
+            }
+        }
+        """
+        And I append the following on uaclient config:
+        """
+        features:
+          machine_token_overlay: "/tmp/machine-token-overlay.json"
+        """
+        And I attach `contract_token` with sudo
+        And I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            SERVICE       ENTITLED  STATUS    DESCRIPTION
+            cc-eal        no
+            """
+        When I run `ua --version` as non-root
+        Then I will see the uaclient version on stdout with overlay info
+        When I run `ua version` as non-root
+        Then I will see the uaclient version on stdout with overlay info
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
 
     @series.trusty
     Scenario: Attached disable of different services in a trusty machine
@@ -113,133 +258,6 @@ Feature: Command behaviour when attached to an UA subscription
             -32768 https://esm.ubuntu.com/ubuntu/ trusty-infra-security/main amd64 Packages
             """
 
-    @series.trusty
-    Scenario: Attached detach in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua detach` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua detach --assume-yes` with sudo
-        Then I will see the following on stdout:
-            """
-            Detach will disable the following service:
-                esm-infra
-            Updating package lists
-            This machine is now detached
-            """
-       When I run `ua status --all` as non-root
-       Then stdout matches regexp:
-           """
-           SERVICE       AVAILABLE  DESCRIPTION
-           cc-eal        +no         +Common Criteria EAL2 Provisioning Packages
-           esm-apps      +no         +UA Apps: Extended Security Maintenance
-           esm-infra     +yes        +UA Infra: Extended Security Maintenance
-           fips          +no         +NIST-certified FIPS modules
-           fips-updates  +no         +Uncertified security updates to FIPS modules
-           livepatch     +yes        +Canonical Livepatch service
-           """
-       And stdout matches regexp:
-          """
-          This machine is not attached to a UA subscription.
-          """
-
-    @series.trusty
-    Scenario: Attached auto-attach in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua auto-attach` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua auto-attach` with sudo
-        Then stderr matches regexp:
-            """
-            This machine is already attached
-            """
-
-    @series.trusty
-    Scenario: Attached show version in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua version` as non-root
-        Then I will see the uaclient version on stdout
-        When I run `ua version` with sudo
-        Then I will see the uaclient version on stdout
-        When I run `ua --version` as non-root
-        Then I will see the uaclient version on stdout
-        When I run `ua --version` with sudo
-        Then I will see the uaclient version on stdout
-
-    @series.trusty
-    Scenario: Unattached status in a trusty machine with machine token overlay
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
-        """
-        {
-            "machineTokenInfo": {
-                "contractInfo": {
-                    "resourceEntitlements": [
-                        {
-                            "type": "cc-eal",
-                            "entitled": false
-                        }
-                    ]
-                }
-            }
-        }
-        """
-        And I append the following on uaclient config:
-        """
-        features:
-          machine_token_overlay: "/tmp/machine-token-overlay.json"
-        """
-        And I attach `contract_token` with sudo
-        And I run `ua status --all` with sudo
-        Then stdout matches regexp:
-            """
-            SERVICE       ENTITLED  STATUS    DESCRIPTION
-            cc-eal        no
-            """
-        When I run `ua --version` as non-root
-        Then I will see the uaclient version on stdout with overlay info
-        When I run `ua version` as non-root
-        Then I will see the uaclient version on stdout with overlay info
-
-   @series.focal
-   Scenario: Attached refresh in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua refresh` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua refresh` with sudo
-        Then I will see the following on stdout:
-            """
-            Successfully refreshed your subscription
-            """
-
-    @series.focal
-    Scenario: Attached disable of an already disabled service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua disable livepatch` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable livepatch` with sudo
-        Then I will see the following on stdout:
-            """
-            Livepatch is not currently enabled
-            See: sudo ua status
-            """
-
     @series.focal
     Scenario: Attached disable of an already disabled, enabled and not found services
         Given a `focal` machine with ubuntu-advantage-tools installed
@@ -268,23 +286,6 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
     @series.focal
-    Scenario: Attached disable of an unknown service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua disable foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua disable foobar` with sudo
-        Then stderr matches regexp:
-
-            """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
-            """
-
-    @series.focal
     Scenario: Attached disable of an already enabled service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -303,99 +304,3 @@ Feature: Command behaviour when attached to an UA subscription
             """
             esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance
             """
-
-    @series.focal
-    Scenario: Attached detach in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua detach` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua detach --assume-yes` with sudo
-        Then I will see the following on stdout:
-            """
-            Detach will disable the following service:
-                esm-infra
-            Updating package lists
-            This machine is now detached
-            """
-       When I run `ua status --all` as non-root
-       Then stdout matches regexp:
-           """
-           SERVICE       AVAILABLE  DESCRIPTION
-           cc-eal        +no         +Common Criteria EAL2 Provisioning Packages
-           esm-apps      +yes        +UA Apps: Extended Security Maintenance
-           esm-infra     +yes        +UA Infra: Extended Security Maintenance
-           fips          +no         +NIST-certified FIPS modules
-           fips-updates  +no         +Uncertified security updates to FIPS modules
-           livepatch     +yes        +Canonical Livepatch service
-           """
-       And stdout matches regexp:
-          """
-          This machine is not attached to a UA subscription.
-          """
-
-    @series.focal
-    Scenario: Attached auto-attach in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua auto-attach` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua auto-attach` with sudo
-        Then stderr matches regexp:
-            """
-            This machine is already attached
-            """
-
-    @series.focal
-    Scenario: Attached show version in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua version` as non-root
-        Then I will see the uaclient version on stdout
-        When I run `ua version` with sudo
-        Then I will see the uaclient version on stdout
-        When I run `ua --version` as non-root
-        Then I will see the uaclient version on stdout
-        When I run `ua --version` with sudo
-        Then I will see the uaclient version on stdout
-
-    @series.focal
-    Scenario: Unattached status in a focal machine with machine token overlay
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
-        """
-        {
-            "machineTokenInfo": {
-                "contractInfo": {
-                    "resourceEntitlements": [
-                        {
-                            "type": "cc-eal",
-                            "entitled": false
-                        }
-                    ]
-                }
-            }
-        }
-        """
-        And I append the following on uaclient config:
-        """
-        features:
-          machine_token_overlay: "/tmp/machine-token-overlay.json"
-        """
-        And I attach `contract_token` with sudo
-        And I run `ua status --all` with sudo
-        Then stdout matches regexp:
-            """
-            SERVICE       ENTITLED  STATUS    DESCRIPTION
-            cc-eal        no
-            """
-        When I run `ua --version` as non-root
-        Then I will see the uaclient version on stdout with overlay info
-        When I run `ua version` as non-root
-        Then I will see the uaclient version on stdout with overlay info

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -132,10 +132,10 @@ Feature: Enable command behaviour when attached to an UA subscription
            | trusty  |
            | xenial  |
 
-    @series.trusty
+    @series.all
     @uses.config.machine_type.lxd.container
-    Scenario Outline:  Attached enable of non-container services in a trusty lxd container
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+    Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
@@ -150,14 +150,23 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: Un-supported services in containers
-           | service      | title        | flag                 |
-           | livepatch    | Livepatch    |                      |
-           | fips         | FIPS         | --assume-yes --beta  |
-           | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | release | service      | title        | flag                 |
+           | bionic  | livepatch    | Livepatch    |                      |
+           | bionic  | fips         | FIPS         | --assume-yes --beta  |
+           | bionic  | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | focal   | livepatch    | Livepatch    |                      |
+           | focal   | fips         | FIPS         | --assume-yes --beta  |
+           | focal   | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | trusty  | livepatch    | Livepatch    |                      |
+           | trusty  | fips         | FIPS         | --assume-yes --beta  |
+           | trusty  | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | xenial  | livepatch    | Livepatch    |                      |
+           | xenial  | fips         | FIPS         | --assume-yes --beta  |
+           | xenial  | fips-updates | FIPS Updates | --assume-yes --beta  |
 
-    @series.trusty
-    Scenario Outline:  Attached enable of non-container beta services in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline:  Attached enable of non-container beta services in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service> <flag>` as non-root
         Then I will see the following on stderr:
@@ -169,20 +178,26 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             One moment, checking your subscription first
             """
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
             Cannot enable '<service>'
             For a list of services see: sudo ua status
             """
 
         Examples: beta services in containers
-           | service      | flag         |
-           | fips         | --assume-yes |
-           | fips-updates | --assume-yes |
+           | release | service      | flag         |
+           | bionic  | fips         | --assume-yes |
+           | bionic  | fips-updates | --assume-yes |
+           | focal   | fips         | --assume-yes |
+           | focal   | fips-updates | --assume-yes |
+           | trusty  | fips         | --assume-yes |
+           | trusty  | fips-updates | --assume-yes |
+           | xenial  | fips         | --assume-yes |
+           | xenial  | fips-updates | --assume-yes |
 
-    @series.trusty
-    Scenario Outline: Attached enable not entitled service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Attached enable not entitled service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua enable <service>` as non-root
         Then I will see the following on stderr:
@@ -198,9 +213,15 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: not entitled services
-           | service      | title        |
-           | cis-audit    | CIS Audit    |
-           | esm-apps     | ESM Apps     |
+           | release | service      | title        |
+           | bionic  | cis-audit    | CIS Audit    |
+           | bionic  | esm-apps     | ESM Apps     |
+           | focal   | cis-audit    | CIS Audit    |
+           | focal   | esm-apps     | ESM Apps     |
+           | trusty  | cis-audit    | CIS Audit    |
+           | trusty  | esm-apps     | ESM Apps     |
+           | xenial  | cis-audit    | CIS Audit    |
+           | xenial  | esm-apps     | ESM Apps     |
 
     @series.focal
     @uses.config.machine_type.lxd.vm
@@ -245,73 +266,3 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS enabled
             A reboot is required to complete install
             """
-
-    @series.focal
-    @uses.config.machine_type.lxd.container
-    Scenario Outline: Attached enable of vm-based services in a focal lxd container
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable <service> <flag>` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable <service> <flag>` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install <title> on a container
-            """
-
-        Examples: Un-supported services in containers
-           | service      | title        | flag                 |
-           | livepatch    | Livepatch    |                      |
-           | fips         | FIPS         | --assume-yes --beta  |
-           | fips-updates | FIPS Updates | --assume-yes --beta  |
-
-    @series.focal
-    Scenario Outline:  Attached enable of vm-only beta services in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable <service> <flag>` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable <service> <flag>` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable '<service>'
-            For a list of services see: sudo ua status
-            """
-
-        Examples: beta services in containers
-           | service      | flag         |
-           | fips         | --assume-yes |
-           | fips-updates | --assume-yes |
-
-    @series.focal
-    Scenario Outline: Attached enable not entitled service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable <service>` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable <service> --beta` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            This subscription is not entitled to <title>.
-            For more information see: https://ubuntu.com/advantage
-            """
-
-        Examples: not entitled services
-           | service      | title        |
-           | cis-audit    | CIS Audit    |
-           | esm-apps     | ESM Apps     |

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1,6 +1,137 @@
 @uses.config.contract_token
 Feature: Enable command behaviour when attached to an UA subscription
 
+    @series.all
+    Scenario Outline: Attached enable Common Criteria service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable cc-eal` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable cc-eal --beta` with sudo
+        Then I will see the following on stdout
+            """
+            One moment, checking your subscription first
+            <msg>
+            """
+
+        Examples: ubuntu release
+           | release | msg                                                            |
+           | bionic  | CC EAL2 is not available for Ubuntu 18.04 LTS (Bionic Beaver). |
+           | focal   | CC EAL2 is not available for Ubuntu 20.04 LTS (Focal Fossa).   |
+           | trusty  | CC EAL2 is not available for Ubuntu 14.04 LTS (Trusty Tahr).   |
+
+    @series.all
+    Scenario Outline: Attached enable a disabled beta service and unknown service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable fips foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable fips foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable 'foobar, fips'
+            For a list of services see: sudo ua status
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached enable of an unknown service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        Then stderr matches regexp:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    Scenario Outline: Attached enable of a known service already enabled (UA Infra) in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable esm-infra` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable esm-infra` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            ESM Infra is already enabled.
+            See: sudo ua status
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.all
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached enable a disabled, enable and unknown service in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua enable livepatch esm-infra foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua enable livepatch esm-infra foobar` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install Livepatch on a container
+            ESM Infra is already enabled.
+            See: sudo ua status
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
     @series.trusty
     @uses.config.machine_type.lxd.container
     Scenario Outline:  Attached enable of non-container services in a trusty lxd container
@@ -50,22 +181,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | --assume-yes |
 
     @series.trusty
-    Scenario: Attached enable Common Criteria service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable cc-eal` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable cc-eal --beta` with sudo
-        Then I will see the following on stdout
-            """
-            One moment, checking your subscription first
-            CC EAL2 is not available for Ubuntu 14.04 LTS (Trusty Tahr).
-            """
-
-    @series.trusty
     Scenario Outline: Attached enable not entitled service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -86,86 +201,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | service      | title        |
            | cis-audit    | CIS Audit    |
            | esm-apps     | ESM Apps     |
-
-    @series.trusty
-    Scenario: Attached enable of an unknown service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable foobar` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And I will see the following on stderr:
-            """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
-            """
-
-    @series.trusty
-    Scenario: Attached enable of a known service already enabled (UA Infra) in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable esm-infra` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable esm-infra` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            ESM Infra is already enabled.
-            See: sudo ua status
-            """
-
-    @series.trusty
-    Scenario: Attached enable a disabled, enable and unknown service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable livepatch esm-infra foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable livepatch esm-infra foobar` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install Livepatch on a container
-            ESM Infra is already enabled.
-            See: sudo ua status
-            """
-        And I will see the following on stderr:
-            """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
-            """
-
-    @series.trusty
-    Scenario: Attached enable a disabled beta service and unknown service in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable fips foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable fips foobar` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable 'foobar, fips'
-            For a list of services see: sudo ua status
-            """
 
     @series.focal
     @uses.config.machine_type.lxd.vm
@@ -260,22 +295,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | fips-updates | --assume-yes |
 
     @series.focal
-    Scenario: Attached enable Common Criteria service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable cc-eal` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable cc-eal --beta` with sudo
-        Then I will see the following on stdout
-            """
-            One moment, checking your subscription first
-            CC EAL2 is not available for Ubuntu 20.04 LTS (Focal Fossa).
-            """
-
-    @series.focal
     Scenario Outline: Attached enable not entitled service in a focal machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -296,80 +315,3 @@ Feature: Enable command behaviour when attached to an UA subscription
            | service      | title        |
            | cis-audit    | CIS Audit    |
            | esm-apps     | ESM Apps     |
-
-    @series.focal
-    Scenario: Attached enable of an unknown service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable foobar` with sudo
-        Then stderr matches regexp:
-            """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
-            """
-
-    @series.focal
-    Scenario: Attached enable of a known service already enabled (UA Infra) in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable esm-infra` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable esm-infra` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            ESM Infra is already enabled.
-            See: sudo ua status
-            """
-
-    @series.focal
-    @uses.config.machine_type.lxd.container
-    Scenario: Attached enable a disabled, enabled and unknown service in a focal lxd container
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable livepatch esm-infra foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable livepatch esm-infra foobar` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install Livepatch on a container
-            ESM Infra is already enabled.
-            See: sudo ua status
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
-            """
-
-    @series.focal
-    Scenario: Attached enable a disabled beta service and unknown service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua enable fips foobar` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua enable fips foobar` with sudo
-        Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable 'foobar, fips'
-            For a list of services see: sudo ua status
-	    """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -19,9 +19,9 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release | msg                                                            |
+           | trusty  | CC EAL2 is not available for Ubuntu 14.04 LTS (Trusty Tahr).   |
            | bionic  | CC EAL2 is not available for Ubuntu 18.04 LTS (Bionic Beaver). |
            | focal   | CC EAL2 is not available for Ubuntu 20.04 LTS (Focal Fossa).   |
-           | trusty  | CC EAL2 is not available for Ubuntu 14.04 LTS (Trusty Tahr).   |
 
     @series.all
     Scenario Outline: Attached enable a disabled beta service and unknown service in a ubuntu machine
@@ -45,10 +45,10 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached enable of an unknown service in a ubuntu machine
@@ -72,10 +72,10 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     Scenario Outline: Attached enable of a known service already enabled (UA Infra) in a ubuntu machine
@@ -96,10 +96,10 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -127,10 +127,10 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: ubuntu release
            | release |
-           | bionic  |
-           | focal   |
            | trusty  |
            | xenial  |
+           | bionic  |
+           | focal   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -151,18 +151,18 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: Un-supported services in containers
            | release | service      | title        | flag                 |
-           | bionic  | livepatch    | Livepatch    |                      |
-           | bionic  | fips         | FIPS         | --assume-yes --beta  |
-           | bionic  | fips-updates | FIPS Updates | --assume-yes --beta  |
-           | focal   | livepatch    | Livepatch    |                      |
-           | focal   | fips         | FIPS         | --assume-yes --beta  |
-           | focal   | fips-updates | FIPS Updates | --assume-yes --beta  |
            | trusty  | livepatch    | Livepatch    |                      |
            | trusty  | fips         | FIPS         | --assume-yes --beta  |
            | trusty  | fips-updates | FIPS Updates | --assume-yes --beta  |
            | xenial  | livepatch    | Livepatch    |                      |
            | xenial  | fips         | FIPS         | --assume-yes --beta  |
            | xenial  | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | bionic  | livepatch    | Livepatch    |                      |
+           | bionic  | fips         | FIPS         | --assume-yes --beta  |
+           | bionic  | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | focal   | livepatch    | Livepatch    |                      |
+           | focal   | fips         | FIPS         | --assume-yes --beta  |
+           | focal   | fips-updates | FIPS Updates | --assume-yes --beta  |
 
     @series.all
     Scenario Outline:  Attached enable of non-container beta services in a ubuntu machine
@@ -186,14 +186,14 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: beta services in containers
            | release | service      | flag         |
-           | bionic  | fips         | --assume-yes |
-           | bionic  | fips-updates | --assume-yes |
-           | focal   | fips         | --assume-yes |
-           | focal   | fips-updates | --assume-yes |
            | trusty  | fips         | --assume-yes |
            | trusty  | fips-updates | --assume-yes |
            | xenial  | fips         | --assume-yes |
            | xenial  | fips-updates | --assume-yes |
+           | bionic  | fips         | --assume-yes |
+           | bionic  | fips-updates | --assume-yes |
+           | focal   | fips         | --assume-yes |
+           | focal   | fips-updates | --assume-yes |
 
     @series.all
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
@@ -214,14 +214,14 @@ Feature: Enable command behaviour when attached to an UA subscription
 
         Examples: not entitled services
            | release | service      | title        |
-           | bionic  | cis-audit    | CIS Audit    |
-           | bionic  | esm-apps     | ESM Apps     |
-           | focal   | cis-audit    | CIS Audit    |
-           | focal   | esm-apps     | ESM Apps     |
            | trusty  | cis-audit    | CIS Audit    |
            | trusty  | esm-apps     | ESM Apps     |
            | xenial  | cis-audit    | CIS Audit    |
            | xenial  | esm-apps     | ESM Apps     |
+           | bionic  | cis-audit    | CIS Audit    |
+           | bionic  | esm-apps     | ESM Apps     |
+           | focal   | cis-audit    | CIS Audit    |
+           | focal   | esm-apps     | ESM Apps     |
 
     @series.focal
     @uses.config.machine_type.lxd.vm

--- a/features/environment.py
+++ b/features/environment.py
@@ -31,6 +31,7 @@ class UAClientBehaveConfig:
         A valid contract token to use during attach scenarios
     :param contract_token_staging:
         A valid staging contract token to use during attach scenarios
+    :param cmdline_tags: Tags used to control which scenarios will be executed
     :param image_clean:
         This indicates whether the image created for this test run should be
         cleaned up when all tests are complete.

--- a/features/environment.py
+++ b/features/environment.py
@@ -16,6 +16,7 @@ from features.util import (
 )
 
 PR_DEB_FILE = "/tmp/ubuntu-advantage.deb"
+ALL_SUPPORTED_SERIES = ["bionic", "focal", "trusty", "xenial"]
 
 
 class UAClientBehaveConfig:
@@ -211,8 +212,14 @@ def before_scenario(context: Context, scenario: Scenario):
                     reason="TODO: cannot test trusty using lxd.vm GH: #1088"
                 )
                 return
-            if series not in context.series_image_name:
-                create_uat_lxd_image(context, series)
+            elif series == "all":
+                series = ALL_SUPPORTED_SERIES
+            else:
+                series = [series]
+
+            for release in series:
+                if release not in context.series_image_name:
+                    create_uat_lxd_image(context, release)
 
 
 def after_all(context):
@@ -244,7 +251,7 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
     """Create a given series lxd image with ubuntu-advantage-tools installed
 
     This will launch a container, install ubuntu-advantage-tools, and publish
-    the image.    The image's name is stored in context.series_image_name for
+    the image. The image's name is stored in context.series_image_name for
     use within step code.
 
     :param context:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -14,6 +14,17 @@ CONTAINER_PREFIX = "behave-test-"
 
 @given("a `{series}` machine with ubuntu-advantage-tools installed")
 def given_a_machine(context, series):
+    filter_series = context.config.filter_series
+    if filter_series and series not in filter_series:
+        context.scenario.skip(
+            reason=(
+                "Skipping scenario outline series {series}."
+                " Cmdline provided @series tags: {cmdline_series}".format(
+                    series=series, cmdline_series=filter_series
+                )
+            )
+        )
+        return
     if series in context.reuse_container:
         context.container_name = context.reuse_container[series]
     else:

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,5 +1,27 @@
 Feature: Command behaviour when unattached
 
+    @series.all
+    Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `ua auto-attach` as non-root
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo)
+            """
+        When I run `ua auto-attach` with sudo
+        Then stderr matches regexp:
+            """
+            Auto-attach image support is not available on <data>
+            See: https://ubuntu.com/advantage
+            """
+
+        Examples: ubuntu release
+           | release | data       |
+           | bionic  | lxd        |
+           | focal   | lxd        |
+           | trusty  | nocloudnet |
+           | xenial  | lxd        |
+
     @series.trusty
     Scenario Outline: Unattached commands that requires enabled user in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
@@ -42,21 +64,6 @@ Feature: Command behaviour when unattached
            | disable  | livepatch |
            | enable   | unknown   |
            | disable  | unknown   |
-
-    @series.trusty
-    Scenario: Unattached auto-attach does nothing in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I run `ua auto-attach` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua auto-attach` with sudo
-        Then stderr matches regexp:
-            """
-            Auto-attach image support is not available on nocloudnet
-            See: https://ubuntu.com/advantage
-            """
 
     @series.focal
     Scenario Outline: Unattached commands that requires enabled user in a focal machine
@@ -101,18 +108,3 @@ Feature: Command behaviour when unattached
            | enable  | livepatch |
            | disable | unknown   |
            | enable  | unknown   |
-
-    @series.focal
-    Scenario: Unattached auto-attach does nothing in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I run `ua auto-attach` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua auto-attach` with sudo
-        Then stderr matches regexp:
-            """
-            Auto-attach image support is not available on lxd
-            See: https://ubuntu.com/advantage
-            """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -17,10 +17,10 @@ Feature: Command behaviour when unattached
 
         Examples: ubuntu release
            | release | data       |
-           | bionic  | lxd        |
-           | focal   | lxd        |
            | trusty  | nocloudnet |
            | xenial  | lxd        |
+           | bionic  | lxd        |
+           | focal   | lxd        |
 
     @series.all
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
@@ -39,14 +39,14 @@ Feature: Command behaviour when unattached
 
         Examples: ua commands
            | release | command |
-           | bionic  | detach  |
-           | bionic  | refresh |
-           | focal   | detach  |
-           | focal   | refresh |
            | trusty  | detach  |
            | trusty  | refresh |
            | xenial  | detach  |
            | xenial  | refresh |
+           | bionic  | detach  |
+           | bionic  | refresh |
+           | focal   | detach  |
+           | focal   | refresh |
 
     @series.all
     Scenario Outline: Unattached command known and unknown services in a ubuntu machine
@@ -66,14 +66,6 @@ Feature: Command behaviour when unattached
 
         Examples: ua commands
            | release | command  | service   |
-           | bionic  | enable   | livepatch |
-           | bionic  | disable  | livepatch |
-           | bionic  | enable   | unknown   |
-           | bionic  | disable  | unknown   |
-           | focal   | enable   | livepatch |
-           | focal   | disable  | livepatch |
-           | focal   | enable   | unknown   |
-           | focal   | disable  | unknown   |
            | trusty  | enable   | livepatch |
            | trusty  | disable  | livepatch |
            | trusty  | enable   | unknown   |
@@ -82,3 +74,11 @@ Feature: Command behaviour when unattached
            | xenial  | disable  | livepatch |
            | xenial  | enable   | unknown   |
            | xenial  | disable  | unknown   |
+           | bionic  | enable   | livepatch |
+           | bionic  | disable  | livepatch |
+           | bionic  | enable   | unknown   |
+           | bionic  | disable  | unknown   |
+           | focal   | enable   | livepatch |
+           | focal   | disable  | livepatch |
+           | focal   | enable   | unknown   |
+           | focal   | disable  | unknown   |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -22,52 +22,9 @@ Feature: Command behaviour when unattached
            | trusty  | nocloudnet |
            | xenial  | lxd        |
 
-    @series.trusty
-    Scenario Outline: Unattached commands that requires enabled user in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I run `ua <command>` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua <command>` with sudo
-        Then I will see the following on stderr:
-            """
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
-
-        Examples: ua commands
-           | command |
-           | detach  |
-           | refresh |
-
-    @series.trusty
-    Scenario Outline: Unattached command known and unknown services in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
-        When I run `ua <command> livepatch` as non-root
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        When I run `ua <command> <service>` with sudo
-        Then I will see the following on stderr:
-            """
-            To use '<service>' you need an Ubuntu Advantage subscription
-            Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
-            """
-
-        Examples: ua commands
-           | command  | service   | 
-           | enable   | livepatch |
-           | disable  | livepatch |
-           | enable   | unknown   |
-           | disable  | unknown   |
-
-    @series.focal
-    Scenario Outline: Unattached commands that requires enabled user in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua <command>` as non-root
         Then I will see the following on stderr:
             """
@@ -81,14 +38,19 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command |
-           | detach  |
-           | refresh |
+           | release | command |
+           | bionic  | detach  |
+           | bionic  | refresh |
+           | focal   | detach  |
+           | focal   | refresh |
+           | trusty  | detach  |
+           | trusty  | refresh |
+           | xenial  | detach  |
+           | xenial  | refresh |
 
-
-    @series.focal
-    Scenario Outline: Unattached command of a known service in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Unattached command known and unknown services in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua <command> livepatch` as non-root
         Then I will see the following on stderr:
             """
@@ -103,8 +65,20 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ua commands
-           | command | service   |
-           | disable | livepatch |
-           | enable  | livepatch |
-           | disable | unknown   |
-           | enable  | unknown   |
+           | release | command  | service   |
+           | bionic  | enable   | livepatch |
+           | bionic  | disable  | livepatch |
+           | bionic  | enable   | unknown   |
+           | bionic  | disable  | unknown   |
+           | focal   | enable   | livepatch |
+           | focal   | disable  | livepatch |
+           | focal   | enable   | unknown   |
+           | focal   | disable  | unknown   |
+           | trusty  | enable   | livepatch |
+           | trusty  | disable  | livepatch |
+           | trusty  | enable   | unknown   |
+           | trusty  | disable  | unknown   |
+           | xenial  | enable   | livepatch |
+           | xenial  | disable  | livepatch |
+           | xenial  | enable   | unknown   |
+           | xenial  | disable  | unknown   |

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -75,7 +75,7 @@ Feature: Unattached status
 
         Examples: ubuntu release
            | release | esm-apps | cc-eal | fips | fips-update |
-           | bionic  | yes      | no     | yes  | yes         |
-           | focal   | yes      | no     | no   | no          |
            | trusty  | no       | no     | no   | no          |
            | xenial  | yes      | yes    | yes  | yes         |
+           | bionic  | yes      | no     | yes  | yes         |
+           | focal   | yes      | no     | no   | no          |

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,13 +1,13 @@
 Feature: Unattached status
 
-    @series.trusty
-    Scenario: Unattached status in a trusty machine
-        Given a `trusty` machine with ubuntu-advantage-tools installed
+    @series.all
+    Scenario Outline: Unattached status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua status` as non-root
-        Then I will see the following on stdout:
+        Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            esm-apps      no         UA Apps: Extended Security Maintenance
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
 
@@ -15,24 +15,24 @@ Feature: Unattached status
             See https://ubuntu.com/advantage
             """
         When I run `ua status --all` as non-root
-        Then I will see the following on stdout:
+        Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
-            esm-apps      no         UA Apps: Extended Security Maintenance
+            cc-eal        <cc-eal>    +Common Criteria EAL2 Provisioning Packages
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
-            fips          no         NIST-certified FIPS modules
-            fips-updates  no         Uncertified security updates to FIPS modules
+            fips          <fips>      +NIST-certified FIPS modules
+            fips-updates  <fips>      +Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
         When I run `ua status` with sudo
-        Then I will see the following on stdout:
+        Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            esm-apps      no         UA Apps: Extended Security Maintenance
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
 
@@ -40,14 +40,14 @@ Feature: Unattached status
             See https://ubuntu.com/advantage
             """
         When I run `ua status --all` with sudo
-        Then I will see the following on stdout:
+        Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
-            esm-apps      no         UA Apps: Extended Security Maintenance
+            cc-eal        <cc-eal>    +Common Criteria EAL2 Provisioning Packages
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
-            fips          no         NIST-certified FIPS modules
-            fips-updates  no         Uncertified security updates to FIPS modules
+            fips          <fips>      +NIST-certified FIPS modules
+            fips-updates  <fips>      +Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
@@ -59,89 +59,23 @@ Feature: Unattached status
               allow_beta: true
             """
         And I run `ua status` as non-root
-        Then I will see the following on stdout:
+        Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
-            esm-apps      no         UA Apps: Extended Security Maintenance
+            cc-eal        <cc-eal>    +Common Criteria EAL2 Provisioning Packages
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
-            fips          no         NIST-certified FIPS modules
-            fips-updates  no         Uncertified security updates to FIPS modules
+            fips          <fips>      +NIST-certified FIPS modules
+            fips-updates  <fips>      +Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """ 
-    
-    @series.focal
-    Scenario: Unattached status in a focal machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
-        When I run `ua status` as non-root
-        Then I will see the following on stdout:
-            """
-            SERVICE       AVAILABLE  DESCRIPTION
-            esm-apps      yes        UA Apps: Extended Security Maintenance
-            esm-infra     yes        UA Infra: Extended Security Maintenance
-            livepatch     yes        Canonical Livepatch service
 
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
-        When I run `ua status --all` as non-root
-        Then I will see the following on stdout:
-            """
-            SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
-            esm-apps      yes        UA Apps: Extended Security Maintenance
-            esm-infra     yes        UA Infra: Extended Security Maintenance
-            fips          no         NIST-certified FIPS modules
-            fips-updates  no         Uncertified security updates to FIPS modules
-            livepatch     yes        Canonical Livepatch service
-
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
-        When I run `ua status` with sudo
-        Then I will see the following on stdout:
-            """
-            SERVICE       AVAILABLE  DESCRIPTION
-            esm-apps      yes        UA Apps: Extended Security Maintenance
-            esm-infra     yes        UA Infra: Extended Security Maintenance
-            livepatch     yes        Canonical Livepatch service
-
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
-        When I run `ua status --all` with sudo
-        Then I will see the following on stdout:
-            """
-            SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
-            esm-apps      yes        UA Apps: Extended Security Maintenance
-            esm-infra     yes        UA Infra: Extended Security Maintenance
-            fips          no         NIST-certified FIPS modules
-            fips-updates  no         Uncertified security updates to FIPS modules
-            livepatch     yes        Canonical Livepatch service
-
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
-        When I append the following on uaclient config:
-            """
-            features:
-              allow_beta: true
-            """
-        And I run `ua status` as non-root
-        Then I will see the following on stdout:
-            """
-            SERVICE       AVAILABLE  DESCRIPTION
-            cc-eal        no         Common Criteria EAL2 Provisioning Packages
-            esm-apps      yes        UA Apps: Extended Security Maintenance
-            esm-infra     yes        UA Infra: Extended Security Maintenance
-            fips          no         NIST-certified FIPS modules
-            fips-updates  no         Uncertified security updates to FIPS modules
-            livepatch     yes        Canonical Livepatch service
-
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
-            """
+        Examples: ubuntu release
+           | release | esm-apps | cc-eal | fips | fips-update |
+           | bionic  | yes      | no     | yes  | yes         |
+           | focal   | yes      | no     | no   | no          |
+           | trusty  | no       | no     | no   | no          |
+           | xenial  | yes      | yes    | yes  | yes         |

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,10 @@ commands =
     mypy: mypy --python-version 3.6 uaclient/ features/
     mypy: mypy --python-version 3.7 uaclient/ features/
     black: black --check --diff uaclient/ features/ setup.py
-    behave: behave --verbose {posargs}
+    behave-14.04: behave --no-skipped --verbose {posargs} --tags="@series.trusty, @series.all"
+    behave-16.04: behave --no-skipped --verbose {posargs} --tags="@series.xenial, @series.all"
+    behave-18.04: behave --no-skipped --verbose {posargs} --tags="@series.bionic, @series.all"
+    behave-20.04: behave --no-skipped --verbose {posargs} --tags="@series.focal, @series.all"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
Right now, our behave tests maunly cover trusty and focal releases. We are creating a new way to allow our behave test to perform test on all 4 releases we want to support (Bionic, Focal, Trusty and Xenial)

This is still a WIP, since there are still tests that need to be converted and some test that may need to be updated, as this behave [issue](https://github.com/behave/behave/issues/847) states.

However, this PR already has the initial idea for how we can reuse tests for multiple ubuntu releases