### PR TITLE
tests: fix pycloudlib integration-reqs, support trusty and drop eoan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -555,22 +555,6 @@ matrix:
         - cp ubuntu-advantage-tools-pro-bionic.deb bionic-debs
         - ls bionic-debs
     - env:
-        PACKAGE_BUILD_SERIES=eoan
-      stage: build
-      workspaces:
-        create:
-          name: eoan
-          paths:
-            - eoan-debs
-      install:
-        - make travis-deb-install
-      script:
-        - make travis-deb-script
-        - mkdir eoan-debs
-        - cp ubuntu-advantage-tools-eoan.deb eoan-debs
-        - cp ubuntu-advantage-tools-pro-eoan.deb eoan-debs
-        - ls eoan-debs
-    - env:
         PACKAGE_BUILD_SERIES=focal
       stage: build
       workspaces:
@@ -597,9 +581,6 @@ matrix:
     - python: 3.6
       stage: flake
       env: TOXENV=py3-bionic,flake8-bionic
-    - python: 3.7
-      stage: flake
-      env: TOXENV=py3-eoan,flake8-eoan
     - python: 3.8
       stage: flake
       env: TOXENV=py3,flake8

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -14,7 +14,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         UA Infrastructure Extended Security Maintenance \(ESM\) is not enabled.
 
         \d+ update(s)? can be installed immediately.
-        \d+ of these updates are security updates.
+        \d+ of these updates (is a|are) security update(s)?.
 
         Enable UA Infrastructure ESM to receive \d+ additional security update(s)?.
         See https://ubuntu.com/advantage or run: sudo ua status
@@ -27,7 +27,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Then if `<release>` in `focal` and stdout matches regexp:
         """
         \d+ updates can be installed immediately.
-        \d+ of these updates are security updates.
+        \d+ of these updates (is a|are) security update(s)?.
         """
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
@@ -56,7 +56,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         \d+ updates can be installed immediately.
         \d+ of these updates (is|are) provided through UA Infrastructure ESM.
-        \d+ of these updates (is|are) security updates.
+        \d+ of these updates (is a|are) security update(s)?.
         To see these additional updates run: apt list --upgradable
         """
         Then if `<release>` in `xenial or bionic` and stdout matches regexp:

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -14,12 +14,15 @@ except ImportError:
 class Cloud:
     """Base class for cloud providers that should be tested through behave.
 
-    :param tag:
-        A tag to be used when creating the resources on the cloud provider
-    :region:
-        The region to create the cloud resources on
     :machine_type:
         A string representing the type of machine to launch (pro or generic)
+    :region:
+        The region to create the cloud resources on
+    :param tag:
+        A tag to be used when creating the resources on the cloud provider
+    :timestamp_suffix:
+        Boolean set true to direct pycloudlib to append a timestamp to the end
+        of the provided tag.
     """
 
     name = ""
@@ -31,6 +34,7 @@ class Cloud:
         machine_type: str,
         region: "Optional[str]" = None,
         tag: "Optional[str]" = None,
+        timestamp_suffix: bool = True,
     ) -> None:
         if tag:
             self.tag = tag
@@ -40,6 +44,7 @@ class Cloud:
         self.region = region
         self._api = None
         self.key_name = pycloudlib.util.get_timestamped_tag(self.tag)
+        self.timestamp_suffix = timestamp_suffix
 
         missing_env_vars = self.missing_env_vars()
         if missing_env_vars:
@@ -200,6 +205,9 @@ class EC2(Cloud):
         A string representing the type of machine to launch (pro or generic)
     :tag:
         A tag to be used when creating the resources on the cloud provider
+    :timestamp_suffix:
+        Boolean set true to direct pycloudlib to append a timestamp to the end
+        of the provided tag.
     """
 
     name = "aws"
@@ -216,13 +224,19 @@ class EC2(Cloud):
         machine_type: str,
         region: "Optional[str]" = "us-east-2",
         tag: "Optional[str]" = None,
+        timestamp_suffix: bool = True,
     ) -> None:
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         logging.basicConfig(
             filename="pycloudlib-behave.log", level=logging.DEBUG
         )
-        super().__init__(region=region, machine_type=machine_type, tag=tag)
+        super().__init__(
+            region=region,
+            machine_type=machine_type,
+            tag=tag,
+            timestamp_suffix=timestamp_suffix,
+        )
 
     @property
     def api(self) -> pycloudlib.cloud.BaseCloud:
@@ -233,6 +247,7 @@ class EC2(Cloud):
                 access_key_id=self.aws_access_key_id,
                 secret_access_key=self.aws_secret_access_key,
                 region=self.region,
+                timestamp_suffix=self.timestamp_suffix,
             )
 
         return self._api
@@ -319,10 +334,13 @@ class Azure(Cloud):
         The Azure subscription id
     :machine_type:
         A string representing the type of machine to launch (pro or generic)
-    :tag:
-        A tag to be used when creating the resources on the cloud provider
     :region:
         The region to create the resources on
+    :tag:
+        A tag to be used when creating the resources on the cloud provider
+    :timestamp_suffix:
+        Boolean set true to direct pycloudlib to append a timestamp to the end
+        of the provided tag.
     """
 
     name = "Azure"
@@ -339,6 +357,7 @@ class Azure(Cloud):
         machine_type: str,
         region: "Optional[str]" = "centralus",
         tag: "Optional[str]" = None,
+        timestamp_suffix: bool = True,
         az_client_id: "Optional[str]" = None,
         az_client_secret: "Optional[str]" = None,
         az_tenant_id: "Optional[str]" = None,
@@ -349,7 +368,12 @@ class Azure(Cloud):
         self.az_tenant_id = az_tenant_id
         self.az_subscription_id = az_subscription_id
 
-        super().__init__(machine_type=machine_type, region=region, tag=tag)
+        super().__init__(
+            machine_type=machine_type,
+            region=region,
+            tag=tag,
+            timestamp_suffix=timestamp_suffix,
+        )
 
     @property
     def api(self) -> pycloudlib.cloud.BaseCloud:
@@ -361,6 +385,7 @@ class Azure(Cloud):
                 client_secret=self.az_client_secret,
                 tenant_id=self.az_tenant_id,
                 subscription_id=self.az_subscription_id,
+                timestamp_suffix=self.timestamp_suffix,
             )
 
         return self._api

--- a/features/environment.py
+++ b/features/environment.py
@@ -216,6 +216,7 @@ class UAClientBehaveConfig:
                 region=os.environ.get("AWS_DEFAULT_REGION", "us-east-2"),
                 machine_type=self.machine_type,
                 tag=timed_job_tag,
+                timestamp_suffix=False,
             )
             self.cloud_api = self.cloud_manager.api
         elif "azure" in self.machine_type:
@@ -226,6 +227,7 @@ class UAClientBehaveConfig:
                 az_subscription_id=az_subscription_id,
                 machine_type=self.machine_type,
                 tag=timed_job_tag,
+                timestamp_suffix=False,
             )
             self.cloud_api = self.cloud_manager.api
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -209,6 +209,7 @@ class UAClientBehaveConfig:
         timed_job_tag = datetime.datetime.utcnow().strftime(
             "uaclient-ci-%m%d-"
         ) + os.environ.get("TRAVIS_JOB_NUMBER", "dev")
+        timed_job_tag = timed_job_tag.replace(".", "-")
         if "aws" in self.machine_type:
             self.cloud_manager = cloud.EC2(
                 aws_access_key_id,

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-git+https://github.com/canonical/pycloudlib.git
+git+https://github.com/blackboxsw/pycloudlib.git
 
 # Simplestreams is not found on PyPi so pull from repo directly
 git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-git+https://github.com/blackboxsw/pycloudlib.git
+git+https://github.com/canonical/pycloudlib.git
 
 # Simplestreams is not found on PyPi so pull from repo directly
 git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d

--- a/tools/constraints-eoan.txt
+++ b/tools/constraints-eoan.txt
@@ -1,7 +1,0 @@
-attrs==18.2
-flake8==3.7.8
-py==1.8.0
-pycodestyle==2.5.0
-pytest==3.10.1
-pytest-cov==2.7.1
-pyyaml==5.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, flake8, py3-{xenial,bionic,eoan}, flake8-{trusty,xenial,bionic,eoan}, mypy, black
+envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic}, mypy, black
 
 [testenv]
 deps =
@@ -8,7 +8,6 @@ deps =
     trusty: -ctools/constraints-trusty.txt
     xenial: -ctools/constraints-xenial.txt
     bionic: -ctools/constraints-bionic.txt
-    eoan: -ctools/constraints-eoan.txt
     mypy: mypy
     black: -rdev-requirements.txt
     behave: -rintegration-requirements.txt
@@ -25,7 +24,6 @@ commands =
     py3: py.test {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient setup.py
     flake8-bionic: flake8 features
-    flake8-eoan: flake8 features
     mypy: mypy --python-version 3.4 uaclient/
     mypy: mypy --python-version 3.5 uaclient/
     mypy: mypy --python-version 3.6 uaclient/ features/


### PR DESCRIPTION
commit fd6f4c28740d36334623f192f2e826eac01a406c leaked development testing
pycloudlib dependency

The following integration test changes are included in this branch:
- Provide the `timestamp_suffix=False` param to cloud_api setup to make sure pycloudlib doesn't append
  a second timestamp suffix to the tag used during resource and instance creation
- separate trusty vs non-trusty apt source cloud-config because cloud-config option formats differ on trusty
- drop Ubuntu Eoan tox and travis test targets as that release support hit EOL on 07/2020.
- replace leaked blackboxsw/pycloudlib with canonical/pycloudlib integration dependency



