### PR TITLE
Conditionally install packages when enabling FIPS

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -62,6 +62,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
         And I run `ua disable livepatch` with sudo
+        And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
         When I run `ua enable fips --assume-yes --beta` with sudo
         Then stdout matches regexp:
             """
@@ -77,6 +78,12 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `openssh-server` is installed and has `fips` on its version
+        And I verify that `openssh-client` is installed and has `fips` on its version
+        And I verify that `strongswan` is installed and has `fips` on its version
+        And I verify that `openssh-server-hmac` is installed and has `fips` on its version
+        And I verify that `openssh-client-hmac` is installed and has `fips` on its version
+        And I verify that `strongswan-hmac` is installed and has `fips` on its version
         When I reboot the `<release>` machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
@@ -100,6 +107,13 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         0
         """
+        And I verify that `openssh-server` is installed and has `fips` on its version
+        And I verify that `openssh-client` is installed and has `fips` on its version
+        And I verify that `strongswan` is installed and has `fips` on its version
+        And I verify that `openssh-server-hmac` is installed and has `fips` on its version
+        And I verify that `openssh-client-hmac` is installed and has `fips` on its version
+        And I verify that `strongswan-hmac` is installed and has `fips` on its version
+
         Examples: ubuntu release
            | release |
            | xenial  |

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -78,12 +78,12 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that `openssh-server` is installed and has `fips` on its version
-        And I verify that `openssh-client` is installed and has `fips` on its version
-        And I verify that `strongswan` is installed and has `fips` on its version
-        And I verify that `openssh-server-hmac` is installed and has `fips` on its version
-        And I verify that `openssh-client-hmac` is installed and has `fips` on its version
-        And I verify that `strongswan-hmac` is installed and has `fips` on its version
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
         When I reboot the `<release>` machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
@@ -107,14 +107,14 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         0
         """
-        And I verify that `openssh-server` is installed and has `fips` on its version
-        And I verify that `openssh-client` is installed and has `fips` on its version
-        And I verify that `strongswan` is installed and has `fips` on its version
-        And I verify that `openssh-server-hmac` is installed and has `fips` on its version
-        And I verify that `openssh-client-hmac` is installed and has `fips` on its version
-        And I verify that `strongswan-hmac` is installed and has `fips` on its version
+        And I verify that `openssh-server` installed version matches regexp `fips`
+        And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `openssh-server-hmac` installed version matches regexp `fips`
+        And I verify that `openssh-client-hmac` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | fips-apt-source |
+           | xenial  | https://esm.staging.ubuntu.com/fips/ubuntu xenial/main |
+           | bionic  | https://esm.staging.ubuntu.com/fips/ubuntu bionic/main |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,9 +1,16 @@
 import datetime
 import subprocess
+import re
 import shlex
 
 from behave import given, then, when
-from hamcrest import assert_that, equal_to, matches_regexp, not_
+from hamcrest import (
+    assert_that,
+    equal_to,
+    matches_regexp,
+    not_,
+    contains_string,
+)
 
 from features.environment import create_uat_image
 from features.util import (
@@ -243,15 +250,42 @@ def there_should_be_no_files_matching_regex(context, path_regex):
         )
 
 
-@then("I verify that `{package}` is installed and has `{name}` on its version")
-def verify_package_is_installed_and_has_name_on_version(
-    context, package, name
-):
+@then("I verify that `{package}` installed version matches regexp `{regex}`")
+def verify_installed_package_matches_version_regexp(context, package, regex):
+    when_i_run_command(
+        context,
+        "dpkg-query --showformat='${{Version}}' --show {}".format(package),
+        "as non-root",
+    )
+    assert_that(context.process.stdout.strip(), matches_regexp(regex))
+
+
+@then("I verify that `{package}` is installed from apt source `{apt_source}`")
+def verify_package_is_installed_from_apt_source(context, package, apt_source):
     when_i_run_command(
         context, "apt-cache policy {}".format(package), "as non-root"
     )
-    context.text = "Installed: .*{}.*".format(name)
-    then_stdout_matches_regexp(context)
+    policy = context.process.stdout.strip()
+    RE_APT_SOURCE = r"\s+\d+\s+(?P<source>.*)"
+    lines = policy.splitlines()
+    for index, line in enumerate(lines):
+        if re.match(r"\s+\*\*\*", line):  # apt-policy installed prefix ***
+            # Next line is the apt repo from which deb is installed
+            installed_apt_source = re.match(RE_APT_SOURCE, lines[index + 1])
+            if installed_apt_source is None:
+                raise RuntimeError(
+                    "Unable to process apt-policy line {}".format(
+                        lines[index + 1]
+                    )
+                )
+            assert_that(
+                installed_apt_source.groupdict()["source"],
+                contains_string(apt_source),
+            )
+            return
+    raise AssertionError(
+        "Package {package} is not installed".format(package=package)
+    )
 
 
 def get_command_prefix_for_user_spec(user_spec):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -243,6 +243,17 @@ def there_should_be_no_files_matching_regex(context, path_regex):
         )
 
 
+@then("I verify that `{package}` is installed and has `{name}` on its version")
+def verify_package_is_installed_and_has_name_on_version(
+    context, package, name
+):
+    when_i_run_command(
+        context, "apt-cache policy {}".format(package), "as non-root"
+    )
+    context.text = "Installed: .*{}.*".format(name)
+    then_stdout_matches_regexp(context)
+
+
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
     if user_spec == "with sudo":


### PR DESCRIPTION
When enabling FIPS we will now be checking if the user has some predefined packages installed. If they are, we will update them to the FIPS version and also install the corresponding hmac package.

Fix #1239