### PR TITLE
Overrides/disable auto attach

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -152,7 +152,7 @@ Feature: Command behaviour when attached to an UA subscription
            | xenial  |
 
     @series.all
-    Scenario Outline: Unattached status in a ubuntu machine with machine token overlay
+    Scenario Outline: Unattached status in a ubuntu machine with feature overrides
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/machine-token-overlay.json` with the following:
         """
@@ -173,6 +173,8 @@ Feature: Command behaviour when attached to an UA subscription
         """
         features:
           machine_token_overlay: "/tmp/machine-token-overlay.json"
+          disable_auto_attach: true
+          other: false
         """
         And I attach `contract_token` with sudo
         And I run `ua status --all` with sudo
@@ -182,9 +184,14 @@ Feature: Command behaviour when attached to an UA subscription
             cc-eal        no
             """
         When I run `ua --version` as non-root
-        Then I will see the uaclient version on stdout with features ` +machine_token_overlay`
+        Then I will see the uaclient version on stdout with features ` +disable_auto_attach +machine_token_overlay -other`
         When I run `ua version` as non-root
-        Then I will see the uaclient version on stdout with features ` +machine_token_overlay`
+        Then I will see the uaclient version on stdout with features ` +disable_auto_attach +machine_token_overlay -other`
+        When I run `ua auto-attach` with sudo
+        Then stdout matches regexp:
+        """
+        Skipping auto-attach. Config disable_auto_attach is set.
+        """
 
         Examples: ubuntu release
            | release |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -182,9 +182,9 @@ Feature: Command behaviour when attached to an UA subscription
             cc-eal        no
             """
         When I run `ua --version` as non-root
-        Then I will see the uaclient version on stdout with overlay info
+        Then I will see the uaclient version on stdout with features ` +machine_token_overlay`
         When I run `ua version` as non-root
-        Then I will see the uaclient version on stdout with overlay info
+        Then I will see the uaclient version on stdout with features ` +machine_token_overlay`
 
         Examples: ubuntu release
            | release |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -157,7 +157,9 @@ def then_i_will_see_the_uaclient_version_on_stdout(context, feature_str=None):
 
 
 @then("I will see the uaclient version on stdout with features `{features}`")
-def then_i_will_see_the_uaclient_version_with_feature_suffix(context, features):
+def then_i_will_see_the_uaclient_version_with_feature_suffix(
+    context, features
+):
     then_i_will_see_the_uaclient_version_on_stdout(
         context, feature_str=features
     )

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -144,29 +144,22 @@ def then_i_will_see_on_stderr(context):
 
 
 @then("I will see the uaclient version on stdout")
-def then_i_will_see_the_uaclient_version_on_stdout(context, overlay_str=None):
+def then_i_will_see_the_uaclient_version_on_stdout(context, feature_str=None):
     python_import = "from uaclient.version import get_version"
 
-    if overlay_str is not None:
-        python_cmd = 'get_version(machine_token_overlay_str="{}")'.format(
-            overlay_str
-        )
-    else:
-        python_cmd = "get_version()"
-
-    cmd = "python3 -c '{}; print({})'".format(python_import, python_cmd)
+    cmd = "python3 -c '{}; print(get_version())'".format(python_import)
 
     actual_version = context.process.stdout.strip()
     when_i_run_command(context, cmd, "as non-root")
-    expected_version = context.process.stdout.strip()
+    expected_version = context.process.stdout.strip() + feature_str
 
     assert_that(expected_version, equal_to(actual_version))
 
 
-@then("I will see the uaclient version on stdout with overlay info")
-def then_i_will_see_the_uaclient_version_with_overlay_info(context):
+@then("I will see the uaclient version on stdout with features `{features}`")
+def then_i_will_see_the_uaclient_version_with_feature_suffix(context, features):
     then_i_will_see_the_uaclient_version_on_stdout(
-        context, " +machine-token-overlay"
+        context, feature_str=features
     )
 
 

--- a/features/util.py
+++ b/features/util.py
@@ -350,9 +350,10 @@ def lxc_build_deb(container_name: str, output_deb_file: str) -> None:
                 SOURCE_PR_TGZ
             )
         )
+        subprocess.run(["make", "clean"])
         os.chdir("..")
         subprocess.run(
-            ["tar", "-zcvf", SOURCE_PR_TGZ, "ubuntu-advantage-client"]
+            ["tar", "-zcf", SOURCE_PR_TGZ, "ubuntu-advantage-client"]
         )
         os.chdir("ubuntu-advantage-client")
     subprocess.run(
@@ -368,7 +369,7 @@ def lxc_build_deb(container_name: str, output_deb_file: str) -> None:
             apt-get update
             apt-get install make
             cd /tmp
-            tar -zxvf *gz
+            tar -zxf *gz
             cd ubuntu-advantage-client
             make deps
             dpkg-buildpackage -us -uc

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -511,6 +511,13 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
 
 @assert_root
 def action_auto_attach(args, cfg):
+    disable_auto_attach = util.is_config_value_true(
+        config=cfg.cfg, path_to_value="features.disable_auto_attach"
+    )
+    if disable_auto_attach:
+        msg = "Skipping auto-attach. Config disable_auto_attach is set."
+        logging.debug(msg)
+        return 0
     token = _get_contract_token_from_cloud_identity(cfg)
     return _attach_with_token(cfg, token=token, allow_enable=True)
 
@@ -650,13 +657,7 @@ def get_version(_args=None, _cfg=None):
     if _cfg is None:
         _cfg = config.UAConfig()
 
-    machine_token_overlay_str = ""
-    if _cfg.cfg.get("features", {}).get("machine_token_overlay") is not None:
-        machine_token_overlay_str = " +machine-token-overlay"
-
-    return version.get_version(
-        machine_token_overlay_str=machine_token_overlay_str
-    )
+    return version.get_version(features=_cfg.features)
 
 
 def print_version(_args=None, _cfg=None):

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -517,6 +517,7 @@ def action_auto_attach(args, cfg):
     if disable_auto_attach:
         msg = "Skipping auto-attach. Config disable_auto_attach is set."
         logging.debug(msg)
+        print(msg)
         return 0
     token = _get_contract_token_from_cloud_identity(cfg)
     return _attach_with_token(cfg, token=token, allow_enable=True)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -126,12 +126,17 @@ class UAConfig:
         return bool(self.machine_token)  # machine_token is removed on detach
 
     @property
+    def features(self):
+        """Return a dictionary of any features provided in uaclient.conf."""
+        return self.cfg.get("features", {})
+
+    @property
     def machine_token(self):
         """Return the machine-token if cached in the machine token response."""
         if not self._machine_token:
             raw_machine_token = self.read_cache("machine-token")
 
-            machine_token_overlay_path = self.cfg.get("features", {}).get(
+            machine_token_overlay_path = self.features.get(
                 "machine_token_overlay"
             )
 

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -232,7 +232,6 @@ class TestGetContractTokenFromCloudIdentity:
 # For all of these tests we want to appear as root, so mock on the class
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionAutoAttach:
-
     @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_already_attached_on_non_ubuntu_pro(
         self, m_cloud_instance_factory, _m_getuid, FakeConfig
@@ -287,7 +286,7 @@ class TestActionAutoAttach:
         else:
             expected_calls = [
                 mock.call(cfg, "myPKCS7-token", allow_enable=True)
-        ]
+            ]
         get_contract_token_from_cloud_identity.return_value = "myPKCS7-token"
 
         def fake_request_updated_contract(cfg, contract_token, allow_enable):

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -868,6 +868,28 @@ class TestParseConfig:
         assert expected_msg == excinfo.value.msg
 
 
+class TestFeatures:
+    @pytest.mark.parametrize(
+        "cfg_features,expected",
+        (
+            ({}, {}),
+            (None, {}),
+            ({"feature1": "value1"}, {"feature1": "value1"}),
+            (
+                {"feature1": "value1", "feature2": False},
+                {"feature1": "value1", "feature2": False},
+            ),
+        ),
+    )
+    def test_features_are_a_property_of_uaconfig(self, cfg_features, expected):
+        if cfg_features is None:
+            user_cfg = None
+        else:
+            user_cfg = {"features": cfg_features}
+        cfg = UAConfig(cfg=user_cfg)
+        assert expected == cfg.features
+
+
 class TestMachineTokenOverlay:
     machine_token_dict = {
         "availableResources": [

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -12,14 +12,14 @@ from uaclient.version import get_version
 class TestGetVersion:
 
     @pytest.mark.parametrize(
-        "feature_dict,suffix", (({}, ""), ({"on": True}, " +on"))
+        "features,suffix", (({}, ""), ({"on": True}, " +on"))
     )
-    @mock.patch("uaclient.version.PACKAGED_VERSION", "24.1~18.04.1")
     @mock.patch("uaclient.version.os.path.exists", return_value=True)
     def test_get_version_returns_packaged_version(
-        self, m_exists, m_subp, feature_dict, suffix
+        self, m_exists, m_subp, features, suffix
     ):
-        assert "24.1~18.04.1" + suffix == get_version(features=feature_dict)
+        with mock.patch("uaclient.version.PACKAGED_VERSION", "24.1~18.04.1"):
+            assert "24.1~18.04.1" + suffix == get_version(features=features)
         assert 0 == m_subp.call_count
 
     @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -1,5 +1,7 @@
 import mock
 
+import pytest
+
 import os.path
 
 from uaclient import util
@@ -8,9 +10,16 @@ from uaclient.version import get_version
 
 @mock.patch("uaclient.util.subp")
 class TestGetVersion:
+
+    @pytest.mark.parametrize(
+        "feature_dict,suffix", (({}, ""), ({"on": True}, " +on"))
+    )
     @mock.patch("uaclient.version.PACKAGED_VERSION", "24.1~18.04.1")
-    def test_get_version_returns_packaged_version(self, m_subp):
-        assert "24.1~18.04.1" == get_version()
+    @mock.patch("uaclient.version.os.path.exists", return_value=True)
+    def test_get_version_returns_packaged_version(
+        self, m_exists, m_subp, feature_dict, suffix
+    ):
+        assert "24.1~18.04.1" + suffix == get_version(features=feature_dict)
         assert 0 == m_subp.call_count
 
     @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -10,7 +10,6 @@ from uaclient.version import get_version
 
 @mock.patch("uaclient.util.subp")
 class TestGetVersion:
-
     @pytest.mark.parametrize(
         "features,suffix", (({}, ""), ({"on": True}, " +on"))
     )

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -10,10 +10,10 @@ from uaclient import util
 
 __VERSION__ = "25.0"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
-VERSION_TMPL = "{version}{overlay}"
+VERSION_TMPL = "{version}{feature_suffix}"
 
 
-def get_version(_args=None, machine_token_overlay_str=""):
+def get_version(_args=None, features={}):
     """Return the packaged version as a string
 
          Prefer the binary PACKAGED_VESION set by debian/rules to DEB_VERSION.
@@ -24,9 +24,14 @@ def get_version(_args=None, machine_token_overlay_str=""):
            b. If run in a git-ubuntu pkg repo, upstream tags aren't visible,
               parse the debian/changelog in that case
     """
+    feature_suffix = ""
+    for key, value in sorted(features.items()):
+        feature_suffix += " {enabled}{name}".format(
+            enabled="+" if value else "-", name=key
+        )
     if not PACKAGED_VERSION.startswith("@@PACKAGED_VERSION"):
         return VERSION_TMPL.format(
-            version=PACKAGED_VERSION, overlay=machine_token_overlay_str
+            version=PACKAGED_VERSION, feature_suffix=feature_suffix
         )
     topdir = os.path.dirname(os.path.dirname(__file__))
     if os.path.exists(os.path.join(topdir, ".git")):
@@ -40,8 +45,8 @@ def get_version(_args=None, machine_token_overlay_str=""):
             cmd = ["dpkg-parsechangelog", "-S", "version"]
             out, _ = util.subp(cmd)
             return VERSION_TMPL.format(
-                version=out.strip(), overlay=machine_token_overlay_str
+                version=out.strip(), feature_suffix=feature_suffix
             )
     return VERSION_TMPL.format(
-        version=__VERSION__, overlay=machine_token_overlay_str
+        version=__VERSION__, feature_suffix=feature_suffix
     )


### PR DESCRIPTION
Add config feature override to avoid `ua auto-attach` on pro instances.

Adding the following to uaclient.conf will result in skipping auto-attach to aid in test creation of -proposed ubuntu-advantage-tools packages.

```yaml
features:
   disable_auto_enable: true
```