### PR TITLE
Update beta info for services

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -41,7 +41,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
-        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
         livepatch    +yes      +n/a      +Canonical Livepatch service
         """
@@ -88,7 +87,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
-        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
         livepatch    +yes      +<lp_status>  +<lp_desc>
         """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -293,6 +293,7 @@ Feature: Command behaviour when attached to an UA subscription
         https://esm.ubuntu.com/ubuntu/ trusty-infra-updates/main amd64 Packages
         """
 
+    @wip
     @series.all
     Scenario Outline: Help command on an attached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -327,6 +328,42 @@ Feature: Command behaviour when attached to an UA subscription
             """
             No help available for 'invalid-service'
             """
+        When I run `ua --help` as non-root
+        Then stdout matches regexp:
+        """
+        Client to manage Ubuntu Advantage services on a machine.
+         - esm-infra: UA Infra: Extended Security Maintenance
+           \(https://ubuntu.com/security/esm\)
+         - livepatch: Canonical Livepatch service
+           \(https://ubuntu.com/security/livepatch\)
+        """
+        When I run `ua help` as non-root
+        Then stdout matches regexp:
+        """
+        Client to manage Ubuntu Advantage services on a machine.
+         - esm-infra: UA Infra: Extended Security Maintenance
+           \(https://ubuntu.com/security/esm\)
+         - livepatch: Canonical Livepatch service
+           \(https://ubuntu.com/security/livepatch\)
+        """
+        When I run `ua help --all` as non-root
+        Then stdout matches regexp:
+        """
+        Client to manage Ubuntu Advantage services on a machine.
+         - cc-eal: Common Criteria EAL2 Provisioning Packages
+           \(https://ubuntu.com/cc-eal\)
+         - cis-audit: Center for Internet Security Audit Tools
+           \(https://ubuntu.com/security/hardening\)
+         - esm-apps: UA Apps: Extended Security Maintenance
+           \(https://ubuntu.com/security/esm\)
+         - esm-infra: UA Infra: Extended Security Maintenance
+           \(https://ubuntu.com/security/esm\)
+         - fips-updates: Uncertified security updates to FIPS modules
+           \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS modules \(https://ubuntu.com/security/fips\)
+         - livepatch: Canonical Livepatch service
+           \(https://ubuntu.com/security/livepatch\)
+        """
 
         Examples: ubuntu release
            | release |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -293,7 +293,6 @@ Feature: Command behaviour when attached to an UA subscription
         https://esm.ubuntu.com/ubuntu/ trusty-infra-updates/main amd64 Packages
         """
 
-    @wip
     @series.all
     Scenario Outline: Help command on an attached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -40,7 +40,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar, fips'.
-            Try esm-apps, esm-infra, livepatch
+            Try esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -67,7 +67,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-apps, esm-infra, livepatch
+            Try esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -167,7 +167,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-apps, esm-infra, livepatch
+            Try esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -227,7 +227,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service '<service>'.
-            Try esm-apps, esm-infra, livepatch
+            Try esm-infra, livepatch
             """
 
         Examples: beta services in containers

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -17,18 +17,17 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found
             """
 
+    @wip
     @series.xenial
     @series.bionic
     @series.focal
     Scenario Outline: Attached enable esm-apps on a machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
-        And I run `ua status` as non-root
+        And I run `ua status --all` as non-root
         Then stdout matches regexp
         """
         esm-apps      yes                enabled            UA Apps: Extended Security Maintenance
-        esm-infra     no                 —                  UA Infra: Extended Security Maintenance
-        livepatch     yes                n/a                Canonical Livepatch service
         """
         When I run `ua disable livepatch` with sudo
         Then I verify that running `apt update` `with sudo` exits `0`

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -17,7 +17,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found
             """
 
-    @wip
     @series.xenial
     @series.bionic
     @series.focal

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -7,7 +7,6 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
 
@@ -32,7 +31,6 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
-            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance
             esm-infra     yes        UA Infra: Extended Security Maintenance
             livepatch     yes        Canonical Livepatch service
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -59,13 +59,13 @@ _LOCK_FILE = None
 class UAArgumentParser(argparse.ArgumentParser):
     def __init__(
         self,
-        base_desc: str = None,
-        non_beta_services_desc: "List[str]" = None,
-        beta_services_desc: "List[str]" = None,
         prog=None,
         usage=None,
         epilog=None,
         formatter_class=argparse.HelpFormatter,
+        base_desc: str = None,
+        non_beta_services_desc: "List[str]" = None,
+        beta_services_desc: "List[str]" = None,
     ):
         super().__init__(
             prog=prog,
@@ -738,13 +738,13 @@ def get_parser():
             non_beta_services_desc.extend(service_info)
 
     parser = UAArgumentParser(
-        base_desc=base_desc,
-        non_beta_services_desc=non_beta_services_desc,
-        beta_services_desc=beta_services_desc,
         prog=NAME,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         usage=USAGE_TMPL.format(name=NAME, command="[command]"),
         epilog=EPILOG_TMPL.format(name=NAME, command="[command]"),
+        base_desc=base_desc,
+        non_beta_services_desc=non_beta_services_desc,
+        beta_services_desc=beta_services_desc,
     )
     parser.add_argument(
         "--debug",

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -57,9 +57,51 @@ _LOCK_FILE = None
 
 
 class UAArgumentParser(argparse.ArgumentParser):
+    def __init__(
+        self,
+        base_desc: str = None,
+        non_beta_services_desc: "List[str]" = None,
+        beta_services_desc: "List[str]" = None,
+        prog=None,
+        usage=None,
+        epilog=None,
+        formatter_class=argparse.HelpFormatter,
+    ):
+        super().__init__(
+            prog=prog,
+            usage=usage,
+            epilog=epilog,
+            formatter_class=formatter_class,
+        )
+
+        self.base_desc = base_desc
+        self.non_beta_services_desc = non_beta_services_desc
+        self.beta_services_desc = beta_services_desc
+
     def error(self, message):
         self.print_usage(sys.stderr)
         self.exit(2, message)
+
+    def print_help(self, file=None, show_all=False):
+        desc_vars = [
+            self.base_desc,
+            self.non_beta_services_desc,
+            self.beta_services_desc,
+        ]
+
+        if all([desc_var is None for desc_var in desc_vars]):
+            super().print_help(file=file)
+        elif show_all:
+            self.description = "\n".join(
+                [self.base_desc]
+                + sorted(self.non_beta_services_desc + self.beta_services_desc)
+            )
+        else:
+            self.description = "\n".join(
+                [self.base_desc] + self.non_beta_services_desc
+            )
+
+        super().print_help(file=file)
 
 
 def assert_lock_file(lock_holder=None):
@@ -217,6 +259,13 @@ def help_parser(parser):
             )
         ),
     )
+
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Allow the visualization of beta services",
+    )
+
     return parser
 
 
@@ -661,7 +710,9 @@ def action_attach(args, cfg):
 
 def get_parser():
     service_line_tmpl = " - {name}: {description}{url}"
-    description_lines = [__doc__]
+    base_desc = __doc__
+    non_beta_services_desc = []
+    beta_services_desc = []
     sorted_classes = sorted(entitlements.ENTITLEMENT_CLASS_BY_NAME.items())
     for name, ent_cls in sorted_classes:
         if ent_cls.help_doc_url:
@@ -672,19 +723,26 @@ def get_parser():
             name=name, description=ent_cls.description, url=url
         )
         if len(service_line) <= 80:
-            description_lines.append(service_line)
+            service_info = [service_line]
         else:
             wrapped_words = []
             line = service_line
             while len(line) > 80:
                 [line, wrapped_word] = line.rsplit(" ", 1)
                 wrapped_words.insert(0, wrapped_word)
-            description_lines.extend([line, "   " + " ".join(wrapped_words)])
+            service_info = [line + "\n   " + " ".join(wrapped_words)]
+
+        if ent_cls.is_beta:
+            beta_services_desc.extend(service_info)
+        else:
+            non_beta_services_desc.extend(service_info)
 
     parser = UAArgumentParser(
+        base_desc=base_desc,
+        non_beta_services_desc=non_beta_services_desc,
+        beta_services_desc=beta_services_desc,
         prog=NAME,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="\n".join(description_lines),
         usage=USAGE_TMPL.format(name=NAME, command="[command]"),
         epilog=EPILOG_TMPL.format(name=NAME, command="[command]"),
     )
@@ -753,6 +811,7 @@ def get_parser():
     )
     help_parser(parser_help)
     parser_help.set_defaults(action=action_help)
+
     return parser
 
 
@@ -814,9 +873,10 @@ def action_refresh(args, cfg):
 
 def action_help(args, cfg):
     service = args.service
+    show_all = args.all
 
     if not service:
-        get_parser().print_help()
+        get_parser().print_help(show_all=show_all)
         return 0
 
     if not cfg:

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -18,6 +18,7 @@ class ESMAppsEntitlement(ESMBaseEntitlement):
     title = "ESM Apps"
     description = "UA Apps: Extended Security Maintenance"
     repo_key_file = "ubuntu-advantage-esm-apps.gpg"
+    is_beta = True
 
 
 class ESMInfraEntitlement(ESMBaseEntitlement):

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -36,7 +36,7 @@ BIG_DESC = "123456789 " * 7 + "next line"
 BIG_URL = "http://" + "adsf" * 10
 
 
-SERVICES_WRAPPED_HELP = textwrap.dedent(
+ALL_SERVICES_WRAPPED_HELP = textwrap.dedent(
     """
 Client to manage Ubuntu Advantage services on a machine.
  - cc-eal: Common Criteria EAL2 Provisioning Packages
@@ -47,16 +47,26 @@ Client to manage Ubuntu Advantage services on a machine.
    (https://ubuntu.com/security/esm)
  - esm-infra: UA Infra: Extended Security Maintenance
    (https://ubuntu.com/security/esm)
- - fips: NIST-certified FIPS modules (https://ubuntu.com/security/fips)
  - fips-updates: Uncertified security updates to FIPS modules
    (https://ubuntu.com/security/fips)
+ - fips: NIST-certified FIPS modules (https://ubuntu.com/security/fips)
+ - livepatch: Canonical Livepatch service
+   (https://ubuntu.com/security/livepatch)
+"""
+)
+
+SERVICES_WRAPPED_HELP = textwrap.dedent(
+    """
+Client to manage Ubuntu Advantage services on a machine.
+ - esm-infra: UA Infra: Extended Security Maintenance
+   (https://ubuntu.com/security/esm)
  - livepatch: Canonical Livepatch service
    (https://ubuntu.com/security/livepatch)
 """
 )
 
 
-@pytest.fixture(params=["direct", "--help", "ua help"])
+@pytest.fixture(params=["direct", "--help", "ua help", "ua help --all"])
 def get_help(request, capsys):
     if request.param == "direct":
 
@@ -64,7 +74,7 @@ def get_help(request, capsys):
             parser = get_parser()
             help_file = io.StringIO()
             parser.print_help(file=help_file)
-            return help_file.getvalue()
+            return (help_file.getvalue(), "base")
 
     elif request.param == "--help":
 
@@ -74,15 +84,19 @@ def get_help(request, capsys):
                 with pytest.raises(SystemExit):
                     parser.parse_args()
             out, _err = capsys.readouterr()
-            return out
+            return (out, "base")
 
-    elif request.param == "ua help":
+    elif "help" in request.param:
 
         def _get_help_output():
-            with mock.patch("sys.argv", ["ua", "help"]):
+            with mock.patch("sys.argv", request.param.split(" ")):
                 main()
             out, _err = capsys.readouterr()
-            return out
+
+            if "--all" in request.param:
+                return (out, "all")
+
+            return (out, "base")
 
     else:
         raise NotImplementedError("Unknown help source: {}", request.param)
@@ -99,7 +113,7 @@ class TestCLIParser:
         """Help lines are wrapped at 80 chars"""
 
         def cls_mock_factory(desc, url):
-            return mock.Mock(description=desc, help_doc_url=url)
+            return mock.Mock(description=desc, help_doc_url=url, is_beta=False)
 
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "test": cls_mock_factory(BIG_DESC, BIG_URL)
@@ -109,11 +123,17 @@ class TestCLIParser:
             " - test: " + " ".join(["123456789"] * 7),
             "   next line ({url})".format(url=BIG_URL),
         ]
-        assert "\n".join(lines) in get_help()
+        out, _ = get_help()
+        assert "\n".join(lines) in out
 
     def test_help_sourced_dynamically_from_each_entitlement(self, get_help):
         """Help output is sourced from entitlement name and description."""
-        assert SERVICES_WRAPPED_HELP in get_help()
+        out, type_request = get_help()
+
+        if type_request == "base":
+            assert SERVICES_WRAPPED_HELP in out
+        else:
+            assert ALL_SERVICES_WRAPPED_HELP in out
 
     @pytest.mark.parametrize(
         "out_format, expected_return",
@@ -142,6 +162,8 @@ class TestCLIParser:
         type(m_args).service = m_service_name
         m_format = mock.PropertyMock(return_value=out_format)
         type(m_args).format = m_format
+        m_all = mock.PropertyMock(return_value=True)
+        type(m_args).all = m_all
 
         m_entitlement_cls = mock.MagicMock()
         m_ent_help_info = mock.PropertyMock(return_value="Test")
@@ -193,6 +215,8 @@ class TestCLIParser:
         m_args = mock.MagicMock()
         m_service_name = mock.PropertyMock(return_value="test")
         type(m_args).service = m_service_name
+        m_all = mock.PropertyMock(return_value=True)
+        type(m_args).all = m_all
 
         m_entitlement_cls = mock.MagicMock()
         m_ent_help_info = mock.PropertyMock(
@@ -264,6 +288,8 @@ class TestCLIParser:
         m_args = mock.MagicMock()
         m_service_name = mock.PropertyMock(return_value="test")
         type(m_args).service = m_service_name
+        m_all = mock.PropertyMock(return_value=True)
+        type(m_args).all = m_all
 
         m_available_resources.return_value = [
             {"name": "ent1", "available": True}


### PR DESCRIPTION
This PR updates two aspects of uaclient:

* Turn `esm-apps` into a beta service
* Do not show beta services on `ua help` command, unless the user runs the `ua help --all`.  Also `ua --help` will now display the help with only the non-beta services