### PR TITLE
testing: aws pro support for locally building a pr and updating pro images for test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,21 +96,6 @@ matrix:
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
-    - python: 3.7
-      env: TOXENV=behave-pro-aws
-      script:
-          - BUILD_PR=1
-          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
-          - >
-              if [ "$BUILD_PR" -eq "1" ]; then
-                 cd $TRAVIS_BUILD_DIR/..
-                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
-                 cp pr_source.tar.gz /tmp
-                 ls -lh /tmp
-                 cd $TRAVIS_BUILD_DIR
-              fi
-          - sudo /usr/sbin/update-ca-certificates
-          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - env:
         PACKAGE_BUILD_SERIES=trusty
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,6 @@ matrix:
     - python: 3.7
       env: TOXENV=behave-pro-aws
       script:
-          # bionic has lxd from deb installed, remove it first to avoid
-          # confusion over versions
           - BUILD_PR=1
           - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
@@ -116,12 +114,7 @@ matrix:
                  cd $TRAVIS_BUILD_DIR
                  pwd
               fi
-          - sudo apt-get remove --yes --purge lxd lxd-client
-          - sudo rm -Rf /var/lib/lxd
-          - sudo snap install lxd
-          - sudo lxd init --auto
-          - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - env:
         PACKAGE_BUILD_SERIES=trusty
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,30 @@ matrix:
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+    - python: 3.7
+      env: TOXENV=behave-pro-aws
+      script:
+          # bionic has lxd from deb installed, remove it first to avoid
+          # confusion over versions
+          - echo $TRAVIS_BRANCH
+          - echo $TRAVIS_BUILD_DIR
+          - BUILD_PR=1
+          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
+          - >
+              if [ "$BUILD_PR" -eq "1" ]; then
+                 cd $TRAVIS_BUILD_DIR/..
+                 tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                 cp pr_source.tar.gz /tmp
+                 ls -lh /tmp
+                 cd $TRAVIS_BUILD_DIR
+                 pwd
+              fi
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
+          - sudo snap install lxd
+          - sudo lxd init --auto
+          - sudo usermod -a -G lxd $USER
+          - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - env:
         PACKAGE_BUILD_SERIES=trusty
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
       script:
           # bionic has lxd from deb installed, remove it first to avoid
           # confusion over versions
-          - echo $TRAVIS_BRANCH
-          - echo $TRAVIS_BUILD_DIR
           - BUILD_PR=1
           - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
@@ -41,8 +39,6 @@ matrix:
       script:
           # bionic has lxd from deb installed, remove it first to avoid
           # confusion over versions
-          - echo $TRAVIS_BRANCH
-          - echo $TRAVIS_BUILD_DIR
           - BUILD_PR=1
           - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
@@ -65,8 +61,6 @@ matrix:
       script:
           # bionic has lxd from deb installed, remove it first to avoid
           # confusion over versions
-          - echo $TRAVIS_BRANCH
-          - echo $TRAVIS_BUILD_DIR
           - BUILD_PR=1
           - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
@@ -89,8 +83,6 @@ matrix:
       script:
           # bionic has lxd from deb installed, remove it first to avoid
           # confusion over versions
-          - echo $TRAVIS_BRANCH
-          - echo $TRAVIS_BUILD_DIR
           - BUILD_PR=1
           - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
@@ -113,8 +105,6 @@ matrix:
       script:
           # bionic has lxd from deb installed, remove it first to avoid
           # confusion over versions
-          - echo $TRAVIS_BRANCH
-          - echo $TRAVIS_BUILD_DIR
           - BUILD_PR=1
           - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
                  cd $TRAVIS_BUILD_DIR
                  pwd
               fi
+          - sudo /usr/sbin/update-ca-certificates
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - env:
         PACKAGE_BUILD_SERIES=trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,10 @@ matrix:
           - >
               if [ "$BUILD_PR" -eq "1" ]; then
                  cd $TRAVIS_BUILD_DIR/..
-                 tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
-                 pwd
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
@@ -44,11 +43,10 @@ matrix:
           - >
               if [ "$BUILD_PR" -eq "1" ]; then
                  cd $TRAVIS_BUILD_DIR/..
-                 tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
-                 pwd
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
@@ -66,11 +64,10 @@ matrix:
           - >
               if [ "$BUILD_PR" -eq "1" ]; then
                  cd $TRAVIS_BUILD_DIR/..
-                 tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
-                 pwd
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
@@ -88,11 +85,10 @@ matrix:
           - >
               if [ "$BUILD_PR" -eq "1" ]; then
                  cd $TRAVIS_BUILD_DIR/..
-                 tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
-                 pwd
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
@@ -108,11 +104,10 @@ matrix:
           - >
               if [ "$BUILD_PR" -eq "1" ]; then
                  cd $TRAVIS_BUILD_DIR/..
-                 tar -zcvf pr_source.tar.gz ubuntu-advantage-client
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
-                 pwd
               fi
           - sudo /usr/sbin/update-ca-certificates
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test

--- a/features/environment.py
+++ b/features/environment.py
@@ -134,8 +134,7 @@ class UAClientBehaveConfig:
             [
                 tag.split(".")[1]
                 for tag in cmdline_tags
-                if tag.startswith("series.")
-                    and "series.all" not in tag
+                if tag.startswith("series.") and "series.all" not in tag
             ]
         )
         # Next, perform any required validation
@@ -546,7 +545,11 @@ def _install_uat_in_container(
                 inst.push_file(deb_file, "/tmp/" + deb_name)
             else:
                 cmd = [
-                    "lxc", "file", "push", deb_file, container_name + "/tmp/"
+                    "lxc",
+                    "file",
+                    "push",
+                    deb_file,
+                    container_name + "/tmp/",
                 ]
                 subprocess.check_call(cmd)
     if cloud_api:

--- a/features/environment.py
+++ b/features/environment.py
@@ -166,8 +166,8 @@ class UAClientBehaveConfig:
         # config options, and means they'll be included in test logs in CI.
         print("Config options:")
         for option in self.all_options:
-            value = getattr(self, option, "ERROR")
-            if option in self.redact_options and value not in (None, "ERROR"):
+            value = getattr(self, option, "<UNSET>")
+            if option in self.redact_options and value not in (None, "<UNSET>"):
                 value = "<REDACTED>"
             print("  {}".format(option), "=", value)
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -546,9 +546,10 @@ def _install_uat_in_container(
                 inst = cloud_api.get_instance(container_name)
                 inst.push_file(deb_file, "/tmp/" + deb_name)
             else:
-                subprocess.run(
-                    ["lxc", "file", "push", deb_file, container_name + "/tmp/"]
-                )
+                cmd = [
+                    "lxc", "file", "push", deb_file, container_name + "/tmp/"
+                ]
+                subprocess.check_call(cmd)
     if cloud_api:
         instance = cloud_api.get_instance(container_name)
         for cmd in cmds:

--- a/features/environment.py
+++ b/features/environment.py
@@ -220,6 +220,7 @@ def before_all(context: Context) -> None:
             tag="uaclientci",
             access_key_id=context.config.aws_access_key_id,
             secret_access_key=context.config.aws_secret_access_key,
+            region="us-east-2",
         )
         cloud_api = context.config.cloud_api
         if not os.path.exists(EC2_KEY_FILE):

--- a/features/environment.py
+++ b/features/environment.py
@@ -415,12 +415,19 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
         build_container_name = (
             "behave-image-pre-build-%s-" % series + time_suffix
         )
+        is_vm = bool(context.config.machine_type == "lxd.vm")
+        if is_vm and series == "xenial":
+            # FIXME: use lxd custom cloud images which containt HWE kernel for
+            # vhost-vsock support
+            lxc_ubuntu_series = "images:ubuntu/16.04/cloud"
+        else:
+            lxc_ubuntu_series = "ubuntu-daily:%s" % series
         launch_lxd_container(
             context,
             series=series,
-            image_name=series,
+            image_name=lxc_ubuntu_series,
             container_name=build_container_name,
-            is_vm=bool(context.config.machine_type == "lxd.vm"),
+            is_vm=is_vm,
         )
     deb_paths = build_debs(
         build_container_name,

--- a/features/environment.py
+++ b/features/environment.py
@@ -135,6 +135,8 @@ class UAClientBehaveConfig:
                 if tag.startswith("series.")
             ]
         )
+        if "all" in self.filter_series:
+            self.filter_series.update(ALL_SUPPORTED_SERIES)
         # Next, perform any required validation
         if self.reuse_image is not None:
             if self.image_clean:

--- a/features/environment.py
+++ b/features/environment.py
@@ -135,10 +135,9 @@ class UAClientBehaveConfig:
                 tag.split(".")[1]
                 for tag in cmdline_tags
                 if tag.startswith("series.")
+                    and "series.all" not in tag
             ]
         )
-        if "all" in self.filter_series:
-            self.filter_series.update(ALL_SUPPORTED_SERIES)
         # Next, perform any required validation
         if self.reuse_image is not None:
             if self.image_clean:

--- a/features/environment.py
+++ b/features/environment.py
@@ -382,35 +382,6 @@ def _capture_container_as_image(
         return image_name
 
 
-def create_uat_ec2_image(context: Context, series: str) -> None:
-    """Create an Ubuntu PRO Ec2 instance with latest ubuntu-advantage-tools
-
-    :param context:
-        A `behave.runner.Context` which will have `config.cloud_api` set on it
-    :param series:
-       A string representing the series name to create
-    """
-    if series in context.reuse_container:
-        print(
-            "\n Reusing the existing EC2 instance: {}({}) ".format(
-                context.reuse_container[series], series
-            )
-        )
-        return
-
-    # Launch pro image based on series marketplace lookup
-    inst = launch_ec2(
-        context, series=series, user_data=USERDATA_INSTALL_DAILY_PRO_UATOOLS
-    )
-    print("--- Creating updated AWS PRO AMI from instance: {}".format(inst.id))
-    context.series_image_name[series] = context.config.cloud_api.snapshot(inst)
-    print(
-        "--- Created updated AWS PRO AMI: {}".format(
-            context.series_image_name[series]
-        )
-    )
-
-
 def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
     """Create a development instance, instal build dependencies and build debs
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -141,7 +141,7 @@ class UAClientBehaveConfig:
                 print(" Reuse_image specified, it will not be deleted.")
 
         has_aws_keys = bool(aws_access_key_id and aws_secret_access_key)
-        if "pro" in self.machine_type:
+        if self.machine_type == "pro.aws":
             self.aws_access_key_id = aws_access_key_id
             self.aws_secret_access_key = aws_secret_access_key
             # Machine-type precludes use of any contract tokens

--- a/features/environment.py
+++ b/features/environment.py
@@ -120,6 +120,8 @@ class UAClientBehaveConfig:
         cmdline_tags: "List" = []
     ) -> None:
         # First, store the values we've detected
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
         self.build_pr = build_pr
         self.contract_token = contract_token
         self.contract_token_staging = contract_token_staging
@@ -143,9 +145,15 @@ class UAClientBehaveConfig:
                 print(" Reuse_image specified, it will not be deleted.")
 
         has_aws_keys = bool(aws_access_key_id and aws_secret_access_key)
-        if self.machine_type == "pro.aws":
-            self.aws_access_key_id = aws_access_key_id
-            self.aws_secret_access_key = aws_secret_access_key
+        if self.machine_type != "pro.aws":
+            for attr_name in ('aws_access_key_id', 'aws_secret_access_key'):
+                if getattr(self, attr_name):
+                    print(
+                        " --- Ignoring UACLIENT_BEHAVE_{} because machine_type"
+                        " is {}".format(attr_name.upper(), self.machine_type)
+                    )
+                    setattr(self, attr_name, None)
+        else:
             # Machine-type precludes use of any contract tokens
             for attr_name in ("contract_token", "contract_token_staging"):
                 if getattr(self, attr_name):

--- a/features/environment.py
+++ b/features/environment.py
@@ -146,7 +146,7 @@ class UAClientBehaveConfig:
 
         has_aws_keys = bool(aws_access_key_id and aws_secret_access_key)
         if self.machine_type != "pro.aws":
-            for attr_name in ('aws_access_key_id', 'aws_secret_access_key'):
+            for attr_name in ("aws_access_key_id", "aws_secret_access_key"):
                 if getattr(self, attr_name):
                     print(
                         " --- Ignoring UACLIENT_BEHAVE_{} because machine_type"
@@ -175,7 +175,10 @@ class UAClientBehaveConfig:
         print("Config options:")
         for option in self.all_options:
             value = getattr(self, option, "<UNSET>")
-            if option in self.redact_options and value not in (None, "<UNSET>"):
+            if option in self.redact_options and value not in (
+                None,
+                "<UNSET>",
+            ):
                 value = "<REDACTED>"
             print("  {}".format(option), "=", value)
 
@@ -309,7 +312,7 @@ def _should_skip_tags(context: Context, tags: "List") -> str:
                                 context.config.aws_access_key_id
                                 and context.config.aws_secret_access_key
                             )
-                            if not has_aws_key:
+                            if not has_aws_keys:
                                 return (
                                     "Skipped: aws.pro machine_type requires"
                                     " UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID and"
@@ -426,9 +429,8 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
     )
     if "pro" in context.config.machine_type:
         return deb_paths
-    else:
-        # Redact ubuntu-advantage-pro deb as inapplicable
-        [deb_path for deb_path in deb_paths if "pro" not in deb_path]
+    # Redact ubuntu-advantage-pro deb as inapplicable
+    return [deb_path for deb_path in deb_paths if "pro" not in deb_path]
 
 
 def create_uat_image(context: Context, series: str) -> None:
@@ -452,7 +454,6 @@ def create_uat_image(context: Context, series: str) -> None:
         )
         return
     time_suffix = datetime.datetime.now().strftime("%s%f")
-    deb_file = None
     deb_paths = []
     if context.config.build_pr:
         deb_paths = build_debs_from_dev_instance(context, series)
@@ -532,8 +533,8 @@ def _install_uat_in_container(
     else:
         for deb_file in deb_paths:
             deb_name = os.path.basename(deb_file)
-            cmds.extend(["sudo", "dpkg", "-i", "/tmp/" + deb_name])
-            cmds.extend(["apt-cache", "policy", deb_name.rstrip(".deb")])
+            cmds.append(["sudo", "dpkg", "-i", "/tmp/" + deb_name])
+            cmds.append(["apt-cache", "policy", deb_name.rstrip(".deb")])
             if cloud_api:
                 inst = cloud_api.get_instance(container_name)
                 inst.push_file(deb_file, "/tmp/" + deb_name)

--- a/features/environment.py
+++ b/features/environment.py
@@ -297,7 +297,7 @@ def _should_skip_tags(context: Context, tags: "List") -> str:
                         if val == "aws.pro":  # Ensure we have AWS creds
                             has_aws_keys = bool(
                                 context.config.aws_access_key_id
-                                    and context.config.aws_secret_access_key
+                                and context.config.aws_secret_access_key
                             )
                             if not has_aws_key:
                                 return (
@@ -420,7 +420,7 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
     :return: A list of paths to applicable deb files published.
     """
     time_suffix = datetime.datetime.now().strftime("%s%f")
-    if context.config.cloud_api:
+    if context.config.machine_type == "pro.aws":
         inst = launch_ec2(
             context,
             series=series,
@@ -533,7 +533,9 @@ def _install_uat_in_container(
     """
     cmds = []
     if not deb_paths:
-        deb_names = " ".join(UA_DEBS) if cloud_api else "ubuntu-advantage-tools"
+        deb_names = (
+            " ".join(UA_DEBS) if cloud_api else "ubuntu-advantage-tools"
+        )
         cmds.extend(
             [
                 [

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -33,8 +33,8 @@ def given_a_machine(context, series):
         return
     if series in context.reuse_container:
         context.container_name = context.reuse_container[series]
-        if context.config.machine_type == "pro.aws":
-            context.instance = context.config.ec2_api.get_instance(
+        if "pro" in context.config.machine_type:
+            context.instance = context.config.cloud_api.get_instance(
                 context.container_name
             )
     elif context.config.machine_type == "pro.aws":
@@ -110,7 +110,7 @@ def when_i_create_file_with_content(context, file_path):
 
     cmd = "printf '{}\n' > {}".format(text, file_path)
     cmd = 'sh -c "{}"'.format(cmd)
-    when_i_run_command(context, cmd, "as non-root")
+    when_i_run_command(context, cmd, "with sudo")
 
 
 @when("I reboot the `{series}` machine")

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -4,9 +4,17 @@ Feature: Command behaviour when attached to an UA subscription
     @series.xenial
     @series.bionic
     @series.focal
-    Scenario Outline: Attached refresh in a trusty machine
+    Scenario Outline: Attached refresh in an Ubuntu PRO machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua status --all` as non-root
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        """
+        And I run `ua auto-attach` with sudo
+        And I run `ua status --all` as non-root
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION

--- a/features/util.py
+++ b/features/util.py
@@ -430,13 +430,14 @@ def lxc_build_debs(container_name: str, output_deb_dir: str) -> "List[str]":
     buildscript = "build-from-source.sh"
     with open(buildscript, "w") as stream:
         stream.write(BUILD_FROM_TGZ)
+    os.chmod(buildscript, 0o755)
     for push_file in (buildscript, SOURCE_PR_TGZ):
         print("--- Push {} -> {}/tmp/".format(push_file, container_name))
         subprocess.run(
             ["lxc", "file", "push", push_file, container_name + "/tmp/"]
         )
     print("--- Run {}".format(buildscript))
-    lxc_exec(container_name, ["sudo", "bash", "/tmp/" + buildscript])
+    lxc_exec(container_name, ["sudo", "/tmp/" + buildscript])
     for deb in UA_DEBS:
         print(
             "--- Pull {}/tmp/{} {} ".format(

--- a/features/util.py
+++ b/features/util.py
@@ -433,25 +433,25 @@ def lxc_build_debs(container_name: str, output_deb_dir: str) -> "List[str]":
     os.chmod(buildscript, 0o755)
     for push_file in (buildscript, SOURCE_PR_TGZ):
         print("--- Push {} -> {}/tmp/".format(push_file, container_name))
-        subprocess.check_call(
-            ["lxc", "file", "push", push_file, container_name + "/tmp/"]
-        )
+        cmd = ["lxc", "file", "push", push_file, container_name + "/tmp/"]
+        subprocess.check_call(cmd)
     print("--- Run {}".format(buildscript))
     lxc_exec(container_name, ["sudo", "/tmp/" + buildscript])
+    deb_paths = []
     for deb in UA_DEBS:
         print(
             "--- Pull {}/tmp/{} {} ".format(
                 container_name, deb, output_deb_dir
             )
         )
-        subprocess.check_call(
-            [
-                "lxc",
-                "file",
-                "pull",
-                container_name + "/tmp/" + deb,
-                output_deb_dir,
-            ]
-        )
+        deb_paths.append(output_deb_dir + deb)
+        cmd = [
+            "lxc",
+            "file",
+            "pull",
+            container_name + "/tmp/" + deb,
+            deb_paths[-1],
+        ]
+        subprocess.check_call(cmd)
     subprocess.run(["lxc", "stop", container_name])
-    return list(UA_DEBS)
+    return deb_paths

--- a/features/util.py
+++ b/features/util.py
@@ -130,7 +130,7 @@ def launch_lxd_container(
     if is_vm:
         lxc_create_vm_profile(series)
         command.extend(["--profile", VM_PROFILE_TMPL.format(series), "--vm"])
-    subprocess.run(command)
+    subprocess.check_call(command)
 
     if is_vm:
         """ When we publish vm images we end up losing the image information.

--- a/features/util.py
+++ b/features/util.py
@@ -412,7 +412,7 @@ def build_debs(
         return lxc_build_debs(container_name, output_deb_dir)
 
 
-def lxc_build_debs(container_name: str, output_deb_dir: str) -> None:
+def lxc_build_debs(container_name: str, output_deb_dir: str) -> "List[str]":
     """
     Push source PR code .tar.gz to the container.
     Run tools/build-from-source.sh which will create the .deb
@@ -433,13 +433,13 @@ def lxc_build_debs(container_name: str, output_deb_dir: str) -> None:
     for push_file in (buildscript, SOURCE_PR_TGZ):
         print("--- Push {} -> {}/tmp/".format(push_file, container_name))
         subprocess.run(
-            ["lxc", "file", "push", push_file, contaner_name + "/tmp/"]
+            ["lxc", "file", "push", push_file, container_name + "/tmp/"]
         )
     print("--- Run {}".format(buildscript))
-    lxc_exec(container_name, ["sudo", "bash", "/tmp/" + script])
+    lxc_exec(container_name, ["sudo", "bash", "/tmp/" + buildscript])
     for deb in UA_DEBS:
         print(
-            "--- Pull {}/tmp/ubuntu-advantage-tools.deb {} ".format(
+            "--- Pull {}/tmp/{} {} ".format(
                 container_name, deb, output_deb_dir
             )
         )
@@ -453,3 +453,4 @@ def lxc_build_debs(container_name: str, output_deb_dir: str) -> None:
             ]
         )
     subprocess.run(["lxc", "stop", container_name])
+    return list(UA_DEBS)

--- a/features/util.py
+++ b/features/util.py
@@ -433,7 +433,7 @@ def lxc_build_debs(container_name: str, output_deb_dir: str) -> "List[str]":
     os.chmod(buildscript, 0o755)
     for push_file in (buildscript, SOURCE_PR_TGZ):
         print("--- Push {} -> {}/tmp/".format(push_file, container_name))
-        subprocess.run(
+        subprocess.check_call(
             ["lxc", "file", "push", push_file, container_name + "/tmp/"]
         )
     print("--- Run {}".format(buildscript))
@@ -444,7 +444,7 @@ def lxc_build_debs(container_name: str, output_deb_dir: str) -> "List[str]":
                 container_name, deb, output_deb_dir
             )
         )
-        subprocess.run(
+        subprocess.check_call(
             [
                 "lxc",
                 "file",

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ deps =
     behave: -rintegration-requirements.txt
 passenv =
     UACLIENT_BEHAVE_*
+setenv =
+    behave-pro-aws: UACLIENT_BEHAVE_MACHINE_TYPE = pro.aws
 commands =
     py3: py.test {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient setup.py
@@ -28,6 +30,7 @@ commands =
     behave-16.04: behave --no-skipped --verbose {posargs} --tags="@series.xenial, @series.all"
     behave-18.04: behave --no-skipped --verbose {posargs} --tags="@series.bionic, @series.all"
     behave-20.04: behave --no-skipped --verbose {posargs} --tags="@series.focal, @series.all"
+    behave-pro-aws: behave --no-skipped --verbose {posargs} --tags="@uses.config.machine_type.pro.aws"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
Add support to build the local branch and test on aws pro images.
Add a new tox target and travis job `behave-aws-pro` to run using your AWS credentials.

To allow building PRO images that don't auto-attach on first boot, we provide custom user-data to cloud-init which will overwrite/usr/bin/ua with an empty script. This is required because PRO images don't currently have ua-tools version 25.0 
Once version 25.0 is included in AWS PRO images, this user-data can be dropped in favor of using `disable_auto_attach: true` feature override in uaclient.conf.

PRO images also need to installed ubuntu-advantage-pro.deb, so refactor of the build_deb related functions was necessary in this branch.

Additionally pro.aws integration tests require AWS crednentials via the environment variables:
  UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID and UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY.

AWS PRO-related Integration tests will be skipped if machine_type != 'pro.aws' or either UACLIENT_BEHAVE_AWS_* environment variable is missing.


To test locally:
  UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID=<YOUR_AWS_KEY_ID> UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY=<YOUR_AWS_SECRET_ACCESS_KEY>  UACLIENT_BEHAVE_BUILD_PR=1 tox -r -e behave-aws-pro --  features/ubuntu_pro.feature