### PR TITLE
tests: add integration tests for aws canonical cloud-images (non Ubuntu-pro)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ script:
 matrix:
   fast_finish: true
   include:
-    - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET)
+    - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
-      env: TOXENV=behave-pro-azure
+      env: TOXENV=behave-aws
       script:
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -26,100 +26,146 @@ matrix:
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
+          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+    - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET)
+      python: 3.7
+      env: TOXENV=behave-azure-pro
+      script:
+          - >
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
+                 cd $TRAVIS_BUILD_DIR/..
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
+                 cp pr_source.tar.gz /tmp
+                 ls -lh /tmp
+                 cd $TRAVIS_BUILD_DIR
+              fi
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
+          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+    - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      python: 3.7
+      env: TOXENV=behave-azure
+      script:
+          - >
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
+                 cd $TRAVIS_BUILD_DIR/..
+                 tar -zcf pr_source.tar.gz ubuntu-advantage-client
+                 cp pr_source.tar.gz /tmp
+                 ls -lh /tmp
+                 cd $TRAVIS_BUILD_DIR
+              fi
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY)
       python: 3.7
-      env: TOXENV=behave-pro-aws
+      env: TOXENV=behave-aws-pro
       script:
-          - BUILD_PR=1
-          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
-              if [ "$BUILD_PR" -eq "1" ]; then
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
                  cd $TRAVIS_BUILD_DIR/..
                  tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
-    - python: 3.7
+    - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      python: 3.7
       env: TOXENV=behave-14.04
       script:
-          # bionic has lxd from deb installed, remove it first to avoid
-          # confusion over versions
-          - BUILD_PR=1
-          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
-              if [ "$BUILD_PR" -eq "1" ]; then
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
                  cd $TRAVIS_BUILD_DIR/..
                  tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          # Because we are using dist:bionic for the travis host, we need
+          # to remove the lxd deb-installed package to avoid
+          # confusion over lxd versions
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
-    - python: 3.7
+    - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      python: 3.7
       env: TOXENV=behave-16.04
       script:
-          # bionic has lxd from deb installed, remove it first to avoid
-          # confusion over versions
-          - BUILD_PR=1
-          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
-              if [ "$BUILD_PR" -eq "1" ]; then
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
                  cd $TRAVIS_BUILD_DIR/..
                  tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          # Because we are using dist:bionic for the travis host, we need
+          # to remove the lxd deb-installed package to avoid
+          # confusion over lxd versions
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
-    - python: 3.7
+    - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      python: 3.7
       env: TOXENV=behave-18.04
       script:
-          # bionic has lxd from deb installed, remove it first to avoid
-          # confusion over versions
-          - BUILD_PR=1
-          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
-              if [ "$BUILD_PR" -eq "1" ]; then
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
                  cd $TRAVIS_BUILD_DIR/..
                  tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          # Because we are using dist:bionic for the travis host, we need
+          # to remove the lxd deb-installed package to avoid
+          # confusion over lxd versions
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
-    - python: 3.7
+    - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      python: 3.7
       env: TOXENV=behave-20.04
       script:
-          # bionic has lxd from deb installed, remove it first to avoid
-          # confusion over versions
-          - BUILD_PR=1
-          - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then BUILD_PR=0; fi
           - >
-              if [ "$BUILD_PR" -eq "1" ]; then
+              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                  BUILD_PR=0
+              else
                  cd $TRAVIS_BUILD_DIR/..
                  tar -zcf pr_source.tar.gz ubuntu-advantage-client
                  cp pr_source.tar.gz /tmp
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          # Because we are using dist:bionic for the travis host, we need
+          # to remove the lxd deb-installed package to avoid
+          # confusion over lxd versions
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - sudo snap install lxd

--- a/README.md
+++ b/README.md
@@ -234,17 +234,29 @@ you need to add `-D reuse_container=container_name`:
 tox -e behave -D reuse_container=container_name
 ```
 
-#### Integration testing on EC2 PRO images
+#### Integration testing on EC2
+The following tox environments allow for testing on EC2:
 
-Any ec2 pro image BDD tests are decorated with:
-    @uses.config.machine_type.pro.aws
+```
+  # To test ubuntu-pro-images on EC2
+  tox -e behave-aws-pro
+  # To test Canonical cloud images (non-ubuntu-pro) on EC2
+  tox -e behave-aws
+```
 
-Providing the environment variable `UACLIENT_BEHAVE_MACHINE_TYPE="pro.aws"`
-will limit test cases executed to AWS Ubuntu PRO only.
+In order to run EC2 tests the following environment variables are required:
+  - UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID
+  - UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY
+
+
+To specifically run non-ubuntu pro tests using canonical cloud-images an
+additional token obtained from https://ubuntu.com/advantage needs to be set:
+  - UACLIENT_BEHAVE_CONTRACT_TOKEN=<your_token>
+
 
 By default, the public AMIs for Ubuntu Pro testing used for each Ubuntu
 release are defined in features/aws-ids.yaml. These ami-ids are determined by
-running ./tools
+running `./tools/refresh-aws-pro-ids`.
 
 Integration tests will read features/aws-ids.yaml to determine which default
 AMI id to use for each supported Ubuntu release.
@@ -256,14 +268,14 @@ marketplace definitions.
 * To manually run EC2 integration tests using packages from `ppa:canonical-server/ua-client-daily` provide the following environment vars:
 
 ```sh
-UACLIENT_BEHAVE_MACHINE_TYPE="pro.aws" UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID=<blah> UACLIENT_BEHAVE_AWS_SECRET_KEY=<blah2> tox -e behave-18.04
+UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID=<blah> UACLIENT_BEHAVE_AWS_SECRET_KEY=<blah2> tox -e behave-aws-pro
 ```
 
 * To manually run EC2 integration tests with a specific AMI Id provide the
 following environment variable to launch your specfic  AMI instead of building
 a daily ubuntu-advantage-tools image.
 ```sh
-UACLIENT_BEHAVE_REUSE_IMAGE=ami-your-custom-ami tox -e behave-18.04
+UACLIENT_BEHAVE_REUSE_IMAGE=ami-your-custom-ami tox -e behave-aws-pro
 ```
 
 ## Building

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -33,3 +33,37 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
            | focal   |
            | trusty  |
            | xenial  |
+
+    @series.all
+    @uses.config.machine_type.azure.generic
+    @uses.config.machine_type.aws.generic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attach command in a ubuntu lxd container
+       Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        ESM Infra enabled
+        """
+        And stdout matches regexp:
+        """
+        This machine is now attached to
+        """
+        And stdout matches regexp:
+        """
+        SERVICE       ENTITLED  STATUS    DESCRIPTION
+        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
+        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
+        livepatch    +yes      +<lp_status>  +<lp_desc>
+        """
+        And stderr matches regexp:
+        """
+        Enabling default service esm-infra
+        """
+
+        Examples: ubuntu release livepatch status
+           | release | lp_status | lp_desc                       |
+           | trusty  | n/a       | Available with the HWE kernel |
+           | xenial  | enabled   | Canonical Livepatch service   |
+           | bionic  | enabled   | Canonical Livepatch service   |
+           | focal   | enabled   | Canonical Livepatch service   |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -43,8 +43,7 @@ def given_a_machine(context, series):
     if series not in context.series_image_name:
         with emit_spinner_on_travis():
             create_uat_image(context, series)
-
-    if context.config.machine_type.startswith("pro"):
+    if context.config.cloud_manager:
         context.instance = context.config.cloud_manager.launch(
             series=series, image_name=context.series_image_name[series]
         )
@@ -71,7 +70,7 @@ def given_a_machine(context, series):
 def when_i_run_command(context, command, user_spec):
     prefix = get_command_prefix_for_user_spec(user_spec)
     full_cmd = prefix + shlex.split(command)
-    if context.config.machine_type.startswith("pro"):
+    if context.config.cloud_manager:
         result = context.instance.execute(full_cmd)
         process = subprocess.CompletedProcess(
             args=full_cmd,

--- a/features/util.py
+++ b/features/util.py
@@ -433,7 +433,7 @@ def spinning_cursor():
 
 
 @contextmanager
-def emit_spinner_on_travis():
+def emit_spinner_on_travis(msg: str = " "):
     """
     A context manager that emits a spinner updating 5 seconds if running on
     Travis.
@@ -451,6 +451,7 @@ def emit_spinner_on_travis():
         return
 
     def emit_spinner():
+        print(msg, end="", flush=True)
         spinner = spinning_cursor()
         while True:
             time.sleep(5)

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,10 @@ passenv =
     TRAVIS
     TRAVIS_*
 setenv =
-    behave-pro-aws: UACLIENT_BEHAVE_MACHINE_TYPE = pro.aws
-    behave-pro-azure: UACLIENT_BEHAVE_MACHINE_TYPE = pro.azure
+    behave-aws: UACLIENT_BEHAVE_MACHINE_TYPE = aws.generic
+    behave-aws-pro: UACLIENT_BEHAVE_MACHINE_TYPE = aws.pro
+    behave-azure: UACLIENT_BEHAVE_MACHINE_TYPE = azure.generic
+    behave-azure-pro: UACLIENT_BEHAVE_MACHINE_TYPE = azure.pro
 commands =
     py3: py.test {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient setup.py
@@ -29,12 +31,14 @@ commands =
     mypy: mypy --python-version 3.6 uaclient/ features/
     mypy: mypy --python-version 3.7 uaclient/ features/
     black: black --check --diff uaclient/ features/ setup.py
-    behave-14.04: behave --no-skipped --verbose {posargs} --tags="@series.trusty, @series.all"
-    behave-16.04: behave --no-skipped --verbose {posargs} --tags="@series.xenial, @series.all"
-    behave-18.04: behave --no-skipped --verbose {posargs} --tags="@series.bionic, @series.all"
-    behave-20.04: behave --no-skipped --verbose {posargs} --tags="@series.focal, @series.all"
-    behave-pro-aws: behave --no-skipped --verbose {posargs} --tags="@uses.config.machine_type.pro.aws"
-    behave-pro-azure: behave --no-skipped --verbose {posargs} --tags="@uses.config.machine_type.pro.azure"
+    behave-14.04: behave -v {posargs} --tags="@series.trusty, @series.all"
+    behave-16.04: behave -v {posargs} --tags="@series.xenial, @series.all"
+    behave-18.04: behave -v {posargs} --tags="@series.bionic, @series.all"
+    behave-20.04: behave -v {posargs} --tags="@series.focal, @series.all"
+    behave-aws: behave -v {posargs} --tags="@uses.config.machine_type.aws.generic"
+    behave-aws-pro: behave -v {posargs} --tags="@uses.config.machine_type.aws.pro"
+    behave-azure: behave -v {posargs} --tags="@uses.config.machine_type.azure.generic"
+    behave-azure-pro: behave -b {posargs} --tags="@uses.config.machine_type.azure.pro"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the
@@ -48,3 +52,10 @@ ignore = E203,E251,W503
 
 [pytest]
 log_format = %(filename)-25s %(lineno)4d %(levelname)-8s %(message)s
+
+[behave]
+logging_level=warning
+log_capture=no
+stdout_capture=no
+stderr_capture=no
+show_skipped=no


### PR DESCRIPTION
Add AWS and Azure integration test support for non-Ubuntu PRO images.

This PR adds two new tox targets and travis jobs: behave-azure and behave-aws which run BDD scenarios decorated with 
the tags `uses.context.config.machine_type.aws.generic` or `uses.context.config.machine_type.azure.generic` for AWS and Azure respectively.

These tox targets/travis jobs will use pycloudlib's released_image(<series>) to obtain the latest public image on the cloud platform instead of specifically requesting the PRO image ids on the cloud.


Each generic (non-pro) image requires proper cloud credentials as UACLIENT_BEHAVE_* environment variables as well
as a UACLIENT_BEHAVE_CONTRACT_TOKEN in order to attach the maching to Ubuntu Advantage.


Additionally, we make the travis jobs depend on conditional inclusion only if on of the required environment variables is present to allow for private repos to run a subset of integration tests without failing if they don't wish to run Azure or AWS for instance.