### PR TITLE
Travis reuse debs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 dist: bionic
 
+stages:
+  - flake
+  - build
+  - integration
+
 install:
   # Required so `git describe` will definitely find a tag; see
   # https://github.com/travis-ci/travis-ci/issues/7422
@@ -14,8 +19,31 @@ matrix:
   include:
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-aws
+      workspaces:
+        use:
+          - trusty
+          - xenial
+          - bionic
+          - focal
       script:
+          - >
+              if [ -d "trusty-debs" ]; then
+                 TRUSTY_DEBS_PATH=trusty-debs
+              fi
+          - >
+              if [ -d "bionic-debs" ]; then
+                 BIONIC_DEBS_PATH=bionic-debs
+              fi
+          - >
+              if [ -d "xenial-debs" ]; then
+                 XENIAL_DEBS_PATH=xenial-debs
+              fi
+          - >
+              if [ -d "focal-debs" ]; then
+                 FOCAL_DEBS_PATH=focal-debs
+              fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
@@ -28,11 +56,34 @@ matrix:
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-azure-pro
+      workspaces:
+        use:
+          - trusty
+          - xenial
+          - bionic
+          - focal
       script:
+          - >
+              if [ -d "trusty-debs" ]; then
+                 TRUSTY_DEBS_PATH=trusty-debs
+              fi
+          - >
+              if [ -d "bionic-debs" ]; then
+                 BIONIC_DEBS_PATH=bionic-debs
+              fi
+          - >
+              if [ -d "xenial-debs" ]; then
+                 XENIAL_DEBS_PATH=xenial-debs
+              fi
+          - >
+              if [ -d "focal-debs" ]; then
+                 FOCAL_DEBS_PATH=focal-debs
+              fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
@@ -45,11 +96,34 @@ matrix:
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-azure
+      workspaces:
+        use:
+          - trusty
+          - xenial
+          - bionic
+          - focal
       script:
+          - >
+              if [ -d "trusty-debs" ]; then
+                 TRUSTY_DEBS_PATH=trusty-debs
+              fi
+          - >
+              if [ -d "bionic-debs" ]; then
+                 BIONIC_DEBS_PATH=bionic-debs
+              fi
+          - >
+              if [ -d "xenial-debs" ]; then
+                 XENIAL_DEBS_PATH=xenial-debs
+              fi
+          - >
+              if [ -d "focal-debs" ]; then
+                 FOCAL_DEBS_PATH=focal-debs
+              fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
@@ -62,11 +136,34 @@ matrix:
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-aws-pro
+      workspaces:
+        use:
+          - trusty
+          - xenial
+          - bionic
+          - focal
       script:
+          - >
+              if [ -d "trusty-debs" ]; then
+                 TRUSTY_DEBS_PATH=trusty-debs
+              fi
+          - >
+              if [ -d "bionic-debs" ]; then
+                 BIONIC_DEBS_PATH=bionic-debs
+              fi
+          - >
+              if [ -d "xenial-debs" ]; then
+                 XENIAL_DEBS_PATH=xenial-debs
+              fi
+          - >
+              if [ -d "focal-debs" ]; then
+                 FOCAL_DEBS_PATH=focal-debs
+              fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
@@ -79,14 +176,20 @@ matrix:
               fi
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-14.04
+      workspaces:
+        use:
+          - trusty
       script:
           - >
-              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
-                  BUILD_PR=0
+              if [ -d "trusty-debs" ]; then
+                 TRUSTY_DEBS_PATH=trusty-debs
+              elif [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+                 BUILD_PR=0
               else
                  cd $TRAVIS_BUILD_DIR/..
                  tar -zcf pr_source.tar.gz ubuntu-advantage-client
@@ -97,18 +200,27 @@ matrix:
           # Because we are using dist:bionic for the travis host, we need
           # to remove the lxd deb-installed package to avoid
           # confusion over lxd versions
+          - echo $BUILD_PR
+          - echo $TRUSTY_DEBS_PATH 
+          - ls trusty-debs
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-16.04
+      workspaces:
+        use:
+          - xenial
       script:
           - >
-              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+              if [ -d "xenial-debs" ]; then
+                 XENIAL_DEBS_PATH=xenial-debs
+              elif [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
               else
                  cd $TRAVIS_BUILD_DIR/..
@@ -125,13 +237,19 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-18.04
+      workspaces:
+        use:
+          - bionic
       script:
           - >
-              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+              if [ -d "bionic-debs" ]; then
+                 BIONIC_DEBS_PATH=bionic-debs
+              elif [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
               else
                  cd $TRAVIS_BUILD_DIR/..
@@ -148,13 +266,19 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
+      stage: integration
       env: TOXENV=behave-20.04
+      workspaces:
+        use:
+          - focal
       script:
           - >
-              if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+              if [ -d "focal-debs" ]; then
+                 FOCAL_DEBS_PATH=focal-debs
+              elif [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
                   BUILD_PR=0
               else
                  cd $TRAVIS_BUILD_DIR/..
@@ -171,50 +295,107 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - env:
         PACKAGE_BUILD_SERIES=trusty
+      stage: build
       install:
         - make travis-deb-install
+      workspaces:
+        create:
+          name: trusty
+          paths:
+            - trusty-debs
       script:
         - make travis-deb-script
+        - mkdir trusty-debs
+        - cp ubuntu-advantage-tools-trusty.deb trusty-debs
+        - cp ubuntu-advantage-tools-pro-trusty.deb trusty-debs
+        - ls trusty-debs
     - env:
         PACKAGE_BUILD_SERIES=xenial
+      stage: build
+      workspaces:
+        create:
+          name: xenial
+          paths:
+            - xenial-debs
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
+        - mkdir xenial-debs
+        - cp ubuntu-advantage-tools-xenial.deb xenial-debs
+        - cp ubuntu-advantage-tools-pro-xenial.deb xenial-debs
+        - ls xenial-debs
     - env:
         PACKAGE_BUILD_SERIES=bionic
+      stage: build
+      workspaces:
+        create:
+          name: bionic
+          paths:
+            - bionic-debs
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
+        - mkdir bionic-debs
+        - cp ubuntu-advantage-tools-bionic.deb bionic-debs
+        - cp ubuntu-advantage-tools-pro-bionic.deb bionic-debs
+        - ls bionic-debs
     - env:
         PACKAGE_BUILD_SERIES=eoan
+      stage: build
+      workspaces:
+        create:
+          name: eoan
+          paths:
+            - eoan-debs
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
+        - mkdir eoan-debs
+        - cp ubuntu-advantage-tools-eoan.deb eoan-debs
+        - cp ubuntu-advantage-tools-pro-eoan.deb eoan-debs
+        - ls eoan-debs
     - env:
         PACKAGE_BUILD_SERIES=focal
+      stage: build
+      workspaces:
+        create:
+          name: focal
+          paths:
+            - focal-debs
       install:
         - make travis-deb-install
       script:
         - make travis-deb-script
+        - mkdir focal-debs
+        - cp ubuntu-advantage-tools-focal.deb focal-debs
+        - cp ubuntu-advantage-tools-pro-focal.deb focal-debs
+        - ls focal-debs
     - python: 3.4
+      stage: flake
       env: TOXENV=py3-trusty,flake8-trusty
       dist: trusty
     - python: 3.5
+      stage: flake
       env: TOXENV=py3-xenial,flake8-xenial
       dist: xenial
     - python: 3.6
+      stage: flake
       env: TOXENV=py3-bionic,flake8-bionic
     - python: 3.7
+      stage: flake
       env: TOXENV=py3-eoan,flake8-eoan
     - python: 3.8
+      stage: flake
       env: TOXENV=py3,flake8
     - python: 3.7
+      stage: flake
       env: TOXENV=mypy
     - python: 3.7
+      stage: flake
       env: TOXENV=black

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,21 +28,22 @@ matrix:
           - bionic
           - focal
       script:
+          - mkdir deb-artifacts
           - >
               if [ -d "trusty-debs" ]; then
-                 TRUSTY_DEBS_PATH=trusty-debs
+                 cp -r trusty-debs/* deb-artifacts
               fi
           - >
               if [ -d "bionic-debs" ]; then
-                 BIONIC_DEBS_PATH=bionic-debs
+                 cp -r bionic-debs/* deb-artifacts
               fi
           - >
               if [ -d "xenial-debs" ]; then
-                 XENIAL_DEBS_PATH=xenial-debs
+                 cp -r xenial-debs/* deb-artifacts
               fi
           - >
               if [ -d "focal-debs" ]; then
-                 FOCAL_DEBS_PATH=focal-debs
+                 cp -r focal-debs/* deb-artifacts
               fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -54,9 +55,10 @@ matrix:
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          - ls deb-artifacts
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_DEBS_PATH=deb-artifacts UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET)
       python: 3.7
       stage: integration
@@ -68,21 +70,22 @@ matrix:
           - bionic
           - focal
       script:
+          - mkdir deb-artifacts
           - >
               if [ -d "trusty-debs" ]; then
-                 TRUSTY_DEBS_PATH=trusty-debs
+                 cp -r trusty-debs/* deb-artifacts
               fi
           - >
               if [ -d "bionic-debs" ]; then
-                 BIONIC_DEBS_PATH=bionic-debs
+                 cp -r bionic-debs/* deb-artifacts
               fi
           - >
               if [ -d "xenial-debs" ]; then
-                 XENIAL_DEBS_PATH=xenial-debs
+                 cp -r xenial-debs/* deb-artifacts
               fi
           - >
               if [ -d "focal-debs" ]; then
-                 FOCAL_DEBS_PATH=focal-debs
+                 cp -r focal-debs/* deb-artifacts
               fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -94,9 +97,10 @@ matrix:
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          - ls deb-artifacts
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_DEBS_PATH=deb-artifacts UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET) AND env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
       stage: integration
@@ -108,21 +112,22 @@ matrix:
           - bionic
           - focal
       script:
+          - mkdir deb-artifacts
           - >
               if [ -d "trusty-debs" ]; then
-                 TRUSTY_DEBS_PATH=trusty-debs
+                 cp -r trusty-debs/* deb-artifacts
               fi
           - >
               if [ -d "bionic-debs" ]; then
-                 BIONIC_DEBS_PATH=bionic-debs
+                 cp -r bionic-debs/* deb-artifacts
               fi
           - >
               if [ -d "xenial-debs" ]; then
-                 XENIAL_DEBS_PATH=xenial-debs
+                 cp -r xenial-debs/* deb-artifacts
               fi
           - >
               if [ -d "focal-debs" ]; then
-                 FOCAL_DEBS_PATH=focal-debs
+                 cp -r focal-debs/* deb-artifacts
               fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -134,9 +139,10 @@ matrix:
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          - ls deb-artifacts
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_DEBS_PATH=deb-artifacts UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY)
       python: 3.7
       stage: integration
@@ -148,21 +154,22 @@ matrix:
           - bionic
           - focal
       script:
+          - mkdir deb-artifacts
           - >
               if [ -d "trusty-debs" ]; then
-                 TRUSTY_DEBS_PATH=trusty-debs
+                 cp -r trusty-debs/* deb-artifacts
               fi
           - >
               if [ -d "bionic-debs" ]; then
-                 BIONIC_DEBS_PATH=bionic-debs
+                 cp -r bionic-debs/* deb-artifacts
               fi
           - >
               if [ -d "xenial-debs" ]; then
-                 XENIAL_DEBS_PATH=xenial-debs
+                 cp -r xenial-debs/* deb-artifacts
               fi
           - >
               if [ -d "focal-debs" ]; then
-                 FOCAL_DEBS_PATH=focal-debs
+                 cp -r focal-debs/* deb-artifacts
               fi
           - >
               if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
@@ -174,9 +181,10 @@ matrix:
                  ls -lh /tmp
                  cd $TRAVIS_BUILD_DIR
               fi
+          - ls deb-artifacts
           - sudo apt-get remove --yes --purge lxd lxd-client
           - sudo rm -Rf /var/lib/lxd
-          - UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
+          - UACLIENT_BEHAVE_DEBS_PATH=deb-artifacts UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
       stage: integration
@@ -208,7 +216,7 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_TRUSTY_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_DEBS_PATH=${TRUSTY_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
       stage: integration
@@ -237,7 +245,7 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_XENIAL_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_DEBS_PATH=${XENIAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
       stage: integration
@@ -266,7 +274,7 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_BIONIC_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_DEBS_PATH=${BIONIC_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - if: env(UACLIENT_BEHAVE_CONTRACT_TOKEN)
       python: 3.7
       stage: integration
@@ -295,7 +303,7 @@ matrix:
           - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
-          - sg lxd -c "UACLIENT_BEHAVE_FOCAL_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
+          - sg lxd -c "UACLIENT_BEHAVE_DEBS_PATH=${FOCAL_DEBS_PATH} UACLIENT_BEHAVE_BUILD_PR=${BUILD_PR} make test"
     - env:
         PACKAGE_BUILD_SERIES=trusty
       stage: build

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ travis-deb-script:
 	# Use this to get a new shell where we're in the sbuild group
 	sudo -E su ${USER} -c 'mk-sbuild ${PACKAGE_BUILD_SERIES}'
 	sudo -E su ${USER} -c 'sbuild --nolog --verbose --dist=${PACKAGE_BUILD_SERIES} ../ubuntu-advantage-tools*.dsc'
+	cp ./ubuntu-advantage-tools*.deb ubuntu-advantage-tools-${PACKAGE_BUILD_SERIES}.deb
+	cp ./ubuntu-advantage-pro*.deb ubuntu-advantage-tools-pro-${PACKAGE_BUILD_SERIES}.deb
 
 
 .PHONY: build clean test testdeps demo


### PR DESCRIPTION
Update `travis.yaml` to allow reusing the packages built in the build in the behave integration tests. The idea here is to avoid having the behave tests reconstructing those packages, since this is a costly operation, specially in`aws` and `azure` tests