### PR TITLE
Fix azure generic integration testing

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -118,7 +118,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
-        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance \(ESM\)
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
         livepatch    +yes      +<lp_status>  +<lp_desc>
         """


### PR DESCRIPTION
Master build is failing due to an azure generic test that expects `esm-apps` to appear on `ua status` output. We are now removing this from the test