### PR TITLE
Improve esm tests for containers

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -93,13 +93,26 @@ Feature: Enable command behaviour when attached to an UA subscription
             ESM Infra is already enabled.
             See: sudo ua status
             """
+        When I run `apt-cache policy` with sudo
+        Then apt-cache policy for the following url has permission `500`
+        """
+        <esm-infra-url> <release>-infra-updates/main amd64 Packages
+        """
+        And I verify that running `apt update` `with sudo` exits `0`
+        When I run `apt install -y <infra-pkg>` with sudo
+        And I run `apt-cache policy <infra-pkg>` as non-root
+        Then stdout matches regexp:
+        """
+        \s*500 <esm-infra-url> <release>-infra-security/main amd64 Packages
+        \s*500 <esm-infra-url> <release>-infra-updates/main amd64 Packages
+        """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | trusty  |
-           | xenial  |
+           | release | infra-pkg | esm-infra-url                       |
+           | bionic  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu |
+           | focal   | hello     | https://esm.ubuntu.com/infra/ubuntu |
+           | trusty  | libgit2-0 | https://esm.ubuntu.com/ubuntu/      |
+           | xenial  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu |
 
     @series.all
     @uses.config.machine_type.lxd.container

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -10,9 +10,10 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable cc-eal` with sudo
-        Then I will see the following on stderr:
+        When I run `ua enable cc-eal --beta` with sudo
+        Then I will see the following on stdout:
             """
+            One moment, checking your subscription first
             GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found
             """
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -333,7 +333,7 @@ def _perform_enable(
     allow_beta |= config_allow_beta
     if not allow_beta and ent_cls.is_beta:
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
-        raise exceptions.UserFacingError(
+        raise exceptions.BetaServiceError(
             tmpl.format(operation="enable", name=entitlement_name)
         )
 
@@ -371,8 +371,10 @@ def action_enable(args, cfg, **kwargs):
                 assume_yes=args.assume_yes,
                 allow_beta=args.beta,
             )
-        except exceptions.UserFacingError:
+        except exceptions.BetaServiceError:
             entitlements_not_found.append(entitlement)
+        except exceptions.UserFacingError as e:
+            print(e)
 
     if entitlements_not_found:
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -16,6 +16,19 @@ class UserFacingError(Exception):
         self.msg = msg
 
 
+class BetaServiceError(UserFacingError):
+    """
+    An exception to be raised trying to interact with beta service
+    without the right parameters.
+
+    :param msg:
+        Takes a single parameter, which is the beta service error message that
+        should be emitted before exiting non-zero.
+    """
+
+    pass
+
+
 class NonAutoAttachImageError(UserFacingError):
     """Raised when machine isn't running an auto-attach enabled image"""
 

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -357,7 +357,7 @@ class TestPerformEnable:
         if silent_if_inapplicable is not None:
             kwargs["silent_if_inapplicable"] = silent_if_inapplicable
 
-        with pytest.raises(exceptions.UserFacingError):
+        with pytest.raises(exceptions.BetaServiceError):
             _perform_enable("testitlement", m_cfg, **kwargs)
 
         assert 1 == m_is_beta.call_count


### PR DESCRIPTION
Improve `esm` test by verifying if both `esm-infra` and `esm-apps` when enabled can download and install packages from those services.

PS: This PR is still not complete because the current contract token does not support enabling `esm-apps`