### PR TITLE
apt-hook: package apt-hook and apt configuration files on all releases

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,9 +45,7 @@ override_dh_gencontrol:
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
-ifeq (${VERSION_ID},"14.04")
 	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
-endif
 
 ifeq (${VERSION_ID},"14.04")
 	# Move ua-auto-attach.conf to ubuntu-advantage-pro


### PR DESCRIPTION
Fixes: #1150

To test on focal or any non-trusty series:
```
dpkg-buildpackage -us -uc
dpkg -c ../ubuntu-advantage-tools_25.0_amd64.deb | grep apt
```

make sure apt-hook and config are included in built binary


I built and installed this deb on a focal container with one downgraded package "hello" that was available in esm-infra-updates:

* when esm-infra enabled, cmdline reports the package count
* when esm-infra disabled, cmdline does not report pkg count
* when all applicable updates are applied from esm-infra, no pkg count listed

```root@dev-f:~# apt update
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [107 kB]
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease                         
Hit:3 http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu focal InRelease
Get:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease [111 kB]        
Hit:5 https://esm.ubuntu.com/infra/ubuntu focal-infra-security InRelease
Hit:6 https://esm.ubuntu.com/infra/ubuntu focal-infra-updates InRelease
Get:7 http://archive.ubuntu.com/ubuntu focal-backports InRelease [98.3 kB]
Fetched 317 kB in 1s (291 kB/s)   
Reading package lists... Done
Building dependency tree       
Reading state information... Done
6 packages can be upgraded. Run 'apt list --upgradable' to see them.
1 of the updates is from UA Infrastructure ESM.

# case 2: disabled esm no esm pkg ocunt
root@dev-f:~# ua disable esm-infra
Updating package lists
root@dev-f:~# apt update
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:3 http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu focal InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Reading package lists... Done
Building dependency tree       
Reading state information... Done
5 packages can be upgraded. Run 'apt list --upgradable' to see them.

# case 3 enabled esm-infra, updated hello to esm version no pkg counts
root@dev-f:~# apt install hello
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following package was automatically installed and is no longer required:
  libfreetype6
Use 'apt autoremove' to remove it.
The following packages will be upgraded:
  hello
1 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
Need to get 52.2 kB of archives.
After this operation, 167 kB of additional disk space will be used.
Get:1 https://esm.ubuntu.com/infra/ubuntu focal-infra-security/main amd64 hello amd64 2.10-2ubuntu3~esm1 [52.2 kB]
Fetched 52.2 kB in 1s (58.7 kB/s)
(Reading database ... 31291 files and directories currently installed.)
Preparing to unpack .../hello_2.10-2ubuntu3~esm1_amd64.deb ...
Unpacking hello (2.10-2ubuntu3~esm1) over (2.10-2ubuntu2) ...
Setting up hello (2.10-2ubuntu3~esm1) ...
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for install-info (6.7.0.dfsg.2-5) ...
root@dev-f:~# apt update
Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://security.ubuntu.com/ubuntu focal-security InRelease               
Hit:3 http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu focal InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease                 
Hit:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:6 https://esm.ubuntu.com/infra/ubuntu focal-infra-security InRelease
Hit:7 https://esm.ubuntu.com/infra/ubuntu focal-infra-updates InRelease
Reading package lists... Done
Building dependency tree       
Reading state information... Done
5 packages can be upgraded. Run 'apt list --upgradable' to see them.

```

