### PR TITLE
Add cleanup to aws instances

### DIFF
--- a/features/util.py
+++ b/features/util.py
@@ -74,6 +74,7 @@ def launch_ec2(
         else:
             inst.delete()
 
+    context.add_cleanup(cleanup_instance)
     print("AWS PRO instance launched: {}".format(inst.id))
     return inst
 


### PR DESCRIPTION
Right now, the `cleanup_instances`method is not be added to the overall context cleanup list. We are adding it to that list, allowing AWS images to be deleted after we remove that context.