### PR TITLE
Fix livepatch behaviour on aws pro focal machine

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -65,15 +65,11 @@ Feature: Command behaviour when attached to an UA subscription
         \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
 
-        # focal livepatch status is displayed was disabled because livepatch
-        # currently fails to apply the kernel patches on the aws focal pro kernel version.
-        # We are changing the status to disabled just to unlock the build, but we
-        # need a better fix for that issue.
         Examples: ubuntu release
            | release | cc-eal-s | esm-a-s | infra-pkg | apps-pkg | fips-s | lp-s     | lp-d                          |
            | xenial  | disabled | enabled | libkrad0  | jq       | n/a    | enabled  | Canonical Livepatch service |
            | bionic  | n/a      | enabled | libkrad0  | bundler  | n/a    | enabled  | Canonical Livepatch service |
-           | focal   | n/a      | enabled | hello     | ant      | n/a    | disabled | Canonical Livepatch service |
+           | focal   | n/a      | enabled | hello     | ant      | n/a    | enabled  | Canonical Livepatch service |
 
     @series.trusty
     Scenario Outline: Attached refresh in a Trusty Ubuntu PRO machine


### PR DESCRIPTION
After the issue raised by this livepatch [bug](https://bugs.launchpad.net/canonical-livepatch-client/+bug/1892908) is addressed, we can rollback to the expected behavior of livepatch on AWS focal PRO machine