### PR TITLE
Show error when enabling service with invalid repo

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -400,3 +400,29 @@ Feature: Command behaviour when attached to an UA subscription
            | focal   |
            | trusty  |
            | xenial  |
+
+    @series.all
+    Scenario Outline: Enable command with invalid repositories in user machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua disable esm-infra` with sudo
+        And I run `add-apt-repository ppa:canonical-server/ua-client-daily -y` with sudo
+        And I run `apt update` with sudo
+        And I run `sed -i 's/ubuntu/ubun/' /etc/apt/sources.list.d/<ppa_file>-<release>.list` with sudo
+        And I run `ua enable esm-infra` with sudo
+        Then stdout matches regexp:
+        """
+        One moment, checking your subscription first
+        Updating package lists
+        APT update failed.
+        APT update failed to read APT config for the following URL:
+        - http://ppa.launchpad.net/canonical-server/ua-client-daily/ubun
+        """
+
+        Examples: ubuntu release
+           | release | ppa_file                                |
+           | trusty  | canonical-server-ua-client-daily        |
+           | xenial  | canonical-server-ubuntu-ua-client-daily |
+           | bionic  | canonical-server-ubuntu-ua-client-daily |
+           | focal   | canonical-server-ubuntu-ua-client-daily |
+

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -323,11 +323,15 @@ class RepoEntitlement(base.UAEntitlement):
                 ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
             )
         except exceptions.UserFacingError:
-            self.remove_apt_config()
+            self.remove_apt_config(run_apt_update=False)
             raise
 
-    def remove_apt_config(self):
-        """Remove any repository apt configuration files."""
+    def remove_apt_config(self, run_apt_update=True):
+        """Remove any repository apt configuration files.
+
+        :param run_apt_update: If after removing the apt update
+            command after removing the apt files.
+        """
         series = util.get_platform_info()["series"]
         repo_filename = self.repo_list_file_tmpl.format(name=self.name)
         entitlement = self.cfg.entitlements[self.name].get("entitlement", {})
@@ -358,10 +362,12 @@ class RepoEntitlement(base.UAEntitlement):
                 )
             elif os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
-        print(status.MESSAGE_APT_UPDATING_LISTS)
-        apt.run_apt_command(
-            ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
-        )
+
+        if run_apt_update:
+            print(status.MESSAGE_APT_UPDATING_LISTS)
+            apt.run_apt_command(
+                ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
+            )
 
 
 def handle_message_operations(

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -259,7 +259,9 @@ class TestESMInfraEntitlementEnable:
         else:
             unlink_calls = []  # esm-apps there is no apt pref file to remove
         assert unlink_calls == m_unlink.call_args_list
-        assert [mock.call()] == m_remove_apt_config.call_args_list
+        assert [
+            mock.call(run_apt_update=False)
+        ] == m_remove_apt_config.call_args_list
 
 
 class TestESMEntitlementDisable:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -128,6 +128,9 @@ STATUS_COLOR = {
 
 MESSAGE_APT_INSTALL_FAILED = "APT install failed."
 MESSAGE_APT_UPDATE_FAILED = "APT update failed."
+MESSAGE_APT_UPDATE_INVALID_URL_CONFIG = (
+    "APT update failed to read APT config for the following URL{}:\n{}"
+)
 MESSAGE_APT_POLICY_FAILED = "Failure checking APT policy."
 MESSAGE_APT_UPDATING_LISTS = "Updating package lists"
 MESSAGE_CONNECTIVITY_ERROR = """\


### PR DESCRIPTION
When we enable a service and a user has an invalid repository in the system, apt update commands will fail to run. Because we run apt update when we enable repo type services, we stumble upon this issue and fail to enable the service. However, we are not showing the user the reason why the enable command failed. We are now updating the logic to display this apt issue when this problem happen during an enable operation.