### PR TITLE
Fix integration test setup scripts

### DIFF
--- a/tools/run_aws_travis_integration_tests.sh
+++ b/tools/run_aws_travis_integration_tests.sh
@@ -3,7 +3,7 @@ source tools/base_travis_integration_tests.sh
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && ["$TRAVIS_BRANCH" = "master"]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   BUILD_PR=0
 else
   create_pr_tar_file

--- a/tools/run_lxd_travis_integration_tests.sh
+++ b/tools/run_lxd_travis_integration_tests.sh
@@ -9,7 +9,7 @@ install_lxd() {
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && ["$TRAVIS_BRANCH" = "master"]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   BUILD_PR=0
 else
   create_pr_tar_file


### PR DESCRIPTION
One check on both lxd and azure setup scripts were incorrect.
We are fixing that check to allow the builds to function as expected

Fixes: #1253