### PR TITLE
Add help content for services

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -300,23 +300,36 @@ Feature: Command behaviour when attached to an UA subscription
         And I run `ua help esm-infra` with sudo
         Then I will see the following on stdout:
             """
-            name: esm-infra
-            entitled: yes
-            status: enabled
-            help:
-            esm-infra help
-            Information about esm-infra
+            Name:
+            esm-infra
+
+            Entitled:
+            yes
+
+            Status:
+            enabled
+
+            Help:
+            UA Infra: Extended Security Maintenance is enabled by default on entitled
+            workloads. It provides access to a private PPA which includes available
+            high and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main
+            repository between the end of the standard (free) Ubuntu LTS security
+            maintenance and its end of life. You can find out more about the esm
+            service at https://ubuntu.com/security/esm.
             """
         When I run `ua help esm-infra --format json` with sudo
         Then I will see the following on stdout:
             """
-            {"name": "esm-infra", "entitled": "yes", "status": "enabled", "help": "esm-infra help\nInformation about esm-infra"}
+            {"name": "esm-infra", "entitled": "yes", "status": "enabled", "help": "UA Infra: Extended Security Maintenance is enabled by default on entitled\nworkloads. It provides access to a private PPA which includes available\nhigh and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main\nrepository between the end of the standard (free) Ubuntu LTS security\nmaintenance and its end of life. You can find out more about the esm\nservice at https://ubuntu.com/security/esm.\n"}
             """
         When I run `ua help invalid-service` with sudo
         Then I will see the following on stdout:
             """
-            name: invalid-service
-            help: No help available for service "invalid-service"
+            Name:
+            invalid-service
+
+            Help:
+            No help available for "invalid-service"
             """
 
         Examples: ubuntu release

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -89,22 +89,33 @@ Feature: Command behaviour when unattached
         When I run `ua help esm-infra` as non-root
         Then I will see the following on stdout:
             """
-            name: esm-infra
-            available: yes
-            help:
-            esm-infra help
-            Information about esm-infra
+            Name:
+            esm-infra
+
+            Available:
+            yes
+
+            Help:
+            UA Infra: Extended Security Maintenance is enabled by default on entitled
+            workloads. It provides access to a private PPA which includes available
+            high and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main
+            repository between the end of the standard (free) Ubuntu LTS security
+            maintenance and its end of life. You can find out more about the esm
+            service at https://ubuntu.com/security/esm.
             """
         When I run `ua help esm-infra --format json` with sudo
         Then I will see the following on stdout:
             """
-            {"name": "esm-infra", "available": "yes", "help": "esm-infra help\nInformation about esm-infra"}
+            {"name": "esm-infra", "available": "yes", "help": "UA Infra: Extended Security Maintenance is enabled by default on entitled\nworkloads. It provides access to a private PPA which includes available\nhigh and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main\nrepository between the end of the standard (free) Ubuntu LTS security\nmaintenance and its end of life. You can find out more about the esm\nservice at https://ubuntu.com/security/esm.\n"}
             """
         When I run `ua help invalid-service` with sudo
         Then I will see the following on stdout:
             """
-            name: invalid-service
-            help: No help available for service "invalid-service"
+            Name:
+            invalid-service
+
+            Help:
+            No help available for "invalid-service"
             """
 
         Examples: ubuntu release

--- a/help-data.yaml
+++ b/help-data.yaml
@@ -1,8 +1,0 @@
-esm-infra:
-   help: |
-     esm-infra help
-     Information about esm-infra
-esm-apps:
-    help: |
-      esm-apps help
-      Information about esm-apps

--- a/help_data.yaml
+++ b/help_data.yaml
@@ -1,0 +1,65 @@
+cc-eal:
+    help: |
+      Common Criteria is an Information Technology Security Evaluation standard
+      (ISO/IEC IS 15408) for computer security certification. Ubuntu 16.04 has
+      been evaluated to assurance level EAL2 through CSEC. The evaluation was
+      performed on Intel x86_64, IBM Power8 and IBM Z hardware platforms.
+
+cis:
+    help: |
+      CIS benchmarks locks down your systems by removing non-secure programs,
+      disabling unused filesystems, disabling unnecessary ports or services to
+      prevent cyber attacks and malware, auditing privileged operations and
+      restricting administrative privileges. The cis-audit command installs
+      tooling needed to automate audit and hardening according to a desired
+      CIS profile - level 1 or level 2 for server or workstation on
+      Ubuntu 18.04 LTS or 16.04 LTS. The audit tooling uses OpenSCAP libraries
+      to do a scan of the system. The tool provides options to generate a
+      report in XML or a html format. The report shows compliance for all the
+      rules against the profile selected during the scan. You can find out
+      more at https://ubuntu.com/security/hardening
+
+esm-apps:
+    help: |
+      UA Apps: Extended Security Maintenance is enabled by default on entitled
+      workloads. It provides access to a private PPA which includes available
+      high and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main
+      and Ubuntu Universe repositories from the Ubuntu LTS release date until
+      its end of life. You can find out more about the esm service at
+      https://ubuntu.com/security/esm
+
+esm-infra:
+   help: |
+     UA Infra: Extended Security Maintenance is enabled by default on entitled
+     workloads. It provides access to a private PPA which includes available
+     high and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main
+     repository between the end of the standard (free) Ubuntu LTS security
+     maintenance and its end of life. You can find out more about the esm
+     service at https://ubuntu.com/security/esm.
+
+fips:
+    help: |
+      FIPS 140-2 is a set of publicly announced cryptographic standards
+      developed by the National Institute of Standards and Technology
+      applicable for FedRAMP, HIPAA, PCI and ISO compliance use cases.
+      Note that ‘FIPS’ does not provide security patching. For FIPS
+      certified modules with security patches please refer to FIPS Updates.
+      The modules are certified on Intel x86_64 and IBM Z hardware platforms
+      for Ubuntu 18.04 and Intel x86_64, IBM Power8 and IBM Z hardware platforms
+      for Ubuntu 16.04. You can find out more at https://ubuntu.com/security/fips.
+
+fips-updates:
+    help: |
+      FIPS Updates installs FIPS updates modules including all security patches
+      for those modules that have been provided since their certification date.
+      You can find out more at ubuntu.com/security/fips
+
+livepatch:
+    help: |
+      Livepatch provides selected high and critical kernel CVE fixes and other
+      non-security bug fixes as kernel livepatches. Livepatches are applied
+      without rebooting a machine which drastically limits the need for
+      unscheduled system reboots. Due to the nature of FIPS compliance,
+      livepatches cannot be enabled on FIPS-enabled systems. You can find out
+      more about Ubuntu Kernel Livepatch service at
+      https://ubuntu.com/security/livepatch

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def _get_version():
 
 def _get_data_files():
     data_files = [
-        ("/etc/ubuntu-advantage", ["uaclient.conf"]),
+        ("/etc/ubuntu-advantage", ["uaclient.conf", "help_data.yaml"]),
         ("/usr/lib/ubuntu-advantage", glob.glob("lib/[!_]*")),
         ("/usr/share/keyrings", glob.glob("keyrings/*")),
         (

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -791,10 +791,7 @@ def action_help(args, cfg):
         print(json.dumps(help_response))
     else:
         for key, value in help_response.items():
-            if "\n" in str(value):
-                print("{}:\n{}".format(key, value))
-            elif value:
-                print("{}: {}".format(key, value))
+            print("{}:\n{}\n".format(key.title(), value))
 
     return 0
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -451,16 +451,14 @@ class UAConfig:
         response_dict["name"] = name
 
         for resource in resources:
-            if resource["name"] == name:
+            if resource["name"] == name and name in ENTITLEMENT_CLASS_BY_NAME:
                 help_resource = resource
                 help_ent_cls = ENTITLEMENT_CLASS_BY_NAME.get(name)
                 help_ent = help_ent_cls(self)
                 break
 
         if help_resource is None:
-            response_dict[
-                "help"
-            ] = 'No help available for service "{}"'.format(name)
+            response_dict["help"] = 'No help available for "{}"'.format(name)
             return response_dict
 
         if self.is_attached:

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -17,7 +17,3 @@ CONFIG_DEFAULTS = {
     "log_level": "INFO",
     "log_file": "/var/log/ubuntu-advantage.log",
 }
-
-DEFAULT_HELP = {
-    "esm-infra": {"help": "esm-infra help\nInformation about esm-infra"}
-}

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -22,7 +22,7 @@ from uaclient.status import (
     ContractStatus,
     UserFacingStatus,
 )
-from uaclient.defaults import DEFAULT_HELP_FILE, DEFAULT_HELP
+from uaclient.defaults import DEFAULT_HELP_FILE
 
 RE_KERNEL_UNAME = (
     r"(?P<major>[\d]+)[.-](?P<minor>[\d]+)[.-](?P<patch>[\d]+\-[\d]+)"
@@ -66,11 +66,11 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     def help_info(self) -> str:
         """Help information for the entitlement"""
         if self._help_info is None:
+            help_dict = {}
+
             if os.path.exists(DEFAULT_HELP_FILE):
                 with open(DEFAULT_HELP_FILE, "r") as f:
-                    help_dict = yaml.load(f, Loader=yaml.FullLoader)
-            else:
-                help_dict = DEFAULT_HELP
+                    help_dict = yaml.safe_load(f)
 
             self._help_info = help_dict.get(self.name, {}).get("help", "")
 

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -3,7 +3,7 @@ from uaclient.entitlements import repo
 
 class CISEntitlement(repo.RepoEntitlement):
 
-    help_doc_url = "https://ubuntu.com/cis-audit"
+    help_doc_url = "https://ubuntu.com/security/hardening"
     name = "cis-audit"
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -9,7 +9,7 @@ except ImportError:
 
 
 class ESMBaseEntitlement(repo.RepoEntitlement):
-    help_doc_url = "https://ubuntu.com/esm"
+    help_doc_url = "https://ubuntu.com/security/esm"
 
 
 class ESMAppsEntitlement(ESMBaseEntitlement):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -24,6 +24,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     # services. And security/CPC signoff on expected conf behavior.
     apt_noninteractive = True
 
+    help_doc_url = "https://ubuntu.com/security/fips"
+
     @property
     def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
         # Use a lambda so we can mock util.is_container in tests
@@ -94,7 +96,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
 class FIPSEntitlement(FIPSCommonEntitlement):
 
-    help_doc_url = "https://ubuntu.com/fips"
     name = "fips"
     title = "FIPS"
     description = "NIST-certified FIPS modules"

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -24,7 +24,7 @@ ERROR_MSG_MAP = {
 
 class LivepatchEntitlement(base.UAEntitlement):
 
-    help_doc_url = "https://ubuntu.com/livepatch"
+    help_doc_url = "https://ubuntu.com/security/livepatch"
     name = "livepatch"
     title = "Livepatch"
     description = "Canonical Livepatch service"

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -42,12 +42,16 @@ Client to manage Ubuntu Advantage services on a machine.
  - cc-eal: Common Criteria EAL2 Provisioning Packages
    (https://ubuntu.com/cc-eal)
  - cis-audit: Center for Internet Security Audit Tools
-   (https://ubuntu.com/cis-audit)
- - esm-apps: UA Apps: Extended Security Maintenance (https://ubuntu.com/esm)
- - esm-infra: UA Infra: Extended Security Maintenance (https://ubuntu.com/esm)
- - fips: NIST-certified FIPS modules (https://ubuntu.com/fips)
+   (https://ubuntu.com/security/hardening)
+ - esm-apps: UA Apps: Extended Security Maintenance
+   (https://ubuntu.com/security/esm)
+ - esm-infra: UA Infra: Extended Security Maintenance
+   (https://ubuntu.com/security/esm)
+ - fips: NIST-certified FIPS modules (https://ubuntu.com/security/fips)
  - fips-updates: Uncertified security updates to FIPS modules
- - livepatch: Canonical Livepatch service (https://ubuntu.com/livepatch)
+   (https://ubuntu.com/security/fips)
+ - livepatch: Canonical Livepatch service
+   (https://ubuntu.com/security/livepatch)
 """
 )
 
@@ -116,14 +120,11 @@ class TestCLIParser:
         (
             (
                 "tabular",
-                "\n".join(
-                    ["name: test", "available: yes", "help: Test service"]
+                "\n\n".join(
+                    ["Name:\ntest", "Available:\nyes", "Help:\nTest\n\n"]
                 ),
             ),
-            (
-                "json",
-                {"name": "test", "available": "yes", "help": "Test service"},
-            ),
+            ("json", {"name": "test", "available": "yes", "help": "Test"}),
         ),
     )
     @mock.patch("uaclient.contract.get_available_resources")
@@ -143,7 +144,7 @@ class TestCLIParser:
         type(m_args).format = m_format
 
         m_entitlement_cls = mock.MagicMock()
-        m_ent_help_info = mock.PropertyMock(return_value="Test service")
+        m_ent_help_info = mock.PropertyMock(return_value="Test")
         m_entitlement_obj = m_entitlement_cls.return_value
         type(m_entitlement_obj).help_info = m_ent_help_info
 
@@ -223,17 +224,19 @@ class TestCLIParser:
         is_beta_call_count = 1 if status_msg == "enabled" else 0
 
         expected_msgs = [
-            "name: test",
-            "entitled: {}".format(ent_msg),
-            "status: {}".format(status_msg),
+            "Name:\ntest",
+            "Entitled:\n{}".format(ent_msg),
+            "Status:\n{}".format(status_msg),
         ]
 
         if is_beta and status_msg == "enabled":
-            expected_msgs.append("beta: True")
+            expected_msgs.append("Beta:\nTrue")
 
-        expected_msgs.append("help:\nTest service\nService is being tested")
+        expected_msgs.append(
+            "Help:\nTest service\nService is being tested\n\n"
+        )
 
-        expected_msg = "\n".join(expected_msgs)
+        expected_msg = "\n\n".join(expected_msgs)
 
         fake_stdout = io.StringIO()
         with mock.patch.object(
@@ -266,8 +269,8 @@ class TestCLIParser:
             {"name": "ent1", "available": True}
         ]
 
-        expected_msg = "\n".join(
-            ["name: test", 'help: No help available for service "test"']
+        expected_msg = "\n\n".join(
+            ["Name:\ntest", 'Help:\nNo help available for "test"\n\n']
         )
 
         fake_stdout = io.StringIO()


### PR DESCRIPTION
Currently, help command for the service does not provide only a basic information for the services. We are now adding the right content for all those services when we run the help command.