### PR TITLE
Install fips metapackage when enabling service

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -289,37 +289,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.bionic
-    @uses.config.machine_type.lxd.vm
-    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua disable livepatch` with sudo
-        When I run `ua enable fips --assume-yes --beta` with sudo
-        Then stdout matches regexp:
-            """
-            Updating package lists
-            Installing FIPS packages
-            FIPS enabled
-            A reboot is required to complete install
-            """
-        When I run `ua status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips          yes                enabled
-            """
-        When I reboot the `<release>` machine
-        And  I run `uname -r` as non-root
-        Then stdout matches regexp:
-            """
-            fips
-            """
-
-        Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-
-    @series.bionic
     @series.xenial
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attached enable of vm-based services in a bionic lxd vm

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -55,3 +55,41 @@ Feature: Enable command behaviour when attached to an UA staging subscription
            | focal   | ant      |
            | trusty  | ant      |
            | xenial  | jq       |
+
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token_staging` with sudo
+        And I run `ua disable livepatch` with sudo
+        When I run `ua enable fips --assume-yes --beta` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing FIPS packages
+            FIPS enabled
+            A reboot is required to complete install
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            fips          yes                enabled
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        When I reboot the `<release>` machine
+        And  I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            fips
+            """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |

--- a/features/util.py
+++ b/features/util.py
@@ -96,16 +96,6 @@ def launch_lxd_container(
         command.extend(["--profile", VM_PROFILE_TMPL.format(series), "--vm"])
     subprocess.check_call(command)
 
-    if is_vm:
-        """ When we publish vm images we end up losing the image information.
-        Since we need at least the release information to reuse the vm instance
-        in other tests, we are adding this information back here."""
-        subprocess.run(["lxc", "stop", container_name])
-        subprocess.run(
-            ["lxc", "config", "set", container_name, "image.release", series]
-        )
-        subprocess.run(["lxc", "start", container_name])
-
     def cleanup_container() -> None:
         if not context.config.destroy_instances:
             print(

--- a/sru/release-26/xenial-enable-fips
+++ b/sru/release-26/xenial-enable-fips
@@ -1,0 +1,188 @@
+=== Begin SRU Template ===
+[Impact]
+When enabling FIPS in a system we expect it to also update the current kernel to a FIPS supported
+one. We are now testing for Xenial if that is the scenario that we land up with after enabling FIPS
+using uaclient.
+
+[Test Case]
+```
+#!/bin/sh
+set -x
+
+STAGING_CONTRACT_TOKEN=<YOUR-STAGING-TOKEN>
+series=xenial
+name=$series-fips
+
+install_uac_from_branch() {
+    branch=$1
+    pkg_name=ubuntu-advantage-tools_26.0_amd64.deb
+
+    multipass exec $name -- sudo apt-get -yq update
+    multipass exec $name -- sudo apt-get -yq install git make
+    multipass exec $name -- git clone https://github.com/canonical/ubuntu-advantage-client.git /tmp/uac
+    multipass exec $name -- sh -c "cd /tmp/uac/ && git checkout $branch"
+    multipass exec $name -- sudo sh -c "cd /tmp/uac/ && make deps > /dev/null"
+    multipass exec $name -- sudo sh -c "cd /tmp/uac/ && dpkg-buildpackage -us -uc > /dev/null"
+    multipass exec $name -- sudo dpkg -i /tmp/$pkg_name
+}
+
+configure_uac_to_use_staging_contract() {
+    multipass exec $name -- sudo sed -i 's/contracts.can/contracts.staging.can/' /etc/ubuntu-advantage/uaclient.conf
+}
+
+enable_fips() {
+    multipass exec $name -- sudo ua attach $STAGING_CONTRACT_TOKEN
+    multipass exec $name -- sudo ua disable livepatch
+    multipass exec $name -- sudo ua enable fips --beta --assume-yes
+    multipass exec $name -- sudo apt update
+
+    traceback_out=$(multipass exec $name -- grep Traceback /var/log/ubuntu-advantage.log)
+
+    if [ -z "$traceback_out" ]; then
+        echo "SUCCESS: No Tracebacks found on ubuntu-advantage.log"
+    else
+        echo "FAILURE: Tracebacks found on ubuntu-advantage.log"
+    fi
+}
+
+check_kernel_for_fips() {
+    kernel_version=$(multipass exec $name -- sh -c "uname -r | grep -o fips")
+    if [ "$kernel_version" = "fips" ]; then
+        echo "SUCCESS: Xenial kernel was updated to fips version"
+    else
+        echo "FAILURE: Xenial kernel was not updated to fips version"
+    fi
+
+    fips_enabled=$(multipass exec $name -- cat /proc/sys/crypto/fips_enabled)
+
+    if [ "$fips_enabled" = "1" ]; then
+        echo "SUCCESS: FIPS is shown as enabled in the system"
+    else
+        echo "FAILURE: FIPS is not shown as enabled in the system"
+    fi
+}
+
+multipass delete $name
+multipass purge
+multipass launch $series --name $name
+
+install_uac_from_branch "update-fips"
+configure_uac_to_use_staging_contract
+enable_fips
+
+multipass exec $name -- sudo reboot
+sleep 20
+multipass exec $name -- sudo ua status --all
+
+check_kernel_for_fips
+```
+
+=== Verification Log ===
+
+Creating xenial-fips
+Configuring xenial-fips
+Starting xenial-fips
+Waiting for initialization to complete
+Launched: xenial-fips
+Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
+Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
+Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
+Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1,476 kB]
+Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
+Get:6 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [7,532 kB]
+Get:7 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [350 kB]
+Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [773 kB]
+Get:9 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [218 kB]
+Get:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [8,236 B]
+Get:11 http://security.ubuntu.com/ubuntu xenial-security/multiverse Translation-en [2,888 B]
+Get:12 http://archive.ubuntu.com/ubuntu xenial/universe Translation-en [4,354 kB]
+Get:13 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [144 kB]
+Get:14 http://archive.ubuntu.com/ubuntu xenial/multiverse Translation-en [106 kB]
+Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1,880 kB]
+Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [454 kB]
+Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1,195 kB]
+Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [348 kB]
+Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [23.0 kB]
+Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [8,632 B]
+Get:21 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [9,812 B]
+Get:22 http://archive.ubuntu.com/ubuntu xenial-backports/main Translation-en [4,456 B]
+Get:23 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [11.3 kB]
+Get:24 http://archive.ubuntu.com/ubuntu xenial-backports/universe Translation-en [4,476 B]
+Fetched 19.2 MB in 5s (3,437 kB/s)
+Reading package lists...
+Reading package lists...
+Building dependency tree...
+Reading state information...
+git is already the newest version (1:2.7.4-0ubuntu1.9).
+Suggested packages:
+  make-doc
+The following NEW packages will be installed:
+  make
+0 upgraded, 1 newly installed, 0 to remove and 20 not upgraded.
+Need to get 151 kB of archives.
+After this operation, 365 kB of additional disk space will be used.
+Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 make amd64 4.1-6 [151 kB]
+Fetched 151 kB in 1s (111 kB/s)
+Selecting previously unselected package make.
+Preparing to unpack .../archives/make_4.1-6_amd64.deb ...
+Unpacking make (4.1-6) ...
+Processing triggers for man-db (2.7.5-1) ...
+Setting up make (4.1-6) ...
+Branch update-fips set up to track remote branch update-fips from origin.
+(Reading database ... 59834 files and directories currently installed.)
+Preparing to unpack .../ubuntu-advantage-tools_26.0_amd64.deb ...
+Unpacking ubuntu-advantage-tools (26.0) over (10ubuntu0.16.04.1) ...
+Setting up ubuntu-advantage-tools (26.0) ...
+Removing obsolete conffile /etc/update-motd.d/99-esm ...
+Processing triggers for man-db (2.7.5-1) ...
+Updating package lists
+ESM Apps enabled
+Installing canonical-livepatch snap
+Canonical livepatch enabled.
+This machine is now attached to 'server-team-ua-client-ci-uaa'
+
+SERVICE       ENTITLED  STATUS    DESCRIPTION
+esm-infra     no                 —                  UA Infra: Extended Security Maintenance (ESM)
+livepatch     yes                enabled            Canonical Livepatch service
+
+Enable services with: ua enable <service>
+
+                Account: server-team-ua-client-ci
+           Subscription: server-team-ua-client-ci-uaa
+            Valid until: n/a
+Technical support level: essential
+One moment, checking your subscription first
+Updating package lists
+Installing FIPS packages
+FIPS enabled
+A reboot is required to complete install
+Hit:1 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+Hit:5 https://esm.staging.ubuntu.com/apps/ubuntu xenial-apps-security InRelease
+Hit:6 https://esm.staging.ubuntu.com/apps/ubuntu xenial-apps-updates InRelease
+Hit:7 https://esm.staging.ubuntu.com/fips/ubuntu xenial InRelease
+Reading package lists...
+Building dependency tree...
+Reading state information...
+5 of the updates are from UA Apps: ESM.
+28 packages can be upgraded. Run 'apt list --upgradable' to see them.
+SUCCESS: No Tracebacks found on ubuntu-advantage.log
+SERVICE       ENTITLED  STATUS    DESCRIPTION
+cc-eal        yes                disabled           Common Criteria EAL2 Provisioning Packages
+cis-audit     no                 —                  Center for Internet Security Audit Tools
+esm-apps      yes                enabled            UA Apps: Extended Security Maintenance (ESM)
+esm-infra     no                 —                  UA Infra: Extended Security Maintenance (ESM)
+fips          yes                enabled            NIST-certified FIPS modules
+fips-updates  yes                disabled           Uncertified security updates to FIPS modules
+livepatch     yes                n/a                Canonical Livepatch service
+
+Enable services with: ua enable <service>
+
+                Account: server-team-ua-client-ci
+           Subscription: server-team-ua-client-ci-uaa
+            Valid until: n/a
+Technical support level: essential
+SUCCESS: Xenial kernel was updated to fips version
+SUCCESS: FIPS is shown as enabled in the system

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,7 +1,5 @@
-from itertools import groupby
-
 from uaclient.entitlements import repo
-from uaclient import apt, status, util
+from uaclient import status, util
 
 try:
     from typing import Any, Callable, Dict, List, Set, Tuple, Union  # noqa
@@ -15,7 +13,6 @@ except ImportError:
 class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     repo_pin_priority = 1001
-    fips_required_packages = frozenset({"fips-initramfs", "linux-fips"})
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
     is_beta = True
 
@@ -52,24 +49,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 False,
             ),
         )
-
-    @property
-    def packages(self) -> "List[str]":
-        packages = []  # type: List[str]
-        installed_packages = apt.get_installed_packages()
-
-        pkg_groups = groupby(
-            super().packages,
-            key=lambda pkg_name: pkg_name.replace("-hmac", ""),
-        )
-
-        for pkg_name, pkg_list in pkg_groups:
-            if pkg_name in installed_packages:
-                packages += pkg_list
-            elif pkg_name in self.fips_required_packages:
-                packages += pkg_list
-
-        return packages
 
     def application_status(self) -> "Tuple[status.ApplicationStatus, str]":
         super_status, super_msg = super().application_status()

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1,9 +1,7 @@
 """Tests related to uaclient.entitlement.base module."""
 
 import contextlib
-import copy
 import io
-import itertools
 import mock
 from functools import partial
 
@@ -24,19 +22,7 @@ M_GETPLATFORM = M_REPOPATH + "util.get_platform_info"
 @pytest.fixture(params=[FIPSEntitlement, FIPSUpdatesEntitlement])
 def fips_entitlement_factory(request, entitlement_factory):
     """Parameterized fixture so we apply all tests to both FIPS and Updates"""
-    additional_packages = [
-        "fips-initramfs",
-        "libssl1.0.0",
-        "libssl1.0.0-hmac",
-        "linux-fips",
-        "openssh-client",
-        "openssh-client-hmac",
-        "openssh-server",
-        "openssh-server-hmac",
-        "openssl",
-        "strongswan",
-        "strongswan-hmac",
-    ]
+    additional_packages = ["ubuntu-fips"]
 
     return partial(
         entitlement_factory,
@@ -359,83 +345,6 @@ class TestFIPSEntitlementEnable:
 
         expected_msg = "Cannot enable FIPS when FIPS Updates is enabled"
         assert expected_msg.strip() == fake_stdout.getvalue().strip()
-
-
-def _fips_pkg_combinations():
-    """Construct all combinations of fips_packages and expected installs"""
-    fips_packages = {
-        "libssl1.0.0": {"libssl1.0.0-hmac"},
-        "openssh-client": {"openssh-client-hmac"},
-        "openssh-server": {"openssh-server-hmac"},
-        "openssl": set(),
-        "strongswan": {"strongswan-hmac"},
-    }
-
-    items = [  # These are the items that we will combine together
-        (pkg_name, [pkg_name] + list(extra_pkgs))
-        for pkg_name, extra_pkgs in fips_packages.items()
-    ]
-    # This produces combinations in all possible combination lengths
-    combinations = itertools.chain.from_iterable(
-        itertools.combinations(items, n) for n in range(1, len(items))
-    )
-    ret = []
-    # This for loop flattens each combination together in to a single
-    # (installed_packages, expected_installs) item
-    for combination in combinations:
-        installed_packages, expected_installs = [], []
-        for pkg, installs in combination:
-            installed_packages.append(pkg)
-            expected_installs.extend(installs)
-        ret.append((installed_packages, expected_installs))
-    return ret
-
-
-class TestFipsEntitlementPackages:
-    @mock.patch(M_PATH + "apt.get_installed_packages", return_value=[])
-    def test_packages_is_list(self, _mock, entitlement):
-        """RepoEntitlement.enable will fail if it isn't"""
-        assert isinstance(entitlement.packages, list)
-
-    @mock.patch(M_PATH + "apt.get_installed_packages", return_value=[])
-    def test_fips_required_packages_included(self, _mock, entitlement):
-        """The fips_required_packages should always be in .packages"""
-        assert entitlement.fips_required_packages.issubset(
-            entitlement.packages
-        )
-
-    @pytest.mark.parametrize(
-        "installed_packages,expected_installs", _fips_pkg_combinations()
-    )
-    @mock.patch(M_PATH + "apt.get_installed_packages")
-    def test_currently_installed_packages_are_included_in_packages(
-        self,
-        m_get_installed_packages,
-        entitlement,
-        installed_packages,
-        expected_installs,
-    ):
-        """If FIPS packages are already installed, upgrade them"""
-        m_get_installed_packages.return_value = list(installed_packages)
-        full_expected_installs = (
-            list(entitlement.fips_required_packages) + expected_installs
-        )
-        assert sorted(full_expected_installs) == sorted(entitlement.packages)
-
-    @mock.patch(M_PATH + "apt.get_installed_packages")
-    def test_multiple_packages_calls_dont_mutate_state(
-        self, m_get_installed_packages, entitlement
-    ):
-        # Make it appear like all packages are installed
-        m_get_installed_packages.return_value.__contains__.return_value = True
-
-        before = copy.deepcopy(entitlement.fips_required_packages)
-
-        assert entitlement.packages
-
-        after = copy.deepcopy(entitlement.fips_required_packages)
-
-        assert before == after
 
 
 class TestFIPSEntitlementDisable:


### PR DESCRIPTION
Currently, we our fips service is expected to install a range of packages that represent the `FIPS`  service. However, we are now expecting `FIPS`  to provide a single metapackage which will install all of the necessary `FIPS` packages for us. To test this feature, we are using the staging contract environment, since the contract in production is still not updated to use the `FIPS` metapackage.

Also, the BDD test for fips are performed only for bionic at this moment. On xenial. when we install the `FIPS` kernel and reboot the machine we cannot access it anymore through `lxd`. That is because the `FIPS` kernel on xenial is missing the required modules to run the `lxd-agent` component of `lxd`, which allow us to communicate with the vm. As a temporary solution, we are testing `FIPS` on xenial through a manual test.

Finally, this PR also fixes #1221, since the error was being caused when we stopped the vm to add new information to the profile. Since this behaviour has been [fixed](https://github.com/lxc/lxd/issues/7648) on lxd, we no longer need this code.