### PR TITLE
Client version overrides

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -123,7 +123,7 @@ class UAConfig:
                 entitlement_cfg["resourceToken"] = tokens_by_name[
                     entitlement_name
                 ]
-            util.apply_series_overrides(entitlement_cfg, self.series)
+            util.apply_contract_overrides(entitlement_cfg, self.series)
             self._entitlements[entitlement_name] = entitlement_cfg
         return self._entitlements
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -264,7 +264,7 @@ def process_entitlement_delta(
     from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
     if series_overrides:
-        util.apply_series_overrides(new_access)
+        util.apply_contract_overrides(new_access)
 
     deltas = util.get_dict_deltas(orig_access, new_access)
     if deltas:

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -320,7 +320,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         transition_to_unentitled = bool(delta_entitlement == util.DROPPED_KEY)
         if not transition_to_unentitled:
             if delta_entitlement:
-                util.apply_series_overrides(deltas)
+                util.apply_contract_overrides(deltas)
                 delta_entitlement = deltas["entitlement"]
             if orig_access and "entitled" in delta_entitlement:
                 transition_to_unentitled = delta_entitlement["entitled"] in (

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,3 +1,4 @@
+from uaclient import apt
 from uaclient.entitlements import repo
 from uaclient import status, util
 
@@ -62,15 +63,27 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             "Reboot to FIPS kernel required",
         )
 
-    def disable(self, silent: bool = False) -> bool:
-        """FIPS cannot be disabled, so simply display a message to the user"""
-        if not silent:
-            print("Warning: no option to disable {}".format(self.title))
-        return False
+    def remove_packages(self) -> None:
+        """Remove fips meta package to disable the service.
 
-    def _cleanup(self) -> None:
-        """FIPS can't be cleaned up automatically, so don't do anything"""
-        pass
+        FIPS meta-package will unset grub config options which will deactivate
+        FIPS on any related packages.
+        """
+        installed_packages = set(apt.get_installed_packages())
+        remove_packages = set(self.packages).intersection(installed_packages)
+        if remove_packages:
+            env = {"DEBIAN_FRONTEND": "noninteractive"}
+            apt_options = [
+                '-o Dpkg::Options::="--force-confdef"',
+                '-o Dpkg::Options::="--force-confold"',
+            ]
+            apt.run_apt_command(
+                ["apt-get", "remove", "--assume-yes"]
+                + apt_options
+                + list(remove_packages),
+                status.MESSAGE_ENABLED_FAILED_TMPL.format(title=self.title),
+                env=env,
+            )
 
 
 class FIPSEntitlement(FIPSCommonEntitlement):
@@ -123,6 +136,11 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                     },
                 )
             ],
+            "post_disable": [
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="disable operation"
+                )
+            ],
         }
 
 
@@ -154,6 +172,11 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                         "assume_yes": self.assume_yes,
                         "msg": status.PROMPT_FIPS_PRE_DISABLE,
                     },
+                )
+            ],
+            "post_disable": [
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="disable operation"
                 )
             ],
         }

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -150,6 +150,8 @@ class RepoEntitlement(base.UAEntitlement):
             return False
         if not self.can_disable(silent):
             return False
+        if hasattr(self, "remove_packages"):
+            self.remove_packages()
         self._cleanup()
         msg_ops = self.messaging.get("post_disable", [])
         if not handle_message_operations(msg_ops):

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -72,6 +72,11 @@ class TestFIPSEntitlementDefaults:
                         },
                     )
                 ],
+                "post_disable": [
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="disable operation"
+                    )
+                ],
             },
             "fips-updates": {
                 "pre_enable": [
@@ -90,6 +95,11 @@ class TestFIPSEntitlementDefaults:
                             "assume_yes": assume_yes,
                             "msg": status.PROMPT_FIPS_PRE_DISABLE,
                         },
+                    )
+                ],
+                "post_disable": [
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="disable operation"
                     )
                 ],
             },
@@ -271,14 +281,18 @@ class TestFIPSEntitlementEnable:
         assert 0 == m_add_pinning.call_count
         assert 0 == m_remove_apt_config.call_count
 
-    def test_failure_to_install_doesnt_remove_packages(self, entitlement):
+    def test_failure_to_install_removes_apt_auth(self, entitlement, tmpdir):
+
+        authfile = tmpdir.join("90ubuntu-advantage")
+        authfile.write("")
+
         def fake_subp(cmd, *args, **kwargs):
             if "install" in cmd:
                 raise util.ProcessExecutionError(cmd)
             return ("", "")
 
         with contextlib.ExitStack() as stack:
-            m_subp = stack.enter_context(
+            stack.enter_context(
                 mock.patch("uaclient.util.subp", side_effect=fake_subp)
             )
             stack.enter_context(
@@ -292,6 +306,11 @@ class TestFIPSEntitlementEnable:
                     entitlement, "setup_apt_config", return_value=True
                 )
             )
+            m_remove_apt_config = stack.enter_context(
+                mock.patch.object(
+                    entitlement, "remove_apt_config", return_value=True
+                )
+            )
             stack.enter_context(
                 mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
             )
@@ -302,8 +321,7 @@ class TestFIPSEntitlementEnable:
             error_msg = "Could not enable {}.".format(entitlement.title)
             assert error_msg == excinfo.value.msg
 
-        for call in m_subp.call_args_list:
-            assert "remove" not in call[0][0]
+        assert 1 == m_remove_apt_config.call_count
 
     @mock.patch("uaclient.entitlements.repo.handle_message_operations")
     @mock.patch("uaclient.util.is_container", return_value=False)
@@ -347,23 +365,79 @@ class TestFIPSEntitlementEnable:
         assert expected_msg.strip() == fake_stdout.getvalue().strip()
 
 
-class TestFIPSEntitlementDisable:
-    @pytest.mark.parametrize("silent", [False, True])
-    @mock.patch("uaclient.util.get_platform_info")
-    def test_disable_returns_false_and_does_nothing(
-        self, m_platform_info, entitlement, silent, capsys
+class TestFIPSEntitlementRemovePackages:
+    @pytest.mark.parametrize("installed_pkgs", (["sl"], ["ubuntu-fips", "sl"]))
+    @mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
+    @mock.patch(M_PATH + "util.subp")
+    @mock.patch(M_PATH + "apt.get_installed_packages")
+    def test_remove_packages_only_removes_if_package_is_installed(
+        self,
+        m_get_installed_packages,
+        m_subp,
+        _m_get_platform,
+        installed_pkgs,
+        entitlement,
     ):
-        """When can_disable is false disable returns false and noops."""
-        with mock.patch("uaclient.apt.remove_auth_apt_repo") as m_remove_apt:
-            assert False is entitlement.disable(silent)
-        assert 0 == m_remove_apt.call_count
+        m_subp.return_value = ("success", "")
+        m_get_installed_packages.return_value = installed_pkgs
+        entitlement.remove_packages()
+        remove_cmd = mock.call(
+            [
+                "apt-get",
+                "remove",
+                "--assume-yes",
+                '-o Dpkg::Options::="--force-confdef"',
+                '-o Dpkg::Options::="--force-confold"',
+                "ubuntu-fips",
+            ],
+            capture=True,
+            retry_sleeps=apt.APT_RETRIES,
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+        if "ubuntu-fips" in installed_pkgs:
+            assert [remove_cmd] == m_subp.call_args_list
+        else:
+            assert 0 == m_subp.call_count
 
-        expected_stdout = ""
-        if not silent:
-            expected_stdout = "Warning: no option to disable {}\n".format(
-                entitlement.title
-            )
-        assert (expected_stdout, "") == capsys.readouterr()
+
+@mock.patch(M_REPOPATH + "handle_message_operations", return_value=True)
+@mock.patch(
+    "uaclient.util.get_platform_info", return_value={"series": "xenial"}
+)
+class TestFIPSEntitlementDisable:
+    def test_disable_on_can_disable_true_removes_apt_config_and_packages(
+        self,
+        _m_platform_info,
+        m_handle_message_operations,
+        entitlement,
+        tmpdir,
+    ):
+        """When can_disable, disable removes apt config and packages."""
+        with mock.patch.object(entitlement, "can_disable", return_value=True):
+            with mock.patch.object(
+                entitlement, "remove_apt_config"
+            ) as m_remove_apt_config:
+                with mock.patch.object(
+                    entitlement, "remove_packages"
+                ) as m_remove_packages:
+                    assert entitlement.disable(True)
+        assert [mock.call()] == m_remove_apt_config.call_args_list
+        assert [mock.call()] == m_remove_packages.call_args_list
+
+    def test_disable_on_can_disable_true_removes_packages(
+        self,
+        _m_platform_info,
+        m_handle_message_operations,
+        entitlement,
+        tmpdir,
+    ):
+        """When can_disable, disable removes apt configuration"""
+        with mock.patch.object(entitlement, "can_disable", return_value=True):
+            with mock.patch.object(
+                entitlement, "remove_apt_config"
+            ) as m_remove_apt_config:
+                assert entitlement.disable(True)
+        assert [mock.call()] == m_remove_apt_config.call_args_list
 
 
 class TestFIPSEntitlementApplicationStatus:
@@ -402,7 +476,7 @@ class TestFIPSEntitlementApplicationStatus:
             ),
         ),
     )
-    def test_kernels_are_used_to_detemine_application_status_message(
+    def test_kernels_are_used_to_determine_application_status_message(
         self, entitlement, platform_info, expected_status, expected_msg
     ):
         msg = "sure is some status here"


### PR DESCRIPTION
# WIP  for discussion with online services team about feasibility

related PR in ua-contracts https://github.com/blackboxsw/ua-contracts/pull/1

    contract: allow contract overrides based on ua client version
    
    When processing applicable directives, affordances and obligations from a
    contract, the client will first override any series-specific config options
    matching the running Ubuntu series under the top-level "series" key. After
    applying any series overrides, the client will then process any applicable
    client config options present under a top-level "client" key.
    
    The subkeys below "client" will be of the form "XX.Y" where XX is the major version and Y is the minor version of the release. Any version less than or equal
    to the current version of ubuntu-advantage client will be applied to the
    contract. Any version number greater than the running client version is
    ignored.
