### PR TITLE
Improve pro testing

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -183,6 +183,16 @@ def then_i_should_see_that_the_command_is_not_found(context, cmd_name):
     assert_that(expected_return, equal_to(actual_return))
 
 
+@then("I verify that running `{cmd_name}` as `{spec}` succeeds")
+def then_i_verify_that_running_cmd_with_spec_succeeds(context, cmd_name, spec):
+    spec = "with sudo" if spec == "sudo" else "as non-root"
+    when_i_run_command(context, cmd_name, spec)
+
+    expected_return = "0"
+    actual_return = str(context.process.returncode)
+    assert_that(actual_return, equal_to(expected_return))
+
+
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
     if user_spec == "with sudo":

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -183,14 +183,22 @@ def then_i_should_see_that_the_command_is_not_found(context, cmd_name):
     assert_that(expected_return, equal_to(actual_return))
 
 
-@then("I verify that running `{cmd_name}` as `{spec}` succeeds")
-def then_i_verify_that_running_cmd_with_spec_succeeds(context, cmd_name, spec):
-    spec = "with sudo" if spec == "sudo" else "as non-root"
+@then("I verify that running `{cmd_name}` `{spec}` exits `{exit_codes}`")
+def then_i_verify_that_running_cmd_with_spec_exits_with_codes(
+    context, cmd_name, spec, exit_codes
+):
     when_i_run_command(context, cmd_name, spec)
 
-    expected_return = "0"
-    actual_return = str(context.process.returncode)
-    assert_that(actual_return, equal_to(expected_return))
+    expected_codes = exit_codes.split(",")
+    assert str(context.process.returncode) in expected_codes
+
+
+@then("apt-cache policy for the following url has permission `{perm_id}`")
+def then_apt_cache_policy_for_the_following_url_has_permission_perm_id(
+    context, perm_id
+):
+    full_url = "{} {}".format(perm_id, context.text)
+    assert_that(context.process.stdout.strip(), matches_regexp(full_url))
 
 
 def get_command_prefix_for_user_spec(user_spec):

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -28,23 +28,23 @@ Feature: Command behaviour when attached to an UA subscription
             livepatch     +yes      +enabled  +Canonical Livepatch service
             """
         When I run `apt-cache policy` with sudo
-        Then stdout matches regexp:
+        Then apt-cache policy for the following url has permission `500`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And stdout matches regexp:
+        And apt-cache policy for the following url has permission `500`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And stdout matches regexp:
+        And apt-cache policy for the following url has permission `500`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And stdout matches regexp:
+        And apt-cache policy for the following url has permission `500`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
-        And I verify that running `apt update` as `sudo` succeeds
+        And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -27,8 +27,46 @@ Feature: Command behaviour when attached to an UA subscription
             fips-updates  +<fips> +<fips-s> +Uncertified security updates to FIPS modules
             livepatch     +yes      +enabled  +Canonical Livepatch service
             """
+        When I run `apt-cache policy` with sudo
+        Then stdout matches regexp:
+        """
+        https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        """
+        And stdout matches regexp:
+        """
+        https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        """
+        And stdout matches regexp:
+        """
+        https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
+        """
+        And stdout matches regexp:
+        """
+        https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        """
+        And I verify that running `apt update` as `sudo` succeeds
+        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo
+        And I run `apt-cache policy <infra-pkg>` as non-root
+        Then stdout matches regexp:
+        """
+        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        """
+        And stdout matches regexp:
+        """
+        Installed: .*[~+]esm
+        """
+        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo
+        And I run `apt-cache policy <apps-pkg>` as non-root
+        Then stdout matches regexp:
+        """
+        Version table:
+        \s*\*\*\* .* 500
+        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        """
+
         Examples: ubuntu release
-           | release | cc-eal | cc-eal-s | fips | fips-s |
-           | xenial  | yes    | disabled | yes  | n/a    |
-           | bionic  | yes    | n/a      | yes  | n/a    |
-           | focal   | yes    | n/a      | yes  | n/a    |
+           | release | cc-eal | cc-eal-s | fips | fips-s | infra-pkg    | apps-pkg |
+           | xenial  | yes    | disabled | yes  | n/a    | libkrad0     | jq       |
+           | bionic  | yes    | n/a      | yes  | n/a    | libkrad0     | bundler  |
+           | focal   | yes    | n/a      | yes  | n/a    | hello        | ant      |


### PR DESCRIPTION
In the pro images test, verify if the both `esm-infra` and `esm-apps` are properly configured and packages originated from those sources can be downloaded and installed without an issue.

This is a working solution, but there is still a discussion about if we should add dummy packages to both of these origins in an attempt to simplify and guarantee a more reliable test for pro images. But since we have not reached a consensus on it yes, this is a working solution nonetheless, although it suffers from some flaws, like checking the package version directly for esm, which is not mandatory for the package maintainer to add when uploading a new package.