### PR TITLE
Add back release info to published vms

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -229,13 +229,15 @@ Feature: Enable command behaviour when attached to an UA subscription
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `ua enable fips --assume-yes --beta` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
+            One moment, checking your subscription first
             FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
         When I run `ua enable fips-updates --assume-yes --beta` with sudo
-        Then stdout matches regexp:
+        Then I will see the following on stdout:
             """
+            One moment, checking your subscription first
             FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
 

--- a/features/util.py
+++ b/features/util.py
@@ -71,6 +71,16 @@ def launch_lxd_container(
         command.extend(["--profile", VM_PROFILE_TMPL.format(series), "--vm"])
     subprocess.run(command)
 
+    if is_vm:
+        """ When we publish vm images we end up loosing the image information.
+        Since we need at least the release information to reuse the vm instance
+        in other tests, we are adding this information back here."""
+        subprocess.run(["lxc", "stop", container_name])
+        subprocess.run(
+            ["lxc", "config", "set", container_name, "image.release", series]
+        )
+        subprocess.run(["lxc", "start", container_name])
+
     def cleanup_container() -> None:
         if not context.config.destroy_instances:
             print("Leaving lxd container running: {}".format(container_name))
@@ -172,7 +182,7 @@ def lxc_create_vm_profile(series: str):
             series=series,
         )
     elif series == "focal":
-        content = content_tmpl.format(vendordata="config: {}")
+        content = content_tmpl.format(vendordata="config: {}", series=series)
     else:
         raise RuntimeError(
             "===No lxc mv support for series {}====".format(series)

--- a/features/util.py
+++ b/features/util.py
@@ -72,7 +72,7 @@ def launch_lxd_container(
     subprocess.run(command)
 
     if is_vm:
-        """ When we publish vm images we end up loosing the image information.
+        """ When we publish vm images we end up losing the image information.
         Since we need at least the release information to reuse the vm instance
         in other tests, we are adding this information back here."""
         subprocess.run(["lxc", "stop", container_name])


### PR DESCRIPTION
Since the vms test are costly to create, when developing new vm behave tests, it is really useful to be able to reuse them.

We found out that the issue is that when we publish the vm images locally, we end-up losing the image information on it. This PR adds a way to bring back at least the `image.release` info back into the image, since this is the info we need to reuse it.

Fixes: #1111