### PR TITLE
Unattached noop upgrade process deltas

### DIFF
--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -1,3 +1,4 @@
+@uses.config.contract_token
 Feature: Upgrade between releases when uaclient is attached
 
     @series.focal

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -49,6 +49,10 @@ current_codename_to_past_codename = {
 
 def process_contract_delta_after_apt_lock() -> None:
     setup_logging(logging.INFO, logging.DEBUG)
+    logging.debug("Check whether to upgrade-lts-contract")
+    if not UAConfig().is_attached:
+        logging.debug("Skiping upgrade-lts-contract. Machine is unattached")
+        return
     out, _err = subp(["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1])
     msg = "Starting upgrade-lts-contract."
     if out:

--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -1,41 +1,82 @@
-import contextlib
-import io
+import logging
 import mock
 import pytest
 
 from lib.upgrade_lts_contract import process_contract_delta_after_apt_lock
 
 
+@pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
 class TestUpgradeLTSContract:
+    @mock.patch(
+        "uaclient.config.UAConfig.is_attached",
+        new_callable=mock.PropertyMock,
+        return_value=False,
+    )
+    def test_unattached_noops(self, m_is_attached, capsys, caplog_text):
+        expected_logs = [
+            "Check whether to upgrade-lts-contract",
+            "Skiping upgrade-lts-contract. Machine is unattached",
+        ]
+
+        process_contract_delta_after_apt_lock()
+
+        assert 1 == m_is_attached.call_count
+        out, _err = capsys.readouterr()
+        assert "" == out
+        debug_logs = caplog_text()
+        for log in expected_logs:
+            assert log in debug_logs
+
+    @mock.patch(
+        "uaclient.config.UAConfig.is_attached",
+        new_callable=mock.PropertyMock,
+        return_value=True,
+    )
     @mock.patch("lib.upgrade_lts_contract.parse_os_release")
     @mock.patch("lib.upgrade_lts_contract.subp")
-    def test_upgrade_abort_when_upgrading_to_trusty(self, m_subp, m_parse_os):
+    def test_upgrade_abort_when_upgrading_to_trusty(
+        self, m_subp, m_parse_os, m_is_attached, capsys, caplog_text
+    ):
         m_parse_os.return_value = {"VERSION_ID": "14.04"}
 
         m_subp.return_value = ("", "")
 
-        expected_msg = "\n".join(
-            [
-                "Starting upgrade-lts-contract.",
-                "Unable to execute upgrade-lts-contract.py on trusty",
-            ]
-        )
-        fake_stdout = io.StringIO()
+        expected_msgs = [
+            "Starting upgrade-lts-contract.",
+            "Unable to execute upgrade-lts-contract.py on trusty",
+        ]
+        expected_logs = ["Check whether to upgrade-lts-contract"]
         with pytest.raises(SystemExit) as execinfo:
-            with contextlib.redirect_stdout(fake_stdout):
-                process_contract_delta_after_apt_lock()
+            process_contract_delta_after_apt_lock()
 
         assert 1 == execinfo.value.code
-        assert expected_msg == fake_stdout.getvalue().strip()
+        assert 1 == m_is_attached.call_count
         assert 1 == m_parse_os.call_count
         assert 1 == m_subp.call_count
+        out, _err = capsys.readouterr()
+        assert out == "\n".join(expected_msgs) + "\n"
+        debug_logs = caplog_text()
+        for log in expected_msgs + expected_logs:
+            assert log in debug_logs
 
+    @mock.patch(
+        "uaclient.config.UAConfig.is_attached",
+        new_callable=mock.PropertyMock,
+        return_value=True,
+    )
     @mock.patch("lib.upgrade_lts_contract.parse_os_release")
     @mock.patch("lib.upgrade_lts_contract.subp")
     @mock.patch("lib.upgrade_lts_contract.process_entitlements_delta")
     @mock.patch("lib.upgrade_lts_contract.time.sleep")
     def test_upgrade_contract_when_apt_lock_is_held(
-        self, m_sleep, m_process_delta, m_subp, m_parse_os
+        self,
+        m_sleep,
+        m_process_delta,
+        m_subp,
+        m_parse_os,
+        m_is_attached,
+        capsys,
+        caplog_text,
     ):
         m_parse_os.return_value = {"VERSION_ID": "20.04"}
 
@@ -56,20 +97,22 @@ class TestUpgradeLTSContract:
             ]
         )
 
-        expected_msg = "\n".join(
-            [
-                base_msg,
-                "upgrade-lts-contract processing contract deltas: {}".format(
-                    "bionic -> focal"
-                ),
-                "upgrade-lts-contract succeeded after 3 retries",
-            ]
-        )
-        fake_stdout = io.StringIO()
-        with contextlib.redirect_stdout(fake_stdout):
-            process_contract_delta_after_apt_lock()
+        expected_msgs = [
+            base_msg,
+            "upgrade-lts-contract processing contract deltas: {}".format(
+                "bionic -> focal"
+            ),
+            "upgrade-lts-contract succeeded after 3 retries",
+        ]
 
-        assert expected_msg == fake_stdout.getvalue().strip()
+        process_contract_delta_after_apt_lock()
+
+        assert 1 == m_is_attached.call_count
         assert 1 == m_parse_os.call_count
         assert 4 == m_subp.call_count
         assert 1 == m_process_delta.call_count
+        out, _err = capsys.readouterr()
+        assert out == "\n".join(expected_msgs) + "\n"
+        debug_logs = caplog_text()
+        for log in expected_msgs + ["Check whether to upgrade-lts-contract"]:
+            assert log in debug_logs


### PR DESCRIPTION
* upgrade-lts-conract: noop during do-release-upgrae on unattached
    
   Fast exit and don't print any messages during do-release-upgrade
   if the machine is not attached to a UA contract
    
   Fixes: #1255

commit 72bf82e458064403d4829a6e6e027a8210015911
 *  behave: upgrade test requires @uses.config.contract_token
