### PR TITLE
Do not remove packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    name: trusty-flake8
   include:
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY)
       stage: build
@@ -832,6 +834,7 @@ matrix:
         - cp ubuntu-advantage-tools-pro-focal.deb focal-debs
         - ls focal-debs
     - python: 3.4
+      name: trusty-flake8
       stage: flake
       env: TOXENV=py3-trusty,flake8-trusty
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ script:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    -name: azurepro-16.04
   include:
     - if: env(UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY)
       stage: build
@@ -238,7 +236,6 @@ matrix:
           - echo $TRAVIS_JOB_NUMBER
           - python3 server-test-scripts/ubuntu-advantage-client/azure_cleanup.py --suffix-tag ${TRAVIS_JOB_NUMBER/./-} --client-id ${UACLIENT_BEHAVE_AZ_CLIENT_ID} --client-secret ${UACLIENT_BEHAVE_AZ_CLIENT_SECRET} --subscription-id ${UACLIENT_BEHAVE_AZ_SUBSCRIPTION_ID} --tenant-id ${UACLIENT_BEHAVE_AZ_TENANT_ID} || true
     - if: env(UACLIENT_BEHAVE_AZ_CLIENT_SECRET)
-      name: azurepro-16.04
       python: 3.7
       stage: integration
       env: 

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -289,23 +289,9 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.xenial
-    @uses.config.machine_type.lxd.vm
-    Scenario: Attached enable of vm-based services in a bionic lxd vm
-        Given a `xenial` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        When I run `ua disable livepatch` with sudo
-        And I run `ua enable fips --assume-yes --beta` with sudo
-        Then stdout matches regexp:
-            """
-            Updating package lists
-            Installing FIPS packages
-            FIPS enabled
-            A reboot is required to complete install
-            """
-
     @series.bionic
     @uses.config.machine_type.lxd.vm
-    Scenario Outline: Attached enable of vm-based services in a bionic lxd vm
+    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` with sudo
@@ -328,6 +314,39 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             fips
             """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+
+    @series.bionic
+    @series.xenial
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attached enable of vm-based services in a bionic lxd vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua status` with sudo
+        Then stdout matches regexp:
+        """
+        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
+        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
+        livepatch    +yes      +enabled  +Canonical Livepatch service
+        """
+        When I run `ua disable livepatch` with sudo
+        And I run `canonical-livepatch status` with sudo
+        Then stdout matches regexp:
+        """
+        Machine is not enabled. Please run 'sudo canonical-livepatch enable' with the
+        token obtained from https://ubuntu.com/livepatch.
+        """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+        """
+        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
+        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
+        livepatch    +yes      +disabled +Canonical Livepatch service
+        """
 
         Examples: ubuntu release
            | release |

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -187,10 +187,6 @@ class LivepatchEntitlement(base.UAEntitlement):
         if not util.which("/snap/bin/canonical-livepatch"):
             return True
         util.subp(["/snap/bin/canonical-livepatch", "disable"], capture=True)
-        logging.debug("Removing canonical-livepatch snap")
-        if not silent:
-            print("Removing canonical-livepatch snap")
-        util.subp([SNAP_CMD, "remove", "canonical-livepatch"], capture=True)
         return True
 
     def application_status(self) -> "Tuple[ApplicationStatus, str]":

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -160,10 +160,6 @@ class RepoEntitlement(base.UAEntitlement):
     def _cleanup(self) -> None:
         """Clean up the entitlement without checks or messaging"""
         self.remove_apt_config()
-        try:
-            util.subp(["apt-get", "remove", "--assume-yes"] + self.packages)
-        except util.ProcessExecutionError:
-            pass
 
     def application_status(self) -> "Tuple[ApplicationStatus, str]":
         entitlement_cfg = self.cfg.entitlements.get(self.name, {})

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -355,34 +355,25 @@ class TestRepoEnable:
         assert can_enable_call_count == m_can_enable.call_count
 
     @pytest.mark.parametrize(
-        "pre_disable_msg,post_disable_msg,output,remove_apt_call_count,retval",
+        "pre_disable_msg,post_disable_msg,output,retval",
         (
             (
                 ["pre1", (lambda: False, {}), "pre2"],
                 ["post1"],
                 "pre1\n",
-                0,
                 False,
             ),
-            (
-                ["pre1", (lambda: True, {}), "pre2"],
-                [],
-                "pre1\npre2\n",
-                1,
-                True,
-            ),
+            (["pre1", (lambda: True, {}), "pre2"], [], "pre1\npre2\n", True),
             (
                 ["pre1", (lambda: True, {}), "pre2"],
                 ["post1", (lambda: False, {}), "post2"],
                 "pre1\npre2\npost1\n",
-                1,
                 False,
             ),
             (
                 ["pre1", (lambda: True, {}), "pre2"],
                 ["post1", (lambda: True, {}), "post2"],
                 "pre1\npre2\npost1\npost2\n",
-                1,
                 True,
             ),
         ),
@@ -400,7 +391,6 @@ class TestRepoEnable:
         pre_disable_msg,
         post_disable_msg,
         output,
-        remove_apt_call_count,
         retval,
         entitlement,
         capsys,
@@ -415,11 +405,6 @@ class TestRepoEnable:
                 assert retval is entitlement.disable()
         stdout, _ = capsys.readouterr()
         assert output == stdout
-        assert remove_apt_call_count == remove_apt_config.call_count
-        if remove_apt_call_count > 0:
-            assert [
-                mock.call(["apt-get", "remove", "--assume-yes"])
-            ] == m_subp.call_args_list
 
     @pytest.mark.parametrize("should_reboot", (False, True))
     @pytest.mark.parametrize("with_pre_install_msg", (False, True))
@@ -558,10 +543,6 @@ class TestRepoEnable:
                             entitlement.enable()
 
         assert "Could not enable Repo Test Class." == excinfo.value.msg
-        expected_call = mock.call(
-            ["apt-get", "remove", "--assume-yes"] + packages
-        )
-        assert expected_call in m_subp.call_args_list
         assert 1 == m_rac.call_count
 
 


### PR DESCRIPTION
When we perform a `disable` or `detach` operation, we end up removing packages that were installed to enable the services. We are now keeping those packages installed when we perform those operations.

Also, this PR is removing the `azurepro-16.04` from `allow_failures`, since the job is running without issues