### PR TITLE
tests: version test feature_str default needs to be an empty string

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -144,7 +144,7 @@ def then_i_will_see_on_stderr(context):
 
 
 @then("I will see the uaclient version on stdout")
-def then_i_will_see_the_uaclient_version_on_stdout(context, feature_str=None):
+def then_i_will_see_the_uaclient_version_on_stdout(context, feature_str=""):
     python_import = "from uaclient.version import get_version"
 
     cmd = "python3 -c '{}; print(get_version())'".format(python_import)


### PR DESCRIPTION
Daily builds broke on non-feature tests due to the recent version overrides commit 4b37254b5d3f20b6c7b0f72c4f9ec200cc96ebe5

This results in travis build failures like this: https://travis-ci.org/github/canonical/ubuntu-advantage-client/jobs/710801369

Set proper default feature_str="" instread of None, so we don't break CI when parameter is absent.