### PR TITLE
Add integration test for purge command

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -18,6 +18,8 @@ remove_logs(){
 
 remove_gpg_files(){
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg
+    rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-apps.gpg
+    rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-fips.gpg
 }
 
 case "$1" in

--- a/debian/postrm
+++ b/debian/postrm
@@ -16,11 +16,8 @@ remove_logs(){
     rm -f /var/log/ubuntu-advantage.log*
 }
 
-remove_postinst_created_files(){
-    # config files created in postinst, need explicit handling on purge
+remove_gpg_files(){
     rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg
-    rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list
-    rm -f /etc/apt/preferences.d/ubuntu-esm-infra-trusty
 }
 
 case "$1" in
@@ -28,6 +25,7 @@ case "$1" in
         remove_apt_auth
         remove_cache_dir
         remove_logs
+        remove_gpg_files
         ;;
 esac
 

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -325,3 +325,33 @@ Feature: Command behaviour when attached to an UA subscription
            | focal   |
            | trusty  |
            | xenial  |
+
+    @series.all
+    Scenario Outline: Purge package after attaching it to a machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `touch /etc/apt/preferences.d/ubuntu-esm-infra` with sudo
+        Then I verify that running `test -f /var/log/ubuntu-advantage.log` `with sudo` exits `0`
+        And I verify that running `test -d /var/lib/ubuntu-advantage` `with sudo` exits `0`
+        And I verify that running `test -f /etc/apt/auth.conf.d/90ubuntu-advantage` `with sudo` exits `0`
+        And I verify that running `test -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg` `with sudo` exits `0`
+        And I verify that running `test -f /etc/apt/sources.list.d/ubuntu-esm-infra.list` `with sudo` exits `0`
+        And I verify that running `test -f /etc/apt/preferences.d/ubuntu-esm-infra` `with sudo` exits `0`
+        When I run `apt-get purge ubuntu-advantage-tools -y` with sudo
+        Then stdout matches regexp:
+        """
+        Purging configuration files for ubuntu-advantage-tools
+        """
+        And I verify that running `test -f /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that running `test -d /var/lib/ubuntu-advantage` `with sudo` exits `1`
+        And I verify that running `test -f /etc/apt/auth.conf.d/90ubuntu-advantage` `with sudo` exits `1`
+        And I verify that running `test -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg` `with sudo` exits `1`
+        And I verify that running `test -f /etc/apt/sources.list.d/ubuntu-esm-infra.list` `with sudo` exits `1`
+        And I verify that running `test -f /etc/apt/preferences.d/ubuntu-esm-infra` `with sudo` exits `1`
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -331,23 +331,23 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `touch /etc/apt/preferences.d/ubuntu-esm-infra` with sudo
-        Then I verify that running `test -f /var/log/ubuntu-advantage.log` `with sudo` exits `0`
+        Then I verify that files exist matching `/var/log/ubuntu-advantage.log`
         And I verify that running `test -d /var/lib/ubuntu-advantage` `with sudo` exits `0`
-        And I verify that running `test -f /etc/apt/auth.conf.d/90ubuntu-advantage` `with sudo` exits `0`
-        And I verify that running `test -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg` `with sudo` exits `0`
-        And I verify that running `test -f /etc/apt/sources.list.d/ubuntu-esm-infra.list` `with sudo` exits `0`
-        And I verify that running `test -f /etc/apt/preferences.d/ubuntu-esm-infra` `with sudo` exits `0`
+        And I verify that files exist matching `/etc/apt/auth.conf.d/90ubuntu-advantage`
+        And I verify that files exist matching `/etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg`
+        And I verify that files exist matching `/etc/apt/sources.list.d/ubuntu-esm-infra.list`
+        And I verify that files exist matching `/etc/apt/preferences.d/ubuntu-esm-infra`
         When I run `apt-get purge ubuntu-advantage-tools -y` with sudo
         Then stdout matches regexp:
         """
         Purging configuration files for ubuntu-advantage-tools
         """
-        And I verify that running `test -f /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that running `test -d /var/lib/ubuntu-advantage` `with sudo` exits `1`
-        And I verify that running `test -f /etc/apt/auth.conf.d/90ubuntu-advantage` `with sudo` exits `1`
-        And I verify that running `test -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg` `with sudo` exits `1`
-        And I verify that running `test -f /etc/apt/sources.list.d/ubuntu-esm-infra.list` `with sudo` exits `1`
-        And I verify that running `test -f /etc/apt/preferences.d/ubuntu-esm-infra` `with sudo` exits `1`
+        And I verify that no files exist matching `/var/log/ubuntu-advantage.log`
+        And I verify that no files exist matching `/var/lib/ubuntu-advantage`
+        And I verify that no files exist matching `/etc/apt/auth.conf.d/90ubuntu-advantage`
+        And I verify that no files exist matching `/etc/apt/sources.list.d/ubuntu-*`
+        And I verify that no files exist matching `/etc/apt/trusted.gpg.d/ubuntu-advantage-*`
+        And I verify that no files exist matching `/etc/apt/preferences.d/ubuntu-*`
 
         Examples: ubuntu release
            | release |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -214,6 +214,22 @@ def then_apt_cache_policy_for_the_following_url_has_permission_perm_id(
     assert_that(context.process.stdout.strip(), matches_regexp(full_url))
 
 
+@then("I verify that files exist matching `{path_regex}`")
+def there_should_be_files_matching_regex(context, path_regex):
+    when_i_run_command(context, "ls {}".format(path_regex), "with sudo")
+    if context.process.returncode != 0:
+        raise AssertionError("Missing expected files: {}".format(path_regex))
+
+
+@then("I verify that no files exist matching `{path_regex}`")
+def there_should_be_no_files_matching_regex(context, path_regex):
+    when_i_run_command(context, "ls {}".format(path_regex), "with sudo")
+    if context.process.returncode == 0:
+        raise AssertionError(
+            "Unexpected files found: {}".format(context.process.stdout.strip())
+        )
+
+
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
     if user_spec == "with sudo":

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -321,7 +321,7 @@ def clean_apt_files(*, _entitlements=None):
         from uaclient import entitlements as _entitlements
 
     for ent_cls in _entitlements.ENTITLEMENT_CLASSES:
-        if not isinstance(ent_cls(), RepoEntitlement):
+        if not issubclass(ent_cls, RepoEntitlement):
             continue
         repo_file = ent_cls.repo_list_file_tmpl.format(name=ent_cls.name)
         pref_file = ent_cls.repo_pref_file_tmpl.format(name=ent_cls.name)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -321,7 +321,7 @@ def clean_apt_files(*, _entitlements=None):
         from uaclient import entitlements as _entitlements
 
     for ent_cls in _entitlements.ENTITLEMENT_CLASSES:
-        if not isinstance(ent_cls, RepoEntitlement):
+        if not isinstance(ent_cls(), RepoEntitlement):
             continue
         repo_file = ent_cls.repo_list_file_tmpl.format(name=ent_cls.name)
         pref_file = ent_cls.repo_pref_file_tmpl.format(name=ent_cls.name)

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -558,7 +558,8 @@ class TestCleanAptFiles:
             with open(pref_name, "w") as f:
                 f.write("")
 
-        m_entitlement = mock.Mock(spec=RepoTestEntitlement)
+        m_entitlement = mock.Mock()
+        m_entitlement.return_value = mock.Mock(spec=RepoTestEntitlement)
         m_entitlement.configure_mock(
             name=entitlement_name,
             repo_list_file_tmpl=repo_tmpl,


### PR DESCRIPTION
Create behave integration test for `apt purge ubuntu-advantage-tools`

To do that we had to:

* Fix the `clean_apt_files` method
* Update the `remove_postinst_created_files` function to only delete gpg keys. The other files should be handled by `clean_apt_files`in `prerm`
* Update postinst to not recreate old apt files for esm-infra for the trusty package