### PR TITLE
Do not enable fips when fips-updates is active

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -431,3 +431,36 @@ Feature: Enable command behaviour when attached to an UA subscription
             One moment, checking your subscription first
             Cannot enable FIPS when Livepatch is enabled
             """
+
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attached enable fips on a machine with fips-updates active
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            ESM Infra enabled
+            Installing canonical-livepatch snap
+            Canonical livepatch enabled
+            """
+        When I run `ua disable livepatch` with sudo
+        And I run `ua enable fips-updates --assume-yes --beta` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install
+            """
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then I will see the following on stdout
+            """
+            One moment, checking your subscription first
+            Cannot enable FIPS when FIPS Updates is enabled
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -102,6 +102,26 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     origin = "UbuntuFIPS"
 
     @property
+    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+        static_affordances = super().static_affordances
+
+        fips_update = FIPSUpdatesEntitlement(self.cfg)
+        enabled_status = status.ApplicationStatus.ENABLED
+        is_fips_update_enabled = bool(
+            fips_update.application_status()[0] == enabled_status
+        )
+
+        return static_affordances + (
+            (
+                "Cannot enable {} when {} is enabled".format(
+                    self.title, fips_update.title
+                ),
+                lambda: is_fips_update_enabled,
+                False,
+            ),
+        )
+
+    @property
     def messaging(
         self
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -321,7 +321,7 @@ class TestFIPSEntitlementEnable:
 
     @mock.patch("uaclient.entitlements.repo.handle_message_operations")
     @mock.patch("uaclient.util.is_container", return_value=False)
-    def test_enable_fails_when_blocking_service_is_enabled(
+    def test_enable_fails_when_livepatch_service_is_enabled(
         self, m_is_container, m_handle_message_op, entitlement
     ):
         m_handle_message_op.return_value = True
@@ -338,6 +338,26 @@ class TestFIPSEntitlementEnable:
         expected_msg = "Cannot enable {} when Livepatch is enabled".format(
             entitlement.title
         )
+        assert expected_msg.strip() == fake_stdout.getvalue().strip()
+
+    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.is_container", return_value=False)
+    def test_enable_fails_when_fips_update_service_is_enabled(
+        self, m_is_container, m_handle_message_op, entitlement_factory
+    ):
+        m_handle_message_op.return_value = True
+        fips_entitlement = entitlement_factory(FIPSEntitlement)
+        base_path = "uaclient.entitlements.fips.FIPSUpdatesEntitlement"
+
+        with mock.patch(
+            "{}.application_status".format(base_path)
+        ) as m_fips_update:
+            m_fips_update.return_value = (status.ApplicationStatus.ENABLED, "")
+            fake_stdout = io.StringIO()
+            with contextlib.redirect_stdout(fake_stdout):
+                fips_entitlement.enable()
+
+        expected_msg = "Cannot enable FIPS when FIPS Updates is enabled"
         assert expected_msg.strip() == fake_stdout.getvalue().strip()
 
 


### PR DESCRIPTION
We are adding a static affordance to verify the status of fips-updates before enabling fips. If fips-updates is enabled, we cannot enable fips, since that would cause package downgrades.
