### PR TITLE
fips: allow disable

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -88,7 +88,18 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         1
         """
-
+        When I run `ua disable fips --assume-yes` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            A reboot is required to complete disable operation
+            """
+        When I reboot the `<release>` machine
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        0
+        """
         Examples: ubuntu release
            | release |
            | xenial  |

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -150,6 +150,8 @@ class RepoEntitlement(base.UAEntitlement):
             return False
         if not self.can_disable(silent):
             return False
+        if hasattr(self, "remove_packages"):
+            self.remove_packages()
         self._cleanup()
         msg_ops = self.messaging.get("post_disable", [])
         if not handle_message_operations(msg_ops):


### PR DESCRIPTION
ua disable fips or fips-update will now uninstall the ubuntu-fips
meta package. This will remove package holds and disable fips-related
settings in grub.

Add post_disable messaging mentioning reboot-required.

Fixes: #1168