### PR TITLE
testing: azure pro testing and ec2 cleanup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,28 @@ install:
   - make testdeps
 script:
   - make test
+stages:
+  - build and style
+  - test
 
 matrix:
   fast_finish: true
   include:
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      stage: test
       python: 3.7
-      env: TOXENV=behave-aws
+      env:
+          - TOXENV=behave-aws
+          - AWS_DEFAULT_REGION=us-east-2
+          - AWS_ACCESS_KEY_ID=${UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID}
+          - AWS_SECRET_ACCESS_KEY=${UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY}
+      install:
+          # Required so `git describe` will definitely find a tag; see
+          # https://github.com/travis-ci/travis-ci/issues/7422
+          - git fetch --unshallow
+          - make testdeps
+          - pip install boto3
+          - git clone https://github.com/canonical/server-test-scripts.git
       script:
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -29,7 +44,13 @@ matrix:
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - >
+            for key_name in `ls *pem`; do
+                K=${key_name/ec2-/};
+                python3 server-test-scripts/ubuntu-advantage-client/ec2_cleanup.py -t ${K%.pem} || true
+            done;
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET)
+      stage: test
       python: 3.7
       env: TOXENV=behave-azure-pro
       script:
@@ -47,6 +68,7 @@ matrix:
           - sudo rm -Rf /var/lib/lxd
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      stage: test
       python: 3.7
       env: TOXENV=behave-azure
       script:
@@ -64,8 +86,13 @@ matrix:
           - sudo rm -Rf /var/lib/lxd
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY)
+      stage: test
       python: 3.7
-      env: TOXENV=behave-aws-pro
+      env:
+          - TOXENV=behave-aws-pro
+          - AWS_DEFAULT_REGION=us-east-2
+          - AWS_ACCESS_KEY_ID=${UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID}
+          - AWS_SECRET_ACCESS_KEY=${UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY}
       script:
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -80,7 +107,13 @@ matrix:
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - >
+            for key_name in `ls *pem`; do
+                K=${key_name/ec2-/};
+                python3 server-test-scripts/ubuntu-advantage-client/ec2_cleanup.py -t ${K%.pem} || true
+            done;
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      stage: test
       python: 3.7
       env: TOXENV=behave-14.04
       script:
@@ -104,6 +137,7 @@ matrix:
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      stage: test
       python: 3.7
       env: TOXENV=behave-16.04
       script:
@@ -127,6 +161,7 @@ matrix:
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      stage: test
       python: 3.7
       env: TOXENV=behave-18.04
       script:
@@ -150,6 +185,7 @@ matrix:
           - sudo usermod -a -G lxd $USER
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
+      stage: test
       python: 3.7
       env: TOXENV=behave-20.04
       script:
@@ -174,6 +210,12 @@ matrix:
           - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - env:
         PACKAGE_BUILD_SERIES=trusty
+      stage: build and style
+      before_cache:
+         - touch ${TRAVIS_BUILD_DIR}/tags/uaclient-ci-0811-181610
+      cache:
+         - directories:
+           - ${TRAVIS_BUILD_DIR}/tags
       install:
         - make travis-deb-install
       script:
@@ -186,35 +228,45 @@ matrix:
         - make travis-deb-script
     - env:
         PACKAGE_BUILD_SERIES=bionic
+      stage: build and style
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
     - env:
         PACKAGE_BUILD_SERIES=eoan
+      stage: build and style
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
     - env:
         PACKAGE_BUILD_SERIES=focal
+      stage: build and style
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
     - python: 3.4
+      stage: build and style
       env: TOXENV=py3-trusty,flake8-trusty
       dist: trusty
     - python: 3.5
+      stage: build and style
       env: TOXENV=py3-xenial,flake8-xenial
       dist: xenial
     - python: 3.6
+      stage: build and style
       env: TOXENV=py3-bionic,flake8-bionic
     - python: 3.7
+      stage: build and style
       env: TOXENV=py3-eoan,flake8-eoan
     - python: 3.8
+      stage: build and style
       env: TOXENV=py3,flake8
     - python: 3.7
+      stage: build and style
       env: TOXENV=mypy
     - python: 3.7
+      stage: build and style
       env: TOXENV=black

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -35,7 +35,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
            | xenial  |
 
     @series.all
-    @uses.config.machine_type.azure.generic
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attach command in a ubuntu lxd container
@@ -64,6 +63,38 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Examples: ubuntu release livepatch status
            | release | lp_status | lp_desc                       |
            | trusty  | n/a       | Available with the HWE kernel |
+           | xenial  | enabled   | Canonical Livepatch service   |
+           | bionic  | enabled   | Canonical Livepatch service   |
+           | focal   | enabled   | Canonical Livepatch service   |
+
+    @series.all
+    @uses.config.machine_type.azure.generic
+    Scenario Outline: Attach command in a ubuntu lxd container
+       Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        ESM Infra enabled
+        """
+        And stdout matches regexp:
+        """
+        This machine is now attached to
+        """
+        And stdout matches regexp:
+        """
+        SERVICE       ENTITLED  STATUS    DESCRIPTION
+        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
+        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
+        livepatch    +yes      +<lp_status>  +<lp_desc>
+        """
+        And stderr matches regexp:
+        """
+        Enabling default service esm-infra
+        """
+
+        Examples: ubuntu release livepatch status
+           | release | lp_status | lp_desc                       |
+           | trusty  | disabled  | Canonical Livepatch service   |
            | xenial  | enabled   | Canonical Livepatch service   |
            | bionic  | enabled   | Canonical Livepatch service   |
            | focal   | enabled   | Canonical Livepatch service   |

--- a/tools/refresh-aws-pro-ids
+++ b/tools/refresh-aws-pro-ids
@@ -29,16 +29,19 @@ def main():
     util.subp(["git", "pull"])
     os.chdir("products")
     aws_ids = {}
-    for aws_listing in glob.glob("listing-aws-premium-*"):
+    for aws_listing in glob.glob("listing-aws-pro-*"):
         m = re.match(
-            r"^listing-aws-premium-(?P<release>\w+).yaml$", aws_listing
+            r"^listing-aws-pro-(?P<release>\w+).yaml$", aws_listing
         )
         if not m:
             print("Skipping unexpected listing file name: %s", aws_listing)
             continue
         listing = yaml.safe_load(open(aws_listing, "r"))
         import pdb; pdb.set_trace()
-        release = listing['metadata']['series']
+        for md in listing['metadata']:
+            if md["key"] == "series":
+                release = md["value"]
+                break
         [marketplace_id] = listing['externalMarketplaceIDs']["IDs"]
         marketplace_id = marketplace_id.replace(MARKETPLACE_PREFIX, "")
         out, _err = util.subp(

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     behave-aws: behave -v {posargs} --tags="@uses.config.machine_type.aws.generic"
     behave-aws-pro: behave -v {posargs} --tags="@uses.config.machine_type.aws.pro"
     behave-azure: behave -v {posargs} --tags="@uses.config.machine_type.azure.generic"
-    behave-azure-pro: behave -b {posargs} --tags="@uses.config.machine_type.azure.pro"
+    behave-azure-pro: behave -v {posargs} --tags="@uses.config.machine_type.azure.pro"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
- Add build vs testing stages to travis.
- Azure Cloud will now create local key files that match the timestamped tag for all resources created by the test run.
- Add ec2 cleanup on aws travis jobs to clean up the specific tagged resources created by the test run.