### PR TITLE
Apt clean

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -118,9 +118,6 @@ case "$1" in
           # 14.04 and unsupported arch
           unconfigure_esm
         fi
-      else
-        # not 14.04, regardless of arch
-        unconfigure_esm
       fi
       if [ ! -f /var/log/ubuntu-advantage.log ]; then
           touch /var/log/ubuntu-advantage.log

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,12 +5,14 @@ set -e
 . /etc/os-release  # For VERSION_ID
 
 
+MYRELEASE=$(lsb_release -sc)
 APT_TRUSTED_KEY_DIR="/etc/apt/trusted.gpg.d"
 UA_KEYRING_DIR="/usr/share/keyrings/"
 
 ESM_INFRA_KEY_TRUSTY="ubuntu-advantage-esm-infra-trusty.gpg"
 
 APT_SRC_DIR="/etc/apt/sources.list.d"
+APT_PREFERENCES_DIR="/etc/apt/preferences.d"
 ESM_APT_SOURCE_FILE_PRECISE="$APT_SRC_DIR/ubuntu-esm-precise.list"
 ESM_APT_SOURCE_FILE_TRUSTY="$APT_SRC_DIR/ubuntu-esm-trusty.list"
 ESM_INFRA_APT_SOURCE_FILE_TRUSTY="$APT_SRC_DIR/ubuntu-esm-infra-trusty.list"
@@ -25,6 +27,40 @@ SYSTEMD_WANTS_AUTO_ATTACH_LINK="/etc/systemd/system/multi-user.target.wants/ua-a
 SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enabled/ua-auto-attach.service.dsh-also"
 SYSTEMD_HELPER_ENABLED_WANTS_LINK="/var/lib/systemd/deb-systemd-helper-enabled/multi-user.target.wants/ua-auto-attach.service"
 
+
+UA_SERVICES="$(ua status | awk '/SERVICE/{flag=1;next}/Enable/{flag=0}flag {if(NF) {printf $1 " "}}')"
+
+# Rename apt config files for ua services removing ubuntu release names
+redact_ubuntu_release_from_ua_apt_filenames() {
+    DIR=$1
+    for file in `ls $DIR`; do
+        release_name=""
+        case "$file" in
+            *-trusty*)
+                release_name=trusty;;
+            *-xenial*)
+                release_name=xenial;;
+            *-bionic*)
+                release_name=bionic;;
+            *-focal*)
+                release_name=focal;;
+            *-groovy*)
+                release_name=groovy;;
+            *) release_name="";;
+         esac
+         if [ "$release_name" ]; then
+             # We have a ubuntu release name in the apt config.
+             # Remove $release_name from original $file.
+             new_file=${file%-${release_name}*}${file#*${release_name}}
+             for service in ${UA_SERVICES}; do
+                 if [ "${file#*$service}" != "$file" ]; then
+                      # Valid apt cfg file for an ubuntu-advantage service
+                      mv $DIR/$file $DIR/$new_file
+                 fi
+             done
+         fi
+    done
+}
 
 check_esm_infra_is_enabled() {
     ua status | egrep -q 'esm-infra.*enabled' && return 0 || return 1
@@ -119,6 +155,12 @@ case "$1" in
           unconfigure_esm
         fi
       fi
+
+     # UA service PPAs support all ubuntu releases, no need to
+     # specialize apt config filenames per ubuntu release.
+     redact_ubuntu_release_from_ua_apt_filenames $APT_SRC_DIR
+     redact_ubuntu_release_from_ua_apt_filenames $APT_PREFERENCES_DIR
+
       if [ ! -f /var/log/ubuntu-advantage.log ]; then
           touch /var/log/ubuntu-advantage.log
       fi

--- a/debian/postrm
+++ b/debian/postrm
@@ -19,7 +19,6 @@ remove_logs(){
 remove_esm(){
     # config files created in postinst, need explicit handling on purge
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg
-    rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list
     rm -f /etc/apt/preferences.d/ubuntu-esm-infra-trusty
 }
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -19,7 +19,6 @@ remove_logs(){
 remove_esm(){
     # config files created in postinst, need explicit handling on purge
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg
-    rm -f /etc/apt/preferences.d/ubuntu-esm-infra-trusty
 }
 
 case "$1" in

--- a/debian/prerm
+++ b/debian/prerm
@@ -5,9 +5,9 @@ set -e
 
 remove_apt_files() {
     python3 -c '
-from uaclient.apt import clean_apt_sources
+from uaclient.apt import clean_apt_files
 
-clean_apt_sources()
+clean_apt_files()
 '
 
 }

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -314,11 +314,13 @@ def clean_apt_files(*, _entitlements=None):
         uaclient.entitlements. (This is only present for testing, because the
         import happens within the function to avoid circular imports.)
     """
+    from uaclient.entitlements.repo import RepoEntitlement
+
     if _entitlements is None:
         from uaclient import entitlements as _entitlements
 
     for ent_cls in _entitlements.ENTITLEMENT_CLASSES:
-        if not hasattr(ent_cls, "repo_url"):
+        if not isinstance(ent_cls, RepoEntitlement):
             continue
         repo_file = ent_cls.repo_list_file_tmpl.format(name=ent_cls.name)
         pref_file = ent_cls.repo_pref_file_tmpl.format(name=ent_cls.name)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -305,9 +305,9 @@ def remove_apt_list_files(repo_url, series):
             os.unlink(path)
 
 
-def clean_apt_sources(*, _entitlements=None):
+def clean_apt_files(*, _entitlements=None):
     """
-    Clean apt sources list files written by uaclient
+    Clean apt files written by uaclient
 
     :param _entitlements:
         The uaclient.entitlements module to use, defaults to
@@ -320,14 +320,16 @@ def clean_apt_sources(*, _entitlements=None):
     for ent_cls in _entitlements.ENTITLEMENT_CLASSES:
         if not hasattr(ent_cls, "repo_url"):
             continue
-        repo_list_glob = ent_cls.repo_list_file_tmpl.format(
-            name=ent_cls.name, series="*"
-        )
+        repo_file = ent_cls.repo_list_file_tmpl.format(name=ent_cls.name)
+        pref_file = ent_cls.repo_pref_file_tmpl.format(name=ent_cls.name)
 
-        # Remove list files
-        for path in glob.glob(repo_list_glob):
-            logging.info("Removing apt source file: %s", path)
-            os.unlink(path)
+        if os.path.exists(repo_file):
+            logging.info("Removing apt source file: %s", repo_file)
+            os.unlink(repo_file)
+
+        if os.path.exists(pref_file):
+            logging.info("Removing apt preferences file: %s", pref_file)
+            os.unlink(pref_file)
 
 
 def get_installed_packages() -> "List[str]":

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -31,8 +31,8 @@ APT_DISABLED_PIN = "-32768"
 
 class RepoEntitlement(base.UAEntitlement):
 
-    repo_list_file_tmpl = "/etc/apt/sources.list.d/ubuntu-{name}-{series}.list"
-    repo_pref_file_tmpl = "/etc/apt/preferences.d/ubuntu-{name}-{series}"
+    repo_list_file_tmpl = "/etc/apt/sources.list.d/ubuntu-{name}.list"
+    repo_pref_file_tmpl = "/etc/apt/preferences.d/ubuntu-{name}"
 
     # The repo Origin value for setting pinning
     origin = None  # type: Optional[str]
@@ -223,10 +223,7 @@ class RepoEntitlement(base.UAEntitlement):
             old_url = orig_entitlement.get("directives", {}).get("aptURL")
             if old_url:
                 # Remove original aptURL and auth and rewrite
-                series = util.get_platform_info()["series"]
-                repo_filename = self.repo_list_file_tmpl.format(
-                    name=self.name, series=series
-                )
+                repo_filename = self.repo_list_file_tmpl.format(name=self.name)
                 apt.remove_auth_apt_repo(repo_filename, old_url)
         self.remove_apt_config()
         self.setup_apt_config()
@@ -238,10 +235,7 @@ class RepoEntitlement(base.UAEntitlement):
         :raise UserFacingError: on failure to setup any aspect of this apt
            configuration
         """
-        series = util.get_platform_info()["series"]
-        repo_filename = self.repo_list_file_tmpl.format(
-            name=self.name, series=series
-        )
+        repo_filename = self.repo_list_file_tmpl.format(name=self.name)
         resource_cfg = self.cfg.entitlements.get(self.name)
         directives = resource_cfg["entitlement"].get("directives", {})
         token = resource_cfg.get("resourceToken")
@@ -279,9 +273,7 @@ class RepoEntitlement(base.UAEntitlement):
                         ),
                     )
                 )
-            repo_pref_file = self.repo_pref_file_tmpl.format(
-                name=self.name, series=series
-            )
+            repo_pref_file = self.repo_pref_file_tmpl.format(name=self.name)
             if self.repo_pin_priority != "never":
                 apt.add_ppa_pinning(
                     repo_pref_file,
@@ -331,9 +323,7 @@ class RepoEntitlement(base.UAEntitlement):
     def remove_apt_config(self):
         """Remove any repository apt configuration files."""
         series = util.get_platform_info()["series"]
-        repo_filename = self.repo_list_file_tmpl.format(
-            name=self.name, series=series
-        )
+        repo_filename = self.repo_list_file_tmpl.format(name=self.name)
         entitlement = self.cfg.entitlements[self.name].get("entitlement", {})
         access_directives = entitlement.get("directives", {})
         repo_url = access_directives.get("aptURL")
@@ -351,9 +341,7 @@ class RepoEntitlement(base.UAEntitlement):
             )
             apt.remove_apt_list_files(repo_url, series)
         if self.repo_pin_priority:
-            repo_pref_file = self.repo_pref_file_tmpl.format(
-                name=self.name, series=series
-            )
+            repo_pref_file = self.repo_pref_file_tmpl.format(name=self.name)
             if self.repo_pin_priority == "never":
                 # Disable the repo with a pinning file
                 apt.add_ppa_pinning(

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -156,7 +156,7 @@ class TestCommonCriteriaEntitlementEnable:
 
         add_apt_calls = [
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-cc-eal-xenial.list",
+                "/etc/apt/sources.list.d/ubuntu-cc-eal.list",
                 "http://CC",
                 "{}-token".format(entitlement.name),
                 ["xenial"],

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -60,7 +60,7 @@ class TestCISEntitlementEnable:
 
         add_apt_calls = [
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list",
+                "/etc/apt/sources.list.d/ubuntu-cis-audit.list",
                 "http://CIS-AUDIT",
                 "{}-token".format(entitlement.name),
                 ["xenial"],

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -81,7 +81,7 @@ class TestESMInfraEntitlementEnable:
         original_exists = os.path.exists
 
         def fake_exists(path):
-            prefs_path = "/etc/apt/preferences.d/ubuntu-{}-trusty".format(
+            prefs_path = "/etc/apt/preferences.d/ubuntu-{}".format(
                 entitlement.name
             )
             if path == prefs_path:
@@ -127,7 +127,7 @@ class TestESMInfraEntitlementEnable:
 
         add_apt_calls = [
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-{}-trusty.list".format(
+                "/etc/apt/sources.list.d/ubuntu-{}.list".format(
                     entitlement.name
                 ),
                 "http://{}".format(entitlement.name.upper()),
@@ -160,9 +160,7 @@ class TestESMInfraEntitlementEnable:
         if entitlement.name == "esm-infra":  # Remove "never" apt pref pin
             unlink_calls = [
                 mock.call(
-                    "/etc/apt/preferences.d/ubuntu-{}-trusty".format(
-                        entitlement.name
-                    )
+                    "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name)
                 )
             ]
         else:
@@ -176,7 +174,7 @@ class TestESMInfraEntitlementEnable:
         original_exists = os.path.exists
 
         def fake_exists(path):
-            prefs_path = "/etc/apt/preferences.d/ubuntu-{}-trusty".format(
+            prefs_path = "/etc/apt/preferences.d/ubuntu-{}".format(
                 entitlement.name
             )
             if path == prefs_path:
@@ -227,7 +225,7 @@ class TestESMInfraEntitlementEnable:
 
         add_apt_calls = [
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-{}-trusty.list".format(
+                "/etc/apt/sources.list.d/ubuntu-{}.list".format(
                     entitlement.name
                 ),
                 "http://{}".format(entitlement.name.upper()),
@@ -255,9 +253,7 @@ class TestESMInfraEntitlementEnable:
             # Enable esm-infra trusty removes apt preferences pin 'never' file
             unlink_calls = [
                 mock.call(
-                    "/etc/apt/preferences.d/ubuntu-{}-trusty".format(
-                        entitlement.name
-                    )
+                    "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name)
                 )
             ]
         else:

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -172,7 +172,7 @@ class TestFIPSEntitlementEnable:
         repo_url = "http://{}".format(entitlement.name.upper())
         add_apt_calls = [
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-{}-xenial.list".format(
+                "/etc/apt/sources.list.d/ubuntu-{}.list".format(
                     entitlement.name
                 ),
                 repo_url,
@@ -183,9 +183,7 @@ class TestFIPSEntitlementEnable:
         ]
         apt_pinning_calls = [
             mock.call(
-                "/etc/apt/preferences.d/ubuntu-{}-xenial".format(
-                    entitlement.name
-                ),
+                "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name),
                 repo_url,
                 entitlement.origin,
                 1001,

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -25,7 +25,7 @@ from uaclient.apt import (
     assert_valid_apt_credentials,
 )
 from uaclient import apt, exceptions, util
-from uaclient.entitlements.tests.test_base import ConcreteTestEntitlement
+from uaclient.entitlements.tests.test_repo import RepoTestEntitlement
 
 
 POST_INSTALL_APT_CACHE_NO_UPDATES = """
@@ -558,7 +558,7 @@ class TestCleanAptFiles:
             with open(pref_name, "w") as f:
                 f.write("")
 
-        m_entitlement = mock.Mock(spec=ConcreteTestEntitlement)
+        m_entitlement = mock.Mock(spec=RepoTestEntitlement)
         m_entitlement.configure_mock(
             name=entitlement_name,
             repo_url="some url",
@@ -570,7 +570,7 @@ class TestCleanAptFiles:
     @mock.patch("uaclient.apt.os.unlink")
     def test_no_removals_for_no_repo_entitlements(self, m_os_unlink):
         m_entitlements = mock.Mock()
-        m_entitlements.ENTITLEMENT_CLASSES = [ConcreteTestEntitlement]
+        m_entitlements.ENTITLEMENT_CLASSES = [RepoTestEntitlement]
 
         clean_apt_files(_entitlements=m_entitlements)
 


### PR DESCRIPTION
RepoEntitlemnt.repo_url class attribute was dropped in 95a89e2.

Adapt clean_apt_files to operate on any RepoEntitlement subclass.

Fixes: #1170
