### PR TITLE
pro: trigger auto-attach as soon as instance-data.json is available

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -55,7 +55,7 @@ ifeq (${VERSION_ID},"14.04")
 else
 	# Move ua-auto-attach.service out to ubuntu-advantage-pro
 	mkdir -p debian/ubuntu-advantage-pro/lib/systemd/system
-	mv debian/ubuntu-advantage-tools/lib/systemd/system/ua-auto-attach.service debian/ubuntu-advantage-pro/lib/systemd/system
+	mv debian/ubuntu-advantage-tools/lib/systemd/system/ua-auto-attach.* debian/ubuntu-advantage-pro/lib/systemd/system
 	cd debian/ubuntu-advantage-tools && rmdir -p lib/systemd/system
 endif
 

--- a/systemd/ua-auto-attach.path
+++ b/systemd/ua-auto-attach.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ubuntu Advantage auto attach trigger
+
+[Path]
+PathExists=/run/cloud-init/instance-data.json
+Unit=ua-auto-attach.service
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Ubuntu Advantage auto attach
-After=cloud-final.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Ensure esm-related services are attached as soon as possible on Ubuntu PRO images.
Don't wait until after cloud-init userdata is processed.

Fixes: #1234