### PR TITLE
Add init script to run remaining uaclient commands after do-release-upgrade

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: bash-completion,
                debhelper (>=9),
                dh-python,
+               dh-systemd,
                gettext,
                git,
                libapt-pkg-dev,

--- a/debian/postinst
+++ b/debian/postinst
@@ -185,10 +185,11 @@ case "$1" in
           chmod 0700 "$private_dir"
       fi
 
-      trusty_pkg=$(echo $PREVIOUS_PKG_VER | grep -o 14.04)
-      if [ "$VERSION_ID" = "16.04" ] && [ ! -z "$trusty_pkg" ]; then
+      if [ "$VERSION_ID" = "16.04" ]; then
+        if echo "$PREVIOUS_PKG_VER" | grep -q "14.04"; then
           # trusty upgrade to xenial has known post-reboot operations required (livepatch)
           mark_reboot_cmds_as_needed
+        fi
       fi
       ;;
 esac

--- a/debian/postinst
+++ b/debian/postinst
@@ -29,6 +29,8 @@ SYSTEMD_WANTS_AUTO_ATTACH_LINK="/etc/systemd/system/multi-user.target.wants/ua-a
 SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enabled/ua-auto-attach.service.dsh-also"
 SYSTEMD_HELPER_ENABLED_WANTS_LINK="/var/lib/systemd/deb-systemd-helper-enabled/multi-user.target.wants/ua-auto-attach.service"
 
+REBOOT_CMD_MARKER_FILE="/var/lib/ubuntu-advantage/marker-reboot-cmds-required"
+
 # Rename apt config files for ua services removing ubuntu release names
 redact_ubuntu_release_from_ua_apt_filenames() {
     DIR=$1
@@ -113,6 +115,12 @@ EOF
     fi
 }
 
+mark_reboot_cmds_as_needed() {
+    if [ ! -f "$REBOOT_CMD_MARKER_FILE" ]; then
+      touch $REBOOT_CMD_MARKER_FILE
+    fi
+}
+
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -175,6 +183,12 @@ case "$1" in
       private_dir="/var/lib/ubuntu-advantage/private"
       if [ -d "$private_dir" ]; then
           chmod 0700 "$private_dir"
+      fi
+
+      trusty_pkg=$(echo $PREVIOUS_PKG_VER | grep -o 14.04)
+      if [ "$VERSION_ID" = "16.04" ] && [ ! -z "$trusty_pkg" ]; then
+          # trusty upgrade to xenial has known post-reboot operations required (livepatch)
+          mark_reboot_cmds_as_needed
       fi
       ;;
 esac

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:
-	dh $@ --with python3,bash-completion --buildsystem=pybuild \
+	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild \
 		--no-start
 
 override_dh_auto_build:
@@ -56,7 +56,7 @@ else
 	# Move ua-auto-attach.service out to ubuntu-advantage-pro
 	mkdir -p debian/ubuntu-advantage-pro/lib/systemd/system
 	mv debian/ubuntu-advantage-tools/lib/systemd/system/ua-auto-attach.* debian/ubuntu-advantage-pro/lib/systemd/system
-	cd debian/ubuntu-advantage-tools && rmdir -p lib/systemd/system
+	cd debian/ubuntu-advantage-tools
 endif
 
 override_dh_auto_clean:

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+"""
+Some uaclient operations cannot be fully completed by running a single
+command. For example, when upgrading uaclient from trusty to xenial,
+we may have a livepatch change in the contract, allowing livepatch to be
+enabled on xenial. However, during the upgrade we cannot install livepatch on
+the system, only after a reboot.
+
+To allow uaclient to postpone commands that need to be executed in a system boot,
+we are using this script, which will basically try to reprocess contract deltas
+on boot time.
+"""
+import logging
+import os
+import sys
+
+from uaclient import config
+
+from uaclient.util import subp, ProcessExecutionError, del_file
+from uaclient.cli import setup_logging, assert_lock_file
+
+
+def run_command(cmd, cfg):
+    try:
+        out, _ = subp(cmd.split(), capture=True)
+        logging.debug("Successfully executed cmd: {}".format(cmd))
+    except ProcessExecutionError as exec_error:
+        msg = (
+            "Failed running cmd: {}\n"
+            "Return code: {}\n"
+            "Stderr: {}\n"
+            "Stdout: {}".format(
+                cmd, exec_error.exit_code, exec_error.stderr, exec_error.stdout
+            )
+        )
+
+        reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
+        del_file(reboot_cmd_marker_file)
+
+        logging.debug(msg)
+        sys.exit(1)
+
+
+def refresh_contract(args, cfg):
+    cmd = "ua refresh"
+    run_command(cmd=cmd, cfg=cfg)
+
+
+@assert_lock_file("ua-reboot-process-deltas")
+def process_remaining_deltas(args, cfg):
+    cmd = "/usr/bin/python3 /usr/lib/ubuntu-advantage/upgrade_lts_contract.py"
+    run_command(cmd=cmd, cfg=cfg)
+
+
+def main(args, cfg):
+    setup_logging(logging.INFO, logging.DEBUG)
+    reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
+
+    if not cfg.is_attached:
+        logging.debug("Skiping reboot_cmds. Machine is unattached")
+
+        if os.path.exists(reboot_cmd_marker_file):
+            del_file(reboot_cmd_marker_file)
+
+        return
+
+    if os.path.exists(reboot_cmd_marker_file):
+        logging.debug(
+            "Running process contract deltas on reboot ...".format(
+                reboot_cmd_marker_file
+            )
+        )
+
+        refresh_contract(args, cfg)
+        process_remaining_deltas(args, cfg)
+
+        del_file(reboot_cmd_marker_file)
+
+        logging.debug(
+            "Completed running process contract deltas on reboot ..."
+        )
+
+
+if __name__ == "__main__":
+    cfg = config.UAConfig()
+    main(args=None, cfg=cfg)

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -17,7 +17,7 @@ import sys
 
 from uaclient import config
 
-from uaclient.util import subp, ProcessExecutionError, del_file
+from uaclient.util import subp, ProcessExecutionError
 from uaclient.cli import setup_logging, assert_lock_file
 
 
@@ -35,8 +35,7 @@ def run_command(cmd, cfg):
             )
         )
 
-        reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
-        del_file(reboot_cmd_marker_file)
+        cfg.delete_cache_key("marker-reboot-cmds")
 
         logging.warning(msg)
         sys.exit(1)
@@ -61,21 +60,17 @@ def main(args, cfg):
         logging.debug("Skipping reboot_cmds. Machine is unattached")
 
         if os.path.exists(reboot_cmd_marker_file):
-            del_file(reboot_cmd_marker_file)
+            cfg.delete_cache_key("marker-reboot-cmds")
 
         return
 
     if os.path.exists(reboot_cmd_marker_file):
-        logging.debug(
-            "Running process contract deltas on reboot ...".format(
-                reboot_cmd_marker_file
-            )
-        )
+        logging.debug("Running process contract deltas on reboot ...")
 
         refresh_contract(args, cfg)
         process_remaining_deltas(args, cfg)
 
-        del_file(reboot_cmd_marker_file)
+        cfg.delete_cache_key("marker-reboot-cmds")
 
         logging.debug(
             "Completed running process contract deltas on reboot ..."

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -58,7 +58,7 @@ def main(args, cfg):
     reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
 
     if not cfg.is_attached:
-        logging.debug("Skiping reboot_cmds. Machine is unattached")
+        logging.debug("Skipping reboot_cmds. Machine is unattached")
 
         if os.path.exists(reboot_cmd_marker_file):
             del_file(reboot_cmd_marker_file)

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -38,7 +38,7 @@ def run_command(cmd, cfg):
         reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
         del_file(reboot_cmd_marker_file)
 
-        logging.debug(msg)
+        logging.warning(msg)
         sys.exit(1)
 
 

--- a/systemd/ua-reboot-cmds.service
+++ b/systemd/ua-reboot-cmds.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Ubuntu Advantage reboot cmds
+ConditionPathExists=/var/lib/ubuntu-advantage/marker-reboot-cmds-required
 
 [Service]
 Type=oneshot
-ConditionPathExists=/var/lib/ubuntu-advantage/marker-reboot-cmds-required
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/reboot_cmds.py
 TimeoutSec=0
 

--- a/systemd/ua-reboot-cmds.service
+++ b/systemd/ua-reboot-cmds.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ubuntu Advantage reboot cmds
+
+[Service]
+Type=oneshot
+ConditionPathExists=/var/lib/ubuntu-advantage/marker-reboot-cmds-required
+ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/reboot_cmds.py
+TimeoutSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -53,6 +53,7 @@ class UAConfig:
         "machine-token": DataPath("machine-token.json", True),
         "lock": DataPath("lock", True),
         "status-cache": DataPath("status.json", False),
+        "marker-reboot-cmds": DataPath("marker-reboot-cmds-required", False),
     }  # type: Dict[str, DataPath]
 
     _entitlements = None  # caching to avoid repetitive file reads

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -219,10 +219,18 @@ class LivepatchEntitlement(base.UAEntitlement):
         """
         if super().process_contract_deltas(orig_access, deltas, allow_enable):
             return True  # Already processed parent class deltas
+
+        delta_entitlement = deltas.get("entitlement", {})
+        process_enable_default = delta_entitlement.get("obligations", {}).get(
+            "enabledByDefault", False
+        )
+
+        if process_enable_default:
+            return self.enable()
+
         application_status, _ = self.application_status()
         if application_status == status.ApplicationStatus.DISABLED:
             return True  # only operate on changed directives when ACTIVE
-        delta_entitlement = deltas.get("entitlement", {})
         delta_directives = delta_entitlement.get("directives", {})
         supported_deltas = set(["caCerts", "remoteServer"])
         process_directives = bool(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -233,6 +233,11 @@ class RepoEntitlement(base.UAEntitlement):
             self.setup_apt_config()
 
         if delta_packages:
+            logging.info(
+                "Installing packages on changed directives: {}".format(
+                    ", ".join(delta_packages)
+                )
+            )
             self.install_packages(package_list=delta_packages)
 
         return True

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -216,11 +216,12 @@ class RepoEntitlement(base.UAEntitlement):
         if application_status == status.ApplicationStatus.DISABLED:
             return True
 
-        logging.info(
-            "Updating '%s' apt sources list on changed directives.", self.name
-        )
-
         if not self._check_apt_url_is_applied(delta_apt_url):
+            logging.info(
+                "Updating '%s' apt sources list on changed directives.",
+                self.name,
+            )
+
             orig_entitlement = orig_access.get("entitlement", {})
             old_url = orig_entitlement.get("directives", {}).get("aptURL")
             if old_url:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -167,6 +167,20 @@ class RepoEntitlement(base.UAEntitlement):
             "{} is not configured".format(self.title),
         )
 
+    def _check_apt_url_is_applied(self, apt_url):
+        """Check if apt url delta should be applied.
+
+        :param apt_url: string containing the apt url to be used.
+
+        :return: False if apt url is already found on the source file.
+                 True otherwise.
+        """
+        if not apt_url:
+            return True
+
+        apt_file = self.repo_list_file_tmpl.format(name=self.name)
+        return bool(apt_url in util.load_file(apt_file))
+
     def process_contract_deltas(
         self,
         orig_access: "Dict[str, Any]",
@@ -206,17 +220,20 @@ class RepoEntitlement(base.UAEntitlement):
             "Updating '%s' apt sources list on changed directives.", self.name
         )
 
-        if delta_apt_url:
+        if not self._check_apt_url_is_applied(delta_apt_url):
             orig_entitlement = orig_access.get("entitlement", {})
             old_url = orig_entitlement.get("directives", {}).get("aptURL")
             if old_url:
                 # Remove original aptURL and auth and rewrite
                 repo_filename = self.repo_list_file_tmpl.format(name=self.name)
                 apt.remove_auth_apt_repo(repo_filename, old_url)
-        self.remove_apt_config()
-        self.setup_apt_config()
+
+            self.remove_apt_config()
+            self.setup_apt_config()
+
         if delta_packages:
             self.install_packages(package_list=delta_packages)
+
         return True
 
     def install_packages(self, package_list: "List[str]" = None) -> None:

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -231,8 +231,10 @@ class TestProcessContractDeltas:
     @mock.patch.object(RepoTestEntitlement, "setup_apt_config")
     @mock.patch.object(RepoTestEntitlement, "remove_apt_config")
     @mock.patch.object(RepoTestEntitlement, "application_status")
+    @mock.patch.object(RepoTestEntitlement, "_check_apt_url_is_applied")
     def test_update_apt_config_and_install_packages_when_active(
         self,
+        m_check_apt_url_applied,
         m_application_status,
         m_remove_apt_config,
         m_setup_apt_config,
@@ -242,6 +244,7 @@ class TestProcessContractDeltas:
         entitlement,
     ):
         """Update_apt_config and packages if active and not enableByDefault."""
+        m_check_apt_url_applied.return_value = False
         application_status = status.ApplicationStatus.ENABLED
         m_application_status.return_value = (application_status, "")
         deltas = {
@@ -265,6 +268,7 @@ class TestProcessContractDeltas:
         else:
             assert 0 == m_install_packages.call_count
         assert [] == m_remove_auth_apt_repo.call_args_list
+        assert 1 == m_check_apt_url_applied.call_count
 
     @mock.patch(
         "uaclient.entitlements.base.UAEntitlement.process_contract_deltas"
@@ -276,8 +280,10 @@ class TestProcessContractDeltas:
     @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
     @mock.patch.object(RepoTestEntitlement, "setup_apt_config")
     @mock.patch.object(RepoTestEntitlement, "remove_apt_config")
+    @mock.patch.object(RepoTestEntitlement, "_check_apt_url_is_applied")
     def test_remove_old_auth_apt_repo_when_active_and_apt_url_delta(
         self,
+        m_check_apt_url_applied,
         m_remove_apt_config,
         m_setup_apt_config,
         m_remove_auth_apt_repo,
@@ -287,6 +293,7 @@ class TestProcessContractDeltas:
         entitlement,
     ):
         """Remove old apt url when aptURL delta occurs on active service."""
+        m_check_apt_url_applied.return_value = False
         m_process_contract_deltas.return_value = False
         m_read_cache.return_value = {
             "services": [{"name": "repotest", "status": "enabled"}]
@@ -314,17 +321,74 @@ class TestProcessContractDeltas:
             )
         ]
         assert apt_auth_remove_calls == m_remove_auth_apt_repo.call_args_list
-        apt_auth_remove_calls = [
-            mock.call(
-                "/etc/apt/sources.list.d/ubuntu-repotest.list", "http://old"
-            )
-        ]
-        assert apt_auth_remove_calls == m_remove_auth_apt_repo.call_args_list
         assert [
             mock.call("status-cache"),
             mock.call("status-cache"),
         ] == m_read_cache.call_args_list
         assert 1 == m_process_contract_deltas.call_count
+
+        assert [
+            mock.call("http://new")
+        ] == m_check_apt_url_applied.call_args_list
+        assert 1 == m_check_apt_url_applied.call_count
+
+    @mock.patch(
+        "uaclient.entitlements.base.UAEntitlement.process_contract_deltas"
+    )
+    @mock.patch("uaclient.config.UAConfig.read_cache")
+    @mock.patch(
+        M_PATH + "util.get_platform_info", return_value={"series": "trusty"}
+    )
+    @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
+    @mock.patch.object(RepoTestEntitlement, "setup_apt_config")
+    @mock.patch.object(RepoTestEntitlement, "remove_apt_config")
+    @mock.patch.object(RepoTestEntitlement, "_check_apt_url_is_applied")
+    def test_system_does_not_change_when_apt_url_delta_already_applied(
+        self,
+        m_check_apt_url_applied,
+        m_remove_apt_config,
+        m_setup_apt_config,
+        m_remove_auth_apt_repo,
+        m_platform_info,
+        m_read_cache,
+        m_process_contract_deltas,
+        entitlement,
+    ):
+        """Do not change system if apt url delta is already applied."""
+        m_check_apt_url_applied.return_value = True
+        m_process_contract_deltas.return_value = False
+        m_read_cache.return_value = {
+            "services": [{"name": "repotest", "status": "enabled"}]
+        }
+        assert entitlement.process_contract_deltas(
+            {
+                "entitlement": {
+                    "entitled": True,
+                    "directives": {"aptURL": "http://old"},
+                }
+            },
+            {
+                "entitlement": {
+                    "obligations": {"enableByDefault": False},
+                    "directives": {"aptURL": "http://new"},
+                },
+                "resourceToken": "repotest-token",
+            },
+        )
+        assert m_remove_apt_config.call_count == 0
+        assert m_setup_apt_config.call_count == 0
+        assert m_remove_auth_apt_repo.call_count == 0
+
+        assert [
+            mock.call("status-cache"),
+            mock.call("status-cache"),
+        ] == m_read_cache.call_args_list
+        assert 1 == m_process_contract_deltas.call_count
+
+        assert [
+            mock.call("http://new")
+        ] == m_check_apt_url_applied.call_args_list
+        assert 1 == m_check_apt_url_applied.call_count
 
 
 class TestRepoEnable:

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -1,0 +1,36 @@
+import logging
+import mock
+import pytest
+
+from uaclient.util import ProcessExecutionError
+from lib.reboot_cmds import run_command
+
+
+class TestRebootCmds:
+    @pytest.mark.parametrize("caplog_text", [logging.WARN], indirect=True)
+    @mock.patch("sys.exit")
+    @mock.patch("lib.reboot_cmds.subp")
+    def test_run_command_failure(self, m_subp, m_exit, caplog_text):
+        cmd = "foobar"
+        m_cfg = mock.MagicMock()
+
+        m_subp.side_effect = ProcessExecutionError(
+            cmd=cmd, exit_code=1, stdout="foo", stderr="bar"
+        )
+
+        run_command(cmd=cmd, cfg=m_cfg)
+        expected_msgs = [
+            "Failed running cmd: foobar",
+            "Return code: 1",
+            "Stderr: bar",
+            "Stdout: foo",
+        ]
+
+        for expected_msg in expected_msgs:
+            assert expected_msg in caplog_text()
+
+        assert m_subp.call_args_list == [mock.call(["foobar"], capture=True)]
+        assert m_cfg.delete_cache_key.call_args_list == [
+            mock.call("marker-reboot-cmds")
+        ]
+        assert m_exit.call_args_list == [mock.call(1)]


### PR DESCRIPTION
After `do-release-upgrade` there could still be operations that should still be performed after a user reboots the machine. For example, when upgrading from trusty to xenial, we cannot enable livepatch after `do-release-upgrade`, only after the user reboots the machine. To handle those situations, we are creating a init script that performs the remaining operations on uaclient to leave the system in a desired state.

What could be improved:

* Right now, the script is running the `upgrade_lts_contract`  script, since we need to perform the exact same operation on reboot. However, our logging can be really confusing because of that, since we will "repeat" the command and this may not be easy to understand why by just looking at the logs
* We can add an integration test for this feature as well