### PR TITLE
Add vm test commands in tox.ini

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -288,7 +288,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
 
-    @series.xenial
     @series.bionic
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
@@ -398,12 +397,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             Canonical livepatch enabled
             """
         When I run `ua disable livepatch` with sudo
-        Then I will see the following on stdout:
-            """
-            Removing canonical-livepatch snap
-            """
-        Then I verify that the `canonical-livepatch` command is not found
-        When I run `ua enable fips --assume-yes --beta` with sudo
+        And I run `ua enable fips --assume-yes --beta` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ setenv =
     awspro: UACLIENT_BEHAVE_MACHINE_TYPE = aws.pro
     azuregeneric: UACLIENT_BEHAVE_MACHINE_TYPE = azure.generic
     azurepro: UACLIENT_BEHAVE_MACHINE_TYPE = azure.pro
+    vm: UACLIENT_BEHAVE_MACHINE_TYPE = lxd.vm
 commands =
     py3: py.test {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient setup.py
@@ -33,6 +34,9 @@ commands =
     behave-lxd-16.04: behave -v {posargs} --tags="series.xenial,series.all" --tags="~upgrade"
     behave-lxd-18.04: behave -v {posargs} --tags="series.bionic,series.all" --tags="~upgrade"
     behave-lxd-20.04: behave -v {posargs} --tags="series.focal,series.all" --tags="~upgrade"
+    behave-vm-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.xenial"
+    behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.bionic"
+    behave-vm-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.focal"
     behave-upgrade-14.04: behave -v {posargs} features/ubuntu_upgrade.feature --tags="series.trusty"
     behave-upgrade-16.04: behave -v {posargs} features/ubuntu_upgrade.feature --tags="series.xenial"
     behave-upgrade-18.04: behave -v {posargs} features/ubuntu_upgrade.feature --tags="series.bionic"


### PR DESCRIPTION
Add `tox` commands that allow us to run only vm tests. Also, we are fixing some vm tests, since we are now not uninstalling packages when we disable services.