### PR TITLE
cli: improve errors on invalid service_name param

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -58,8 +58,8 @@ Feature: Command behaviour when attached to an UA subscription
         When I run `ua disable foobar` with sudo
         Then stderr matches regexp:
             """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
+            Cannot disable unknown service 'foobar'.
+            Try cc-eal, cis-audit, esm-apps, esm-infra, fips, fips-updates, livepatch
             """
 
         Examples: ubuntu release
@@ -219,8 +219,8 @@ Feature: Command behaviour when attached to an UA subscription
             """
         And stderr matches regexp:
             """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
+            Cannot disable unknown service 'foobar'.
+            Try cc-eal, cis-audit, esm-apps, esm-infra, fips, fips-updates, livepatch
             """
         When I run `ua status` with sudo
         Then stdout matches regexp:
@@ -323,13 +323,9 @@ Feature: Command behaviour when attached to an UA subscription
             {"name": "esm-infra", "entitled": "yes", "status": "enabled", "help": "UA Infra: Extended Security Maintenance is enabled by default on entitled\nworkloads. It provides access to a private PPA which includes available\nhigh and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main\nrepository between the end of the standard (free) Ubuntu LTS security\nmaintenance and its end of life. You can find out more about the esm\nservice at https://ubuntu.com/security/esm.\n"}
             """
         When I run `ua help invalid-service` with sudo
-        Then I will see the following on stdout:
+        Then I will see the following on stderr:
             """
-            Name:
-            invalid-service
-
-            Help:
-            No help available for "invalid-service"
+            No help available for 'invalid-service'
             """
 
         Examples: ubuntu release

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -39,8 +39,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
         And stderr matches regexp:
             """
-            Cannot enable 'foobar, fips'
-            For a list of services see: sudo ua status
+            Cannot enable unknown service 'foobar, fips'.
+            Try esm-apps, esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -66,8 +66,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
         Then stderr matches regexp:
             """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
+            Cannot enable unknown service 'foobar'.
+            Try esm-apps, esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -166,8 +166,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
         And stderr matches regexp:
             """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
+            Cannot enable unknown service 'foobar'.
+            Try esm-apps, esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -226,8 +226,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
         And stderr matches regexp:
             """
-            Cannot enable '<service>'
-            For a list of services see: sudo ua status
+            Cannot enable unknown service '<service>'.
+            Try esm-apps, esm-infra, livepatch
             """
 
         Examples: beta services in containers

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -109,13 +109,9 @@ Feature: Command behaviour when unattached
             {"name": "esm-infra", "available": "yes", "help": "UA Infra: Extended Security Maintenance is enabled by default on entitled\nworkloads. It provides access to a private PPA which includes available\nhigh and critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main\nrepository between the end of the standard (free) Ubuntu LTS security\nmaintenance and its end of life. You can find out more about the esm\nservice at https://ubuntu.com/security/esm.\n"}
             """
         When I run `ua help invalid-service` with sudo
-        Then I will see the following on stdout:
+        Then I will see the following on stderr:
             """
-            Name:
-            invalid-service
-
-            Help:
-            No help available for "invalid-service"
+            No help available for 'invalid-service'
             """
 
         Examples: ubuntu release

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -36,12 +36,14 @@ version_to_codename = {
     "16.04": "xenial",
     "18.04": "bionic",
     "20.04": "focal",
+    "20.10": "groovy",
 }
 
 current_codename_to_past_codename = {
     "xenial": "trusty",
     "bionic": "xenial",
     "focal": "bionic",
+    "groovy": "focal",
 }
 
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -437,7 +437,12 @@ class UAConfig:
         return response
 
     def help(self, name):
-        """Return help information from an uaclient service as a dict."""
+        """Return help information from an uaclient service as a dict
+
+        :param name: Name of the service for which to return help data.
+
+        :raises: UserFacingError when no help is available.
+        """
         from uaclient.contract import get_available_resources
         from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
@@ -458,8 +463,9 @@ class UAConfig:
                 break
 
         if help_resource is None:
-            response_dict["help"] = 'No help available for "{}"'.format(name)
-            return response_dict
+            raise exceptions.UserFacingError(
+                "No help available for '{}'".format(name)
+            )
 
         if self.is_attached:
             service_status = self._attached_service_status(help_ent, {})

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -27,3 +27,13 @@ ENTITLEMENT_CLASSES = [
 ENTITLEMENT_CLASS_BY_NAME = dict(
     (cast(str, cls.name), cls) for cls in ENTITLEMENT_CLASSES
 )  # type: Dict[str, Type[UAEntitlement]]
+
+
+ALL_ENTITLEMENTS_STR = ", ".join(sorted(ENTITLEMENT_CLASS_BY_NAME.keys()))
+RELEASED_ENTITLEMENTS_STR = ", ".join(
+    [
+        k
+        for k, cls in sorted(ENTITLEMENT_CLASS_BY_NAME.items())
+        if not cls.is_beta
+    ]
+)  # type: str

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -227,8 +227,8 @@ MESSAGE_CONTRACT_EXPIRED_ERROR = """\
 Subscription has expired
 To obtain a token please visit: https://ubuntu.com/advantage"""
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
-Cannot {operation} '{name}'
-For a list of services see: sudo ua status"""
+Cannot {operation} unknown service '{name}'.
+{service_msg}"""
 MESSAGE_UNEXPECTED_ERROR = """\
 Unexpected error(s) occurred.
 For more details, see the log: /var/log/ubuntu-advantage.log

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -139,7 +139,7 @@ class TestCLIParser:
 
         m_args = mock.MagicMock()
         m_service_name = mock.PropertyMock(return_value="test")
-        type(m_args).service_name = m_service_name
+        type(m_args).service = m_service_name
         m_format = mock.PropertyMock(return_value=out_format)
         type(m_args).format = m_format
 
@@ -192,7 +192,7 @@ class TestCLIParser:
 
         m_args = mock.MagicMock()
         m_service_name = mock.PropertyMock(return_value="test")
-        type(m_args).service_name = m_service_name
+        type(m_args).service = m_service_name
 
         m_entitlement_cls = mock.MagicMock()
         m_ent_help_info = mock.PropertyMock(
@@ -263,21 +263,18 @@ class TestCLIParser:
         """Test help command when an invalid service is provided."""
         m_args = mock.MagicMock()
         m_service_name = mock.PropertyMock(return_value="test")
-        type(m_args).service_name = m_service_name
+        type(m_args).service = m_service_name
 
         m_available_resources.return_value = [
             {"name": "ent1", "available": True}
         ]
 
-        expected_msg = "\n\n".join(
-            ["Name:\ntest", 'Help:\nNo help available for "test"\n\n']
-        )
-
         fake_stdout = io.StringIO()
         with contextlib.redirect_stdout(fake_stdout):
-            action_help(m_args, None)
+            with pytest.raises(UserFacingError) as excinfo:
+                action_help(m_args, None)
 
-        assert expected_msg.strip() == fake_stdout.getvalue().strip()
+        assert "No help available for 'test'" == str(excinfo.value)
         assert 1 == m_service_name.call_count
         assert 1 == m_available_resources.call_count
 
@@ -607,12 +604,12 @@ class TestGetValidEntitlementNames:
             "ent3": True,
         }
 
-        names = ["ent1", "ent3", "ent4"]
+        service = ["ent1", "ent3", "ent4"]
         expected_ents_found = ["ent1", "ent3"]
         expected_ents_not_found = ["ent4"]
 
         actual_ents_found, actual_ents_not_found = get_valid_entitlement_names(
-            names
+            service
         )
 
         assert expected_ents_found == actual_ents_found


### PR DESCRIPTION
Subclass argparse.ArgumentParser to simplify error messages.
Rename service_name param to service in help, enable and disable.
Add valid ENTITLEMENTS_STR to help docs for enable and disable.
Fix usage strings for help, enable and disable.

On invalid service names in enable or disable, emit error:

Unknown service 'your-input'.
Try cis-audit, esm-infra, esm-apps, fips, fips-updates ....

Fixes: #1190
Fixes: #1061