### PR TITLE
Fix shell condition in run_azure_travis_integration_tests.sh

### DIFF
--- a/tools/run_azure_travis_integration_tests.sh
+++ b/tools/run_azure_travis_integration_tests.sh
@@ -3,7 +3,7 @@ source tools/base_travis_integration_tests.sh
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && ["$TRAVIS_BRANCH" = "master"]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   BUILD_PR=0
 else
   create_pr_tar_file


### PR DESCRIPTION
Went to look at the output of a job to check the exact version being used by the tests, and noticed this easy-to-fix error.