### PR TITLE
Status trusty upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,14 @@
-ubuntu-advantage-tools (25.0~beta) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (25.0~20.10.1~beta1) groovy; urgency=medium
+
+  * Beta bug fix release
+    - status: fix missing description_override key after upgrade from
+      trusty (GH: #1201)
+    - During contract delta processing use _check_application_status_on_cache
+      instead of live service status
+
+ -- Chad Smith <chad.smith@canonical.com>  Sat, 10 Oct 2020 21:47:21 -0600
+
+ubuntu-advantage-tools (25.0~20.10.1~beta) groovy; urgency=medium
 
   * d/control:
     - add po-debconf dependency and fix lintian not-using-po-debconf and

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -281,7 +281,7 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     content = [STATUS_HEADER]
     for service_status in status["services"]:
         entitled = service_status["entitled"]
-        descr_override = service_status["description_override"]
+        descr_override = service_status.get("description_override")
         description = (
             descr_override if descr_override else service_status["description"]
         )

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -164,4 +164,7 @@ class TestFormatTabular:
                 "description_override": description_override,
             }
         ]
+        if not description_override:
+            # Remove key to test upgrade path from older ua-tools
+            status_dict_attached["services"][0].pop("description_override")
         assert uf_descr in format_tabular(status_dict_attached)


### PR DESCRIPTION
Handle upgrade case for non-root `ua status` across trusty upgrade to xenial.