### PR TITLE
Update esm-infra lxd test

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -4,12 +4,12 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
     @series.all
     Scenario Outline: Attach command in a machine
        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua attach INVALID_TOKEN` with sudo
+        When I verify that running `ua attach INVALID_TOKEN` `with sudo` exits `1`
         Then stderr matches regexp:
             """
             Invalid token. See https://ubuntu.com/advantage
             """
-        When I run `ua attach INVALID_TOKEN` as non-root
+        When I verify that running `ua attach INVALID_TOKEN` `as non-root` exits `1`
         Then I will see the following on stderr:
              """
              This command must be run as root (try using sudo)

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -7,8 +7,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get install -y <downrev_pkg>` with sudo
+        When I verify that running ` --assume-yes --beta` `with sudo` exits `1`
         And I run `/usr/lib/update-notifier/apt-check  --human-readable` as non-root
-
         Then if `<release>` in `trusty` and stdout matches regexp:
         """
         UA Infrastructure Extended Security Maintenance \(ESM\) is not enabled.
@@ -64,15 +64,14 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         \d+ update(s)? (is a|are) security update(s)?.
         """
         Examples: ubuntu release packages
-           | release | downrev_pkg                     |
-           | trusty  | libgit2-0=0.19.0-2ubuntu0.4     |
-           | xenial  | libkrad0=1.13.2+dfsg-5ubuntu2.1 |
-           | bionic  | libkrad0=1.16-2ubuntu0.1        |
-           | focal   | hello=2.10-2ubuntu2             |
+           | release | downrev_pkg                 |
+           | trusty  | libgit2-0=0.19.0-2ubuntu0.4 |
+           | xenial  | libkrad0=1.13.2+dfsg-5      |
+           | bionic  | libkrad0=1.16-2build1       |
+           | focal   | hello=2.10-2ubuntu2         |
 
     @series.all
     @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.lxd.vm
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -5,8 +5,8 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached refresh in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua refresh` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua refresh` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
@@ -27,13 +27,13 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable livepatch` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua disable livepatch` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua disable livepatch` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua disable livepatch` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             Livepatch is not currently enabled
             See: sudo ua status
@@ -50,13 +50,13 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached disable of an unknown service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable foobar` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua disable foobar` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua disable foobar` with sudo
-        Then stderr matches regexp:
+        And I verify that running `ua disable foobar` `with sudo` exits `1`
+        And stderr matches regexp:
             """
             Cannot disable unknown service 'foobar'.
             Try cc-eal, cis-audit, esm-apps, esm-infra, fips, fips-updates, livepatch
@@ -73,8 +73,8 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached detach in a trusty machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua detach` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua detach` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
@@ -114,8 +114,8 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua auto-attach` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua auto-attach` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
@@ -205,13 +205,13 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached disable of different services in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable esm-infra livepatch foobar` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua disable esm-infra livepatch foobar` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua disable esm-infra livepatch foobar` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua disable esm-infra livepatch foobar` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             Updating package lists
             Livepatch is not currently enabled
@@ -241,7 +241,7 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario Outline: Attached disable of an already enabled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable esm-infra` as non-root
+        Then I verify that running `ua disable esm-infra` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
@@ -267,8 +267,8 @@ Feature: Command behaviour when attached to an UA subscription
     Scenario: Attached disable of an already enabled service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable esm-infra` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua disable esm-infra` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
@@ -323,8 +323,8 @@ Feature: Command behaviour when attached to an UA subscription
             """
             {"name": "esm-infra", "entitled": "yes", "status": "enabled", "help": "esm-infra provides access to a private ppa which includes available high\nand critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main\nrepository between the end of the standard Ubuntu LTS security\nmaintenance and its end of life. It is enabled by default with\nExtended Security Maintenance (ESM) for UA Apps and UA Infra.\nYou can find our more about the esm service at\nhttps://ubuntu.com/security/esm\n"}
             """
-        When I run `ua help invalid-service` with sudo
-        Then I will see the following on stderr:
+        And I verify that running `ua help invalid-service` `with sudo` exits `1`
+        And I will see the following on stderr:
             """
             No help available for 'invalid-service'
             """
@@ -427,4 +427,3 @@ Feature: Command behaviour when attached to an UA subscription
            | xenial  | canonical-server-ubuntu-ua-client-daily |
            | bionic  | canonical-server-ubuntu-ua-client-daily |
            | focal   | canonical-server-ubuntu-ua-client-daily |
-

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -5,13 +5,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable Common Criteria service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable cc-eal` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable cc-eal --beta` with sudo
-        Then I will see the following on stdout
+        And I verify that running `ua enable cc-eal --beta` `with sudo` exits `1`
+        And I will see the following on stdout
             """
             One moment, checking your subscription first
             <msg>
@@ -27,13 +27,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable a disabled beta service and unknown service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable fips foobar` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable fips foobar` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable fips foobar` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable fips foobar` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             """
@@ -54,17 +54,17 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable of an unknown service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable foobar` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable foobar` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable foobar` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable foobar` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             """
-        Then stderr matches regexp:
+        And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
             Try esm-infra, livepatch
@@ -81,12 +81,12 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable of a known service already enabled (UA Infra) in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable esm-infra` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable esm-infra` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable esm-infra` with sudo
+        And I verify that running `ua enable esm-infra` `with sudo` exits `1`
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -120,8 +120,8 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable of a know service shows update in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable esm-infra` with sudo
-        Then I will see the following on stdout:
+        Then I verify that running `ua enable esm-infra` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             ESM Infra is already enabled.
@@ -151,13 +151,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable a disabled, enable and unknown service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable livepatch esm-infra foobar` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable livepatch esm-infra foobar` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable livepatch esm-infra foobar` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable livepatch esm-infra foobar` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             Cannot install Livepatch on a container
@@ -183,13 +183,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable <service> <flag>` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable <service> <flag>` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable <service> <flag>` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable <service> <flag>` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             Cannot install <title> on a container
@@ -214,13 +214,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline:  Attached enable of non-container beta services in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable <service> <flag>` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable <service> <flag>` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable <service> <flag>` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable <service> <flag>` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             """
@@ -245,13 +245,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua enable <service>` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable <service>` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua enable <service> --beta` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable <service> --beta` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             This subscription is not entitled to <title>.
@@ -274,15 +274,14 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario: Attached enable of vm-based services in a focal lxd vm
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable livepatch` with sudo
-        And I run `ua enable fips --assume-yes --beta` with sudo
-        Then I will see the following on stdout:
+        Then I verify that running `ua enable fips --assume-yes --beta` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
-        When I run `ua enable fips-updates --assume-yes --beta` with sudo
-        Then I will see the following on stdout:
+        And I verify that running `ua enable fips-updates --assume-yes --beta` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             FIPS Updates is not available for Ubuntu 20.04 LTS (Focal Fossa).
@@ -301,8 +300,8 @@ Feature: Enable command behaviour when attached to an UA subscription
         livepatch    +yes      +enabled  +Canonical Livepatch service
         """
         When I run `ua disable livepatch` with sudo
-        And I run `canonical-livepatch status` with sudo
-        Then stdout matches regexp:
+        Then I verify that running `canonical-livepatch status` `with sudo` exits `1`
+        And stdout matches regexp:
         """
         Machine is not enabled. Please run 'sudo canonical-livepatch enable' with the
         token obtained from https://ubuntu.com/livepatch.
@@ -324,7 +323,7 @@ Feature: Enable command behaviour when attached to an UA subscription
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attached enable livepatch on a machine with fips active
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `canonical-livepatch status` with sudo
+        When I verify that running `canonical-livepatch status` `with sudo` exits `1`
         Then I will see the following on stderr:
             """
             sudo: canonical-livepatch: command not found
@@ -373,8 +372,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS enabled
             A reboot is required to complete install
             """
-        When I run `ua enable livepatch` with sudo
-        Then I will see the following on stdout
+        And I verify that running `ua enable livepatch` `with sudo` exits `1`
+        And I will see the following on stdout
             """
             One moment, checking your subscription first
             Cannot enable Livepatch when FIPS is enabled
@@ -392,8 +391,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             Installing canonical-livepatch snap
             Canonical livepatch enabled
             """
-        When I run `ua enable fips --assume-yes --beta` with sudo
-        Then I will see the following on stdout
+        And I verify that running `ua enable fips --assume-yes --beta` `with sudo` exits `1`
+        And I will see the following on stdout
             """
             One moment, checking your subscription first
             Cannot enable FIPS when Livepatch is enabled
@@ -421,7 +420,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS Updates enabled
             A reboot is required to complete install
             """
-        When I run `ua enable fips --assume-yes --beta` with sudo
+        When I verify that running `ua enable fips --assume-yes --beta` `with sudo` exits `1`
         Then I will see the following on stdout
             """
             One moment, checking your subscription first

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -127,8 +127,8 @@ Feature: Enable command behaviour when attached to an UA subscription
             ESM Infra is already enabled.
             See: sudo ua status
             """
-        When I run `apt install -y <pkg-version>` with sudo
-        And I run `apt update` with sudo
+        And I verify that running `apt install -y <pkg-version>` `with sudo` exits `0`
+        When I run `apt update` with sudo
         Then stdout matches regexp
         """
         \d+ of the updates (is|are) from UA Infra: ESM
@@ -141,10 +141,10 @@ Feature: Enable command behaviour when attached to an UA subscription
         """
 
         Examples: ubuntu release
-           | release | pkg-version                |
-           | bionic  | libkrad0=1.16-2ubuntu0.1   |
-           | focal   | hello=2.10-2ubuntu2        |
-           | xenial  | libkrad0=1.16-2ubuntu0.1   |
+           | release | pkg-version            |
+           | bionic  | libkrad0=1.16-2build1  |
+           | focal   | hello=2.10-2ubuntu2    |
+           | xenial  | libkrad0=1.13.2+dfsg-5 |
 
     @series.all
     @uses.config.machine_type.lxd.container

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -5,8 +5,8 @@ Feature: Enable command behaviour when attached to an UA staging subscription
     Scenario: Attached enable CC EAL service in a xenial lxd container
         Given a `xenial` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
-        And I run `ua enable cc-eal` as non-root
-        Then I will see the following on stderr:
+        Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
+        And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
@@ -28,8 +28,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         esm-apps      yes                enabled            UA Apps: Extended Security Maintenance \(ESM\)
         """
-        When I run `ua disable livepatch` with sudo
-        Then I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt-cache policy` as non-root
         Then apt-cache policy for the following url has permission `500`
         """

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -19,8 +19,8 @@ Feature: Upgrade between releases when uaclient is attached
         """
         <next_release>
         """
-        When I run `egrep "<release>|disabled" /etc/apt/sources.list.d/*` as non-root
-        Then I will see the following on stdout:
+        And I verify that running `egrep "<release>|disabled" /etc/apt/sources.list.d/*` `as non-root` exits `2`
+        And I will see the following on stdout:
         """
         """
         When I run `ua status` with sudo
@@ -53,8 +53,8 @@ Feature: Upgrade between releases when uaclient is attached
         """
         <next_release>
         """
-        When I run `egrep "<release>|disabled" /etc/apt/sources.list.d/*` as non-root
-        Then I will see the following on stdout:
+        And I verify that running `egrep "<release>|disabled" /etc/apt/sources.list.d/*` `as non-root` exits `2`
+        And I will see the following on stdout:
         """
         """
         When I run `ua status` with sudo

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -3,7 +3,7 @@ Feature: Command behaviour when unattached
     @series.all
     Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua auto-attach` as non-root
+        When I verify that running `ua auto-attach` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
@@ -25,12 +25,12 @@ Feature: Command behaviour when unattached
     @series.all
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua <command>` as non-root
+        When I verify that running `ua <command>` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua <command>` with sudo
+        When I verify that running `ua <command>` `with sudo` exits `1`
         Then stderr matches regexp:
             """
             This machine is not attached to a UA subscription.
@@ -51,12 +51,12 @@ Feature: Command behaviour when unattached
     @series.all
     Scenario Outline: Unattached command known and unknown services in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua <command> livepatch` as non-root
+        When I verify that running `ua <command> <service>` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        When I run `ua <command> <service>` with sudo
+        When I verify that running `ua <command> <service>` `with sudo` exits `1`
         Then stderr matches regexp:
             """
             To use '<service>' you need an Ubuntu Advantage subscription
@@ -109,7 +109,7 @@ Feature: Command behaviour when unattached
             """
             {"name": "esm-infra", "available": "yes", "help": "esm-infra provides access to a private ppa which includes available high\nand critical CVE fixes for Ubuntu LTS packages in the Ubuntu Main\nrepository between the end of the standard Ubuntu LTS security\nmaintenance and its end of life. It is enabled by default with\nExtended Security Maintenance (ESM) for UA Apps and UA Infra.\nYou can find our more about the esm service at\nhttps://ubuntu.com/security/esm\n"}
             """
-        When I run `ua help invalid-service` with sudo
+        When I verify that running `ua help invalid-service` `with sudo` exits `1`
         Then I will see the following on stderr:
             """
             No help available for 'invalid-service'


### PR DESCRIPTION
On the `Attached enable of a know service shows update in a ubuntu machine` we were failing to install the `libkrad0` package on xenial, which makes the test fail. We are now confirming that the package is installed while updating the package version that is installed on xenial.