### PR TITLE
test: travis add aws-pro job avoid 'make clean' when build_pr is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,20 @@ matrix:
   fast_finish: true
   include:
     - python: 3.7
+      env: TOXENV=behave-pro-aws
+      script:
+          - BUILD_PR=1
+          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
+          - >
+              if [ "$BUILD_PR" -eq "1" ]; then
+                 cd $TRAVIS_BUILD_DIR/..
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
+                 cp pr_source.tar.gz /tmp
+                 ls -lh /tmp
+                 cd $TRAVIS_BUILD_DIR
+              fi
+          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+    - python: 3.7
       env: TOXENV=behave-14.04
       script:
           # bionic has lxd from deb installed, remove it first to avoid

--- a/features/environment.py
+++ b/features/environment.py
@@ -14,7 +14,6 @@ import pycloudlib  # type: ignore
 
 from features.util import (
     UA_DEBS,
-    emit_spinner_on_travis,
     launch_lxd_container,
     launch_ec2,
     lxc_exec,
@@ -357,21 +356,6 @@ def before_scenario(context: Context, scenario: Scenario):
     reason = _should_skip_tags(context, scenario.effective_tags)
     if reason:
         scenario.skip(reason=reason)
-        return
-    releases = set([])
-    for tag in scenario.effective_tags:
-        parts = tag.split(".")
-        if parts[0] == "series":
-            if parts[1] == "all":
-                releases.update(ALL_SUPPORTED_SERIES)
-            else:
-                releases.update([parts[1]])
-    if context.config.filter_series:
-        releases = releases.intersection(context.config.filter_series)
-    for release in releases:
-        if release not in context.series_image_name:
-            with emit_spinner_on_travis():
-                create_uat_image(context, release)
 
 
 def after_all(context):

--- a/features/environment.py
+++ b/features/environment.py
@@ -24,7 +24,7 @@ from features.util import (
 ALL_SUPPORTED_SERIES = ["bionic", "focal", "trusty", "xenial"]
 
 DAILY_PPA = "http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu"
-EC2_KEY_FILE = "uaclient.pem"
+DEFAULT_PRIVATE_KEY_FILE = "/tmp/uaclient.pem"
 LOCAL_BUILD_ARTIFACTS_DIR = "/tmp/"
 
 USERDATA_INSTALL_DAILY_PRO_UATOOLS = """\
@@ -69,6 +69,12 @@ class UAClientBehaveConfig:
         cleaned up when all tests are complete.
     :param machine_type:
         The default machine_type to test: lxd.container, lxd.vm or pro.aws
+    :param private_key_file:
+        Optional path to pre-existing private key file to use when connecting
+        launched VMs via ssh.
+    :param private_key_name:
+        Optional name of the cloud's named private key object to use when
+        connecting to launched VMs via ssh. Default: uaclient-integration.
     :param reuse_image:
         A string with an image name that should be used instead of building a
         fresh image for this test run.   If specified, this image will not be
@@ -90,6 +96,8 @@ class UAClientBehaveConfig:
         "contract_token",
         "contract_token_staging",
         "machine_type",
+        "private_key_file",
+        "private_key_name",
         "reuse_image",
     ]
     redact_options = [
@@ -114,6 +122,8 @@ class UAClientBehaveConfig:
         image_clean: bool = True,
         destroy_instances: bool = True,
         machine_type: str = "lxd.container",
+        private_key_file: str = None,
+        private_key_name: str = "uaclient-integration",
         reuse_image: str = None,
         contract_token: str = None,
         contract_token_staging: str = None,
@@ -128,6 +138,8 @@ class UAClientBehaveConfig:
         self.image_clean = image_clean
         self.destroy_instances = destroy_instances
         self.machine_type = machine_type
+        self.private_key_file = private_key_file
+        self.private_key_name = private_key_name
         self.reuse_image = reuse_image
         self.cmdline_tags = cmdline_tags
         self.filter_series = set(
@@ -233,17 +245,25 @@ def before_all(context: Context) -> None:
             secret_access_key=context.config.aws_secret_access_key,
             region="us-east-2",
         )
+        if context.config.private_key_file:
+            private_key_file = context.config.private_key_file
+        else:
+            private_key_file = DEFAULT_PRIVATE_KEY_FILE
         cloud_api = context.config.cloud_api
-        if not os.path.exists(EC2_KEY_FILE):
+        if not os.path.exists(private_key_file):
             if "uaclient-integration" in cloud_api.list_keys():
                 cloud_api.delete_key("uaclient-integration")
             keypair = cloud_api.client.create_key_pair(
                 KeyName="uaclient-integration"
             )
-            with open(EC2_KEY_FILE, "w") as stream:
+            with open(private_key_file, "w") as stream:
                 stream.write(keypair["KeyMaterial"])
-            os.chmod(EC2_KEY_FILE, 0o600)
-        cloud_api.use_key(EC2_KEY_FILE, EC2_KEY_FILE, "uaclient-integration")
+            os.chmod(private_key_file, 0o600)
+        cloud_api.use_key(
+            private_key_file,
+            private_key_file,
+            context.config.private_key_name
+        )
     if context.config.reuse_image:
         series = lxc_get_property(
             context.config.reuse_image, property_name="series", image=True
@@ -381,6 +401,9 @@ def _capture_container_as_image(
     :param cloud_api: Optional pycloud BaseCloud api for applicable
         machine_types.
     """
+    print(
+        "--- Creating  base image snapshot from vm {}".format(container_name)
+    )
     if cloud_api:
         inst = cloud_api.get_instance(container_name)
         return cloud_api.snapshot(instance=inst)
@@ -402,6 +425,9 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
     :return: A list of paths to applicable deb files published.
     """
     time_suffix = datetime.datetime.now().strftime("%s%f")
+    print(
+        "--- Launching vm to build ubuntu-advantage*debs from local source"
+    )
     if context.config.machine_type == "pro.aws":
         inst = launch_ec2(
             context,
@@ -463,6 +489,9 @@ def create_uat_image(context: Context, series: str) -> None:
     if context.config.build_pr:
         deb_paths = build_debs_from_dev_instance(context, series)
 
+    print(
+        "--- Launching VM to create a base image with updated ubuntu-advantage"
+    )
     if context.config.cloud_api:
         inst = launch_ec2(
             context,

--- a/features/environment.py
+++ b/features/environment.py
@@ -14,6 +14,7 @@ import pycloudlib  # type: ignore
 
 from features.util import (
     UA_DEBS,
+    emit_spinner_on_travis,
     launch_lxd_container,
     launch_ec2,
     lxc_exec,
@@ -260,9 +261,7 @@ def before_all(context: Context) -> None:
                 stream.write(keypair["KeyMaterial"])
             os.chmod(private_key_file, 0o600)
         cloud_api.use_key(
-            private_key_file,
-            private_key_file,
-            context.config.private_key_name
+            private_key_file, private_key_file, context.config.private_key_name
         )
     if context.config.reuse_image:
         series = lxc_get_property(
@@ -371,7 +370,8 @@ def before_scenario(context: Context, scenario: Scenario):
         releases = releases.intersection(context.config.filter_series)
     for release in releases:
         if release not in context.series_image_name:
-            create_uat_image(context, release)
+            with emit_spinner_on_travis():
+                create_uat_image(context, release)
 
 
 def after_all(context):
@@ -425,9 +425,7 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
     :return: A list of paths to applicable deb files published.
     """
     time_suffix = datetime.datetime.now().strftime("%s%f")
-    print(
-        "--- Launching vm to build ubuntu-advantage*debs from local source"
-    )
+    print("--- Launching vm to build ubuntu-advantage*debs from local source")
     if context.config.machine_type == "pro.aws":
         inst = launch_ec2(
             context,

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -5,7 +5,9 @@ import shlex
 from behave import given, then, when
 from hamcrest import assert_that, equal_to, matches_regexp
 
+from features.environment import create_uat_image
 from features.util import (
+    emit_spinner_on_travis,
     launch_lxd_container,
     launch_ec2,
     lxc_exec,
@@ -37,7 +39,13 @@ def given_a_machine(context, series):
             context.instance = context.config.cloud_api.get_instance(
                 context.container_name
             )
-    elif context.config.machine_type == "pro.aws":
+        return
+
+    if series not in context.series_image_name:
+        with emit_spinner_on_travis():
+            create_uat_image(context, series)
+
+    if context.config.machine_type == "pro.aws":
         context.instance = launch_ec2(
             context,
             series=series,

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ deps =
     behave: -rintegration-requirements.txt
 passenv =
     UACLIENT_BEHAVE_*
+    TRAVIS
+    TRAVIS_*
 setenv =
     behave-pro-aws: UACLIENT_BEHAVE_MACHINE_TYPE = pro.aws
 commands =


### PR DESCRIPTION
Note: I'd like to merge this branch with separate commits instead of squash merging.

This PR activates the travis job behave-aws-pro

It also drop a 'make clean' in favor of tar --exclude-vcs* flags which ignore .tox and .git subdirs when
creating a source tar file to build from during testing.

Additional features:
 - print launched instance.id right after launch and add retries on instance.wait failuress
 - modify some print statements

 