### PR TITLE
fips: conditional reboot text after enabling/disabling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ ubuntu-advantage-tools (24.3) groovy; urgency=medium
 
   * New bug-fix-only release 24.3:
     - uaclient.version bump to 24.3
+    - fips: add conditional reboot message only if /var/run/reboot-required is
+      present
     - fips: add apt repo key for FIPS and FIPS updates (GH #1026)
 
  -- Chad Smith <chad.smith@canonical.com>  Thu, 20 Aug 2020 14:50:17 -0600

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -60,9 +60,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     name = "fips"
     title = "FIPS"
     description = "NIST-certified FIPS modules"
-    messaging = {
-        "post_enable": ["A reboot is required to complete the install"]
-    }
     origin = "UbuntuFIPS"
     static_affordances = (
         ("Cannot install FIPS on a container", util.is_container, False),
@@ -73,12 +70,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     name = "fips-updates"
     title = "FIPS Updates"
-    messaging = {
-        "post_enable": [
-            "FIPS Updates configured and pending, please reboot to make"
-            " active."
-        ]
-    }
     origin = "UbuntuFIPSUpdates"
     description = "Uncertified security updates to FIPS modules"
     static_affordances = (

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -52,6 +52,18 @@ class RepoEntitlement(base.UAEntitlement):
     def repo_key_file(self) -> str:
         pass
 
+    def check_for_reboot_msg(self, operation: str) -> None:
+        """Check if user should be alerted that a reboot must be performed.
+
+        @param operation: The operation being executed.
+        """
+        if util.should_reboot():
+            print(
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation=operation
+                )
+            )
+
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.
 
@@ -82,11 +94,13 @@ class RepoEntitlement(base.UAEntitlement):
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         for msg in self.messaging.get("post_enable", []):
             print(msg)
+        self.check_for_reboot_msg(operation="install")
         return True
 
     def disable(self, silent=False):
         if not self.can_disable(silent):
             return False
+        self.check_for_reboot_msg(operation="disable operation")
         self._cleanup()
         return True
 

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -107,12 +107,14 @@ class TestCommonCriteriaEntitlementEnable:
         "apt_transport_https,ca_certificates",
         itertools.product([False, True], repeat=2),
     )
+    @mock.patch("uaclient.util.should_reboot", return_value=False)
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.get_platform_info")
     def test_enable_configures_apt_sources_and_auth_files(
         self,
         m_platform_info,
         m_subp,
+        m_should_reboot,
         capsys,
         tmpdir,
         apt_transport_https,
@@ -207,6 +209,7 @@ class TestCommonCriteriaEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cc
         assert [] == m_add_pin.call_args_list
+        assert 1 == m_should_reboot.call_count
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout += "\n".join(
             [

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -34,10 +34,11 @@ class TestCISEntitlementCanEnable:
 
 
 class TestCISEntitlementEnable:
+    @mock.patch("uaclient.util.should_reboot", return_value=False)
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.get_platform_info")
     def test_enable_configures_apt_sources_and_auth_files(
-        self, m_platform_info, m_subp, capsys, entitlement
+        self, m_platform_info, m_subp, m_should_reboot, capsys, entitlement
     ):
         """When entitled, configure apt repo auth token, pinning and url."""
 
@@ -91,6 +92,7 @@ class TestCISEntitlementEnable:
         # No apt pinning for cis-audit
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
+        assert 1 == m_should_reboot.call_count
         expected_stdout = (
             "Updating package lists\n"
             "Installing CIS Audit packages\n"

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -200,6 +200,8 @@ To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
 See https://ubuntu.com/advantage"""
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
+MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL = """\
+A reboot is required to complete {operation}"""
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
 Service {name} is recommended by default. Run: sudo ua enable {name}"""
 MESSAGE_DETACH_SUCCESS = "This machine is now detached"

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -13,6 +13,9 @@ from contextlib import contextmanager
 from functools import wraps
 from http.client import HTTPMessage  # noqa: F401
 
+REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
+
+
 try:
     from typing import (  # noqa: F401
         Any,
@@ -559,3 +562,8 @@ def write_file(filename: str, content: str, mode: int = 0o644) -> None:
         fh.write(content.encode("utf-8"))
         fh.flush()
     os.chmod(filename, mode)
+
+
+def should_reboot() -> bool:
+    """Check if the system needs to be rebooted."""
+    return os.path.exists(REBOOT_FILE_CHECK_PATH)


### PR DESCRIPTION
Only report reboot required text for fips enable disable if
/var/run/reboot-required file is present.

backport of 02de4df


to test:
1. launch aws pro image and provide the following cloud-config userdata
```
#cloud-config                                                                   
write_files:                                                                    
  # TODO(drop path: /usr/bin/ua when 25.0 is in Ubuntu PRO images)              
  - path: /usr/bin/ua                                                           
    content: |                                                                  
        #!/bin/bash                                                             
        DATE=`date -u`                                                          
        echo "$DATE: exec ua $@" >> /root/ua-runs                               
    permissions: '0755'                                                         
  - path: /etc/ubuntu-advantage/uaclient.conf                                   
    content: |                                                                  
      features:                                                                 
         disable_auto_attach: true                                              
    append: true                  
ssh_import_id: [<YOU>]
apt:
  sources:
    testingpro:
      source: "ppa:chad.smith/ua-client-premium-demo"
      keyid: 78030E2CC630045124EC2CAB83712B78F5B6FD57
packages:
  - ubuntu-advantage-tools
  - ubuntu-advantage-pro
```
2. ssh ubuntu@<your_instance>
3. sudo ua auto-attach   # should not say reboot required until /var/run/reboot-required exists on the system
4. ua version # should be 24.3.1 based and 