### PR TITLE
tests: add aws pro integration coverage for daily PPA

### DIFF
--- a/features/aws-ids.yaml
+++ b/features/aws-ids.yaml
@@ -1,0 +1,4 @@
+bionic: ami-0e11aa8c6a6d58146
+focal: ami-0383ece2c0f6de239
+trusty: ami-0a64b4493bc9dc321
+xenial: ami-09e110a448d322f4a

--- a/features/environment.py
+++ b/features/environment.py
@@ -3,14 +3,18 @@ import os
 import itertools
 import subprocess
 import textwrap
+import logging
 from typing import Dict, Optional, Union, List
 
 from behave.model import Feature, Scenario
 
 from behave.runner import Context
 
+import pycloudlib  # type: ignore
+
 from features.util import (
     launch_lxd_container,
+    launch_ec2,
     lxc_exec,
     lxc_get_property,
     lxc_build_deb,
@@ -18,6 +22,22 @@ from features.util import (
 
 PR_DEB_FILE = "/tmp/ubuntu-advantage.deb"
 ALL_SUPPORTED_SERIES = ["bionic", "focal", "trusty", "xenial"]
+
+EC2_KEY_FILE = "uaclient.pem"
+
+DAILY_PPA = "http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu"
+
+USERDATA_INSTALL_DAILY_PRO_UATOOLS = """\
+#cloud-config
+apt:
+  sources:
+    ua-tools-daily:
+        source: "deb {daily_ppa} $RELEASE main"
+        keyid: 8A295C4FB8B190B7
+packages: [ubuntu-advantage-tools, ubuntu-advantage-pro]
+""".format(
+    daily_ppa=DAILY_PPA
+)
 
 
 class UAClientBehaveConfig:
@@ -35,7 +55,7 @@ class UAClientBehaveConfig:
         This indicates whether the image created for this test run should be
         cleaned up when all tests are complete.
     :param machine_type:
-        The default machine_type to test: lxd.container or lxd.vm
+        The default machine_type to test: lxd.container, lxd.vm or pro.aws
     :param reuse_image:
         A string with an image name that should be used instead of building a
         fresh image for this test run.   If specified, this image will not be
@@ -52,20 +72,31 @@ class UAClientBehaveConfig:
     # the test framework
     boolean_options = ["build_pr", "image_clean", "destroy_instances"]
     str_options = [
+        "aws_access_key_id",
+        "aws_secret_access_key",
         "contract_token",
         "contract_token_staging",
         "machine_type",
         "reuse_image",
     ]
-    redact_options = ["contract_token", "contract_token_staging"]
+    redact_options = [
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "contract_token",
+        "contract_token_staging",
+    ]
 
     # This variable is used in .from_environ() but also to emit the "Config
     # options" stanza in __init__
     all_options = boolean_options + str_options
 
+    ec2_api = None  # type: pycloudlib.EC2
+
     def __init__(
         self,
         *,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
         build_pr: bool = False,
         image_clean: bool = True,
         destroy_instances: bool = True,
@@ -76,6 +107,8 @@ class UAClientBehaveConfig:
         cmdline_tags: "List" = []
     ) -> None:
         # First, store the values we've detected
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
         self.build_pr = build_pr
         self.contract_token = contract_token
         self.contract_token_staging = contract_token_staging
@@ -104,6 +137,12 @@ class UAClientBehaveConfig:
             if option in self.redact_options and value not in (None, "ERROR"):
                 value = "<REDACTED>"
             print("  {}".format(option), "=", value)
+        has_aws_keys = bool(aws_access_key_id and aws_secret_access_key)
+        if has_aws_keys and self.machine_type != "pro.aws":
+            raise RuntimeError(
+                "Must set UACLIENT_BEHAVE_MACHINE_TYPE=pro.aws if providing"
+                " AWS keys"
+            )
 
     @classmethod
     def from_environ(cls, config) -> "UAClientBehaveConfig":
@@ -139,11 +178,37 @@ class UAClientBehaveConfig:
 def before_all(context: Context) -> None:
     """behave will invoke this before anything else happens."""
     userdata = context.config.userdata
+    if userdata:
+        print("Userdata key / value pairs:")
+        for key, value in context.config.userdata.items():
+            print("   - {} = {}".format(key, value))
     context.series_image_name = {}
     context.series_reuse_image = ""
     context.reuse_container = {}
     context.config = UAClientBehaveConfig.from_environ(context.config)
-
+    has_aws_keys = bool(
+        context.config.aws_access_key_id
+        and context.config.aws_secret_access_key
+    )
+    if has_aws_keys:
+        logging.basicConfig(
+            filename="pycloudlib-behave.log", level=logging.DEBUG
+        )
+        context.config.ec2_api = pycloudlib.EC2(
+            tag="ua-testing",
+            access_key_id=context.config.aws_access_key_id,
+            secret_access_key=context.config.aws_secret_access_key,
+        )
+        ec2_api = context.config.ec2_api
+        if "uaclient-integration" in ec2_api.list_keys():
+            ec2_api.delete_key("uaclient-integration")
+        keypair = ec2_api.client.create_key_pair(
+            KeyName="uaclient-integration"
+        )
+        with open(EC2_KEY_FILE, "w") as stream:
+            stream.write(keypair["KeyMaterial"])
+        os.chmod(EC2_KEY_FILE, 0o600)
+        ec2_api.use_key(EC2_KEY_FILE, EC2_KEY_FILE, "uaclient-integration")
     if context.config.reuse_image:
         series = lxc_get_property(
             context.config.reuse_image, property_name="series", image=True
@@ -163,14 +228,23 @@ def before_all(context: Context) -> None:
             context.config.reuse_image = None
 
     if userdata.get("reuse_container"):
-        series = lxc_get_property(
-            userdata.get("reuse_container"), property_name="series"
-        )
-        machine_type = lxc_get_property(
-            userdata.get("reuse_container"), property_name="machine_type"
-        )
-        if machine_type:
-            print("Found type: {vm_type}".format(vm_type=machine_type))
+        if context.config.ec2_api:
+            inst = context.config.ec2_api.get_instance(
+                userdata.get("reuse_container")
+            )
+            codename = inst.execute(
+                ["grep", "UBUNTU_CODENAME", "/etc/os-release"]
+            ).strip()
+            [_, series] = codename.split("=")
+        else:  # lxd.vm and lxd.container machine_types
+            series = lxc_get_property(
+                userdata.get("reuse_container"), property_name="series"
+            )
+            machine_type = lxc_get_property(
+                userdata.get("reuse_container"), property_name="machine_type"
+            )
+            if machine_type:
+                print("Found type: {vm_type}".format(vm_type=machine_type))
         context.reuse_container = {series: userdata.get("reuse_container")}
         print(
             textwrap.dedent(
@@ -231,7 +305,10 @@ def before_scenario(context: Context, scenario: Scenario):
         releases = releases.intersection(context.config.filter_series)
     for release in releases:
         if release not in context.series_image_name:
-            create_uat_lxd_image(context, release)
+            if context.config.ec2_api:
+                create_uat_ec2_image(context, release)
+            else:
+                create_uat_lxd_image(context, release)
 
 
 def after_all(context):
@@ -257,6 +334,37 @@ def _capture_container_as_image(container_name: str, image_name: str) -> None:
     """
     subprocess.run(["lxc", "stop", container_name])
     subprocess.run(["lxc", "publish", container_name, "--alias", image_name])
+
+
+def create_uat_ec2_image(context: Context, series: str) -> None:
+    """Create an Ubuntu PRO Ec2 instance with latest ubuntu-advantage-tools
+
+    :param context:
+        A `behave.runner.Context` which will have `config.ec2_api` set on it
+    :param series:
+       A string representing the series name to create
+    """
+    if series in context.reuse_container:
+        print(
+            "\n Reusing the existing EC2 instance: {}({}) ".format(
+                context.reuse_container[series], series
+            )
+        )
+        return
+    if context.config.build_pr:
+        raise RuntimeError("Don't yet support ec2 pro build_pr=1")
+
+    # Launch pro image based on series marketplace lookup
+    inst = launch_ec2(
+        context, series=series, user_data=USERDATA_INSTALL_DAILY_PRO_UATOOLS
+    )
+    print("Creating updated AWS PRO AMI from instance: {}".format(inst.id))
+    context.series_image_name[series] = context.config.ec2_api.snapshot(inst)
+    print(
+        "Created updated AWS PRO AMI: {}".format(
+            context.series_image_name[series]
+        )
+    )
 
 
 def create_uat_lxd_image(context: Context, series: str) -> None:
@@ -296,9 +404,9 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
         )
         launch_lxd_container(
             context,
-            ubuntu_series,
-            build_container_name,
             series=series,
+            image_name=ubuntu_series,
+            container_name=build_container_name,
             is_vm=is_vm,
         )
         lxc_build_deb(build_container_name, output_deb_file=deb_file)
@@ -310,9 +418,9 @@ def create_uat_lxd_image(context: Context, series: str) -> None:
 
     launch_lxd_container(
         context,
-        ubuntu_series,
-        build_container_name,
         series=series,
+        image_name=ubuntu_series,
+        container_name=build_container_name,
         is_vm=is_vm,
     )
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -29,6 +29,12 @@ DAILY_PPA = "http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu"
 
 USERDATA_INSTALL_DAILY_PRO_UATOOLS = """\
 #cloud-config
+write_files:
+  - path: /etc/ubuntu-advantage-client
+    content: |
+      features:
+         disable_auto_attach: true
+    append: true
 apt:
   sources:
     ua-tools-daily:

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -19,6 +19,7 @@ Feature: Command behaviour when attached to an UA subscription
             livepatch     +yes      +enabled  +Canonical Livepatch service
             """
         Examples: ubuntu release
-           | release | cc-eal | cc-eal-s | fips | fips-s   |
-           | xenial  | yes    | disabled | yes  | disabled |
-           | bionic  | yes    | n/a      | yes  | disabled |
+           | release | cc-eal | cc-eal-s | fips | fips-s |
+           | xenial  | yes    | disabled | yes  | n/a    |
+           | bionic  | yes    | n/a      | yes  | n/a    |
+           | focal   | yes    | n/a      | yes  | n/a    |

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -1,0 +1,24 @@
+@uses.config.machine_type.pro.aws
+Feature: Command behaviour when attached to an UA subscription
+
+    @series.xenial
+    @series.bionic
+    @series.focal
+    Scenario Outline: Attached refresh in a trusty machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `ua status --all` as non-root
+        Then stdout matches regexp:
+            """
+            SERVICE       ENTITLED  STATUS    DESCRIPTION
+            cc-eal        +<cc-eal> +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
+            cis-audit     +no       +—    +Center for Internet Security Audit Tools
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance
+            esm-infra     +yes     +enabled +UA Infra: Extended Security Maintenance
+            fips          +<fips> +<fips-s> +NIST-certified FIPS modules
+            fips-updates  +<fips> +<fips-s> +Uncertified security updates to FIPS modules
+            livepatch     +yes      +enabled  +Canonical Livepatch service
+            """
+        Examples: ubuntu release
+           | release | cc-eal | cc-eal-s | fips | fips-s   |
+           | xenial  | yes    | disabled | yes  | disabled |
+           | bionic  | yes    | n/a      | yes  | disabled |

--- a/features/util.py
+++ b/features/util.py
@@ -63,7 +63,7 @@ def launch_ec2(
             aws_pro_ids = yaml.safe_load(stream.read())
         image_name = aws_pro_ids[series]
     print("Launching AWS PRO image {}({})".format(image_name, series))
-    vpc = context.config.ec2_api.create_vpc("uaclient-integration")
+    vpc = context.config.ec2_api.get_or_create_vpc(name="uaclient-integration")
     inst = context.config.ec2_api.launch(
         image_name, user_data=user_data, vpc=vpc
     )

--- a/features/util.py
+++ b/features/util.py
@@ -4,7 +4,9 @@ import sys
 import textwrap
 import time
 import yaml
-from typing import Any, List
+from typing import Any, List, Optional
+
+import pycloudlib  # type: ignore
 
 from behave.runner import Context
 
@@ -14,6 +16,7 @@ LXC_PROPERTY_MAP = {
 }
 SOURCE_PR_TGZ = "/tmp/pr_source.tar.gz"
 VM_PROFILE_TMPL = "behave-{}"
+
 
 # For Xenial and Bionic vendor-data required to setup lxd-agent
 # Additionally xenial needs to launch images:ubuntu/16.04/cloud
@@ -41,11 +44,45 @@ LXC_SETUP_VENDORDATA = textwrap.dedent(
 )
 
 
+def launch_ec2(
+    context: Context,
+    series: str,
+    image_name: "Optional[str]" = None,
+    user_data: "Optional[str]" = None,
+) -> pycloudlib.instance:
+    """Launch a container from an AMI and wait for it to boot
+
+    :return: pycloudlib.instance that was launched
+    """
+    if not image_name:
+        if not series:
+            raise ValueError(
+                "Must provide either series or image_name to launch_ec2"
+            )
+        with open("features/aws-ids.yaml", "r") as stream:
+            aws_pro_ids = yaml.safe_load(stream.read())
+        image_name = aws_pro_ids[series]
+    print("Launching AWS PRO image {}({})".format(image_name, series))
+    vpc = context.config.ec2_api.create_vpc("uaclient-integration")
+    inst = context.config.ec2_api.launch(
+        image_name, user_data=user_data, vpc=vpc
+    )
+
+    def cleanup_instance() -> None:
+        if not context.config.destroy_instances:
+            print("Leaving ec2 instance running: {}".format(inst.id))
+        else:
+            inst.delete()
+
+    print("AWS PRO instance launched: {}".format(inst.id))
+    return inst
+
+
 def launch_lxd_container(
     context: Context,
+    series: str,
     image_name: str,
     container_name: str,
-    series: str,
     is_vm: bool,
 ) -> None:
     """Launch a container from an image and wait for it to boot

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,0 +1,9 @@
+# Integration testing
+behave
+PyHamcrest
+git+https://github.com/canonical/pycloudlib.git
+
+# Simplestreams is not found on PyPi so pull from repo directly
+git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d
+ipdb
+

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,24 @@ from uaclient import defaults, util, version
 NAME = "ubuntu-advantage-tools"
 
 INSTALL_REQUIRES = open("requirements.txt").read().rstrip("\n").split("\n")
-TEST_REQUIRES = open("test-requirements.txt").read().rstrip("\n").split("\n")
+
+
+def split_link_deps(reqs_filename):
+    """Read requirements reqs_filename and split into pkgs and links
+
+   :return: list of package defs and link defs
+   """
+    pkgs = []
+    links = []
+    for line in open(reqs_filename).readlines():
+        if line.startswith("git") or line.startswith("http"):
+            links.append(line)
+        else:
+            pkgs.append(line)
+    return pkgs, links
+
+
+TEST_REQUIRES, TEST_LINKS = split_link_deps("test-requirements.txt")
 
 
 def _get_version():
@@ -52,6 +69,7 @@ setuptools.setup(
     ),
     data_files=_get_data_files(),
     install_requires=INSTALL_REQUIRES,
+    dependency_links=TEST_LINKS,
     extras_require=dict(test=TEST_REQUIRES),
     author="Ubuntu Server Team",
     author_email="ubuntu-server@lists.ubuntu.com",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,3 +10,8 @@ pytest-cov
 # Integration testing
 behave
 PyHamcrest
+git+https://github.com/blackboxsw/pycloudlib.git
+
+# Simplestreams is not found on PyPi so pull from repo directly
+git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d
+ipdb

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,12 +6,3 @@ pycodestyle
 mock
 pytest
 pytest-cov
-
-# Integration testing
-behave
-PyHamcrest
-git+https://github.com/blackboxsw/pycloudlib.git
-
-# Simplestreams is not found on PyPi so pull from repo directly
-git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d
-ipdb

--- a/tools/refresh-aws-pro-ids
+++ b/tools/refresh-aws-pro-ids
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+import glob
+import os
+import re
+import yaml
+
+from uaclient import util
+
+MARKETPLACE_PREFIX = "marketplaceProductCode:"
+
+
+FOOTER_MSG = """
+Please submit a PR to update these default AMIs
+
+git commit -am 'update: AWS Ubuntu PRO marketplace AMIs'
+git push upstream your-branch
+
+Create a new pull request @ https://github.com/canonical/ubuntu-advantage-client/pulls
+"""
+
+
+def main():
+    if not os.path.exists("ua-contracts"):
+        util.subp(
+            ["git", "clone", "git@github.com:CanonicalLtd/ua-contracts.git"]
+        )
+    os.chdir("ua-contracts")
+    util.subp(["git", "pull"])
+    os.chdir("products")
+    aws_ids = {}
+    for aws_listing in glob.glob("listing-aws-premium-*"):
+        m = re.match(
+            r"^listing-aws-premium-(?P<release>\w+).yaml$", aws_listing
+        )
+        if not m:
+            print("Skipping unexpected listing file name: %s", aws_listing)
+            continue
+        listing = yaml.safe_load(open(aws_listing, "r"))
+        import pdb; pdb.set_trace()
+        release = listing['metadata']['series']
+        [marketplace_id] = listing['externalMarketplaceIDs']["IDs"]
+        marketplace_id = marketplace_id.replace(MARKETPLACE_PREFIX, "")
+        out, _err = util.subp(
+            ["aws", "ec2", "describe-images", "--owners", "aws-marketplace",
+             "--filters", "Name=product-code,Values={}".format(marketplace_id),
+             "--query", "sort_by(Images, &CreationDate)[-1].ImageId"]
+        )
+        ami_id = out.strip()
+        aws_ids[release] = ami_id.replace("\"", "")
+
+    os.chdir("../..")
+    with open("features/aws-ids.yaml", "w") as stream:
+        stream.write(yaml.dump(aws_ids))
+
+    print(FOOTER_MSG)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     eoan: -ctools/constraints-eoan.txt
     mypy: mypy
     black: -rdev-requirements.txt
+    behave: -rintegration-requirements.txt
 passenv =
     UACLIENT_BEHAVE_*
 commands =


### PR DESCRIPTION
This branch would be part 1 of 2 for AWS Pro support.  It addresses part of Issue: #1093

In this branch:

- fix setup.py to handle test-requirements which use remote git links for dependencies
- Add pro.aws machine_type definition and @uses decorator for feature tests
- Use pycloudlib to perform ec2 key creation, vpc creation and launch_ec2 instances from a common vpc
- Allow building ec2 Ubuntu PRO images which install the ubuntu-advantage-tools from daily PPA
- separate integration-requirements.txt file as some pycloudlib deps are not available on trusty

We will not run integration tests from trusty, so this dependency mismatch is irrelevant to our test runs