### PR TITLE
ua-auto-attach: finish auto-attach.service before cloud-config.service starts

### DIFF
--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ubuntu Advantage auto attach
+Before=cloud-config.service
+WantedBy=cloud-config.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Declare the ua-auto-attach.service unit as being run explicity Before  and WantedBy cloud-config.service to ensure auto-attach completes before any cloud-config userdata attempts to install or update deb packages.

This guarantees that any packages will be pulled from ESM PPAs if applicable on a given machine if cloud-config requests
package installs.