### PR TITLE
Unhold fips pkgs

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -62,6 +62,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         When I attach `contract_token_staging` with sudo
         And I run `ua disable livepatch` with sudo
         And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
+        And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
         When I run `ua enable fips --assume-yes --beta` with sudo
         Then stdout matches regexp:
             """
@@ -112,6 +113,13 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         And I verify that `openssh-server-hmac` installed version matches regexp `fips`
         And I verify that `openssh-client-hmac` installed version matches regexp `fips`
         And I verify that `strongswan-hmac` installed version matches regexp `fips`
+        When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
+        Then I will see the following on stdout:
+        """
+        openssh-client was already not hold.
+        openssh-server was already not hold.
+        strongswan was already not hold.
+        """
 
         Examples: ubuntu release
            | release | fips-apt-source |

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -189,6 +189,7 @@ class RepoEntitlement(base.UAEntitlement):
         delta_entitlement = deltas.get("entitlement", {})
         delta_directives = delta_entitlement.get("directives", {})
         delta_apt_url = delta_directives.get("aptURL")
+        delta_packages = delta_directives.get("additionalPackages")
         status_cache = self.cfg.read_cache("status-cache")
 
         if delta_directives and status_cache:
@@ -212,6 +213,8 @@ class RepoEntitlement(base.UAEntitlement):
                 apt.remove_auth_apt_repo(repo_filename, old_url)
         self.remove_apt_config()
         self.setup_apt_config()
+        if delta_packages:
+            self.install_packages(package_list=delta_packages)
         return True
 
     def install_packages(self, package_list: "List[str]" = None) -> None:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -109,33 +109,10 @@ class RepoEntitlement(base.UAEntitlement):
             return False
         self.setup_apt_config()
         if self.packages:
-            try:
-                print("Installing {title} packages".format(title=self.title))
-                msg_ops = self.messaging.get("pre_install", [])
-                if not handle_message_operations(msg_ops):
-                    return False
-
-                if self.apt_noninteractive:
-                    env = {"DEBIAN_FRONTEND": "noninteractive"}
-                    apt_options = [
-                        '-o Dpkg::Options::="--force-confdef"',
-                        '-o Dpkg::Options::="--force-confold"',
-                    ]
-                else:
-                    env = {}
-                    apt_options = []
-                apt.run_apt_command(
-                    ["apt-get", "install", "--assume-yes"]
-                    + apt_options
-                    + self.packages,
-                    status.MESSAGE_ENABLED_FAILED_TMPL.format(
-                        title=self.title
-                    ),
-                    env=env,
-                )
-            except exceptions.UserFacingError:
-                self._cleanup()
-                raise
+            msg_ops = self.messaging.get("pre_install", [])
+            if not handle_message_operations(msg_ops):
+                return False
+            self.install_packages()
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         msg_ops = self.messaging.get("post_enable", [])
         if not handle_message_operations(msg_ops):
@@ -237,8 +214,40 @@ class RepoEntitlement(base.UAEntitlement):
         self.setup_apt_config()
         return True
 
+    def install_packages(self, package_list: "List[str]" = None) -> None:
+        """Install contract recommended packages for the entitlement.
+
+        :param package_list: Optional package list to use instead of
+            self.packages.
+        """
+        print("Installing {title} packages".format(title=self.title))
+        if self.apt_noninteractive:
+            env = {"DEBIAN_FRONTEND": "noninteractive"}
+            apt_options = [
+                '-o Dpkg::Options::="--force-confdef"',
+                '-o Dpkg::Options::="--force-confold"',
+            ]
+        else:
+            env = {}
+            apt_options = []
+        if not package_list:
+            package_list = self.packages
+        try:
+            apt.run_apt_command(
+                ["apt-get", "install", "--assume-yes"]
+                + apt_options
+                + package_list,
+                status.MESSAGE_ENABLED_FAILED_TMPL.format(
+                    title=self.title
+                ),
+                env=env,
+            )
+        except exceptions.UserFacingError:
+            self._cleanup()
+            raise
+
     def setup_apt_config(self) -> None:
-        """Setup apt config based on the resourceToken and  directives.
+        """Setup apt config based on the resourceToken and directives.
 
         :raise UserFacingError: on failure to setup any aspect of this apt
            configuration

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -240,9 +240,7 @@ class RepoEntitlement(base.UAEntitlement):
                 ["apt-get", "install", "--assume-yes"]
                 + apt_options
                 + package_list,
-                status.MESSAGE_ENABLED_FAILED_TMPL.format(
-                    title=self.title
-                ),
+                status.MESSAGE_ENABLED_FAILED_TMPL.format(title=self.title),
                 env=env,
             )
         except exceptions.UserFacingError:

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -220,9 +220,9 @@ class TestCommonCriteriaEntitlementEnable:
         expected_stdout += "\n".join(
             [
                 "Updating package lists",
-                "Installing CC EAL2 packages",
                 "(This will download more than 500MB of packages, so may take"
                 " some time.)",
+                "Installing CC EAL2 packages",
                 "CC EAL2 enabled",
                 "Please follow instructions in {} to configure EAL2\n".format(
                     CC_README

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -483,12 +483,12 @@ class TestRepoEnable:
                 )
                 expected_output = (
                     "\n".join(
-                        [
-                            "Updating package lists",
-                            "Installing Repo Test Class packages",
-                        ]
+                        ["Updating package lists"]
                         + (pre_install_msgs if with_pre_install_msg else [])
-                        + ["Repo Test Class enabled"]
+                        + [
+                            "Installing Repo Test Class packages",
+                            "Repo Test Class enabled"
+                        ]
                         + ([reboot_msg] if should_reboot else [])
                     )
                     + "\n"


### PR DESCRIPTION
* FIPSEntitlement.setup_apt_config will unhold deb packages to support Ubuntu PRO FIPS images which were built before UA client official support of FIPS.
* Separate RepoEntitlement.install_packages method out of `enable` method so it can be called during delta processing.
* Handle apt-based contract deltas that include changes in additionalPackages directives during
`repo.process_contract_deltas`. 

Fixes: #1109