### PR TITLE
Update esm-apps check on staging_commands tests

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -27,8 +27,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Then stdout matches regexp
         """
         esm-apps      yes                enabled            UA Apps: Extended Security Maintenance \(ESM\)
-        esm-infra     no                 —                  UA Infra: Extended Security Maintenance \(ESM\)
-        livepatch     yes                n/a                Canonical Livepatch service
         """
         When I run `ua disable livepatch` with sudo
         Then I verify that running `apt update` `with sudo` exits `0`


### PR DESCRIPTION
Because we had deleted the staging token variable from our travis setting, some integration tests were not running. After adding that token again, we can see that we still have some `esm-apps`  related issues on the `staging_commands`  test. This PR fixes that issue