### PR TITLE
Testing/change ppa

### DIFF
--- a/tools/base_travis_integration_tests.sh
+++ b/tools/base_travis_integration_tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+UA_STAGING_PPA=ppa:ua-client/staging
+UA_STAGING_PPA_KEYID=6E34E7116C0BC933
+
 remove_lxd() {
   sudo apt-get remove --yes --purge lxd lxd-client
   sudo rm -Rf /var/lib/lxd

--- a/tools/run_aws_travis_integration_tests.sh
+++ b/tools/run_aws_travis_integration_tests.sh
@@ -3,8 +3,13 @@ source tools/base_travis_integration_tests.sh
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   BUILD_PR=0
+  if [ "$TRAVIS_BRANCH" != "${TRAVIS_BRANCH/release-}" ]; then
+      # Run cron of release-XX branches against UA_STAGING_PPA
+      export UACLIENT_BEHAVE_PPA=${UA_STAGING_PPA}
+      export UACLIENT_BEHAVE_PPA_KEYID=${UA_STAGING_PPA_KEYID}
+  fi
 else
   create_pr_tar_file
 fi

--- a/tools/run_azure_travis_integration_tests.sh
+++ b/tools/run_azure_travis_integration_tests.sh
@@ -10,8 +10,13 @@ install_pycloudlib() {
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   BUILD_PR=0
+  if [ "$TRAVIS_BRANCH" != "${TRAVIS_BRANCH/release-}" ]; then
+      # Run cron of release-XX branches against UA_STAGING_PPA
+      export UACLIENT_BEHAVE_PPA=${UA_STAGING_PPA}
+      export UACLIENT_BEHAVE_PPA_KEYID=${UA_STAGING_PPA_KEYID}
+  fi
 else
   create_pr_tar_file
 fi

--- a/tools/run_lxd_travis_integration_tests.sh
+++ b/tools/run_lxd_travis_integration_tests.sh
@@ -9,8 +9,13 @@ install_lxd() {
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   BUILD_PR=0
+  if [ "$TRAVIS_BRANCH" != "${TRAVIS_BRANCH/release-}" ]; then
+      # Run cron of release-XX branches against UA_STAGING_PPA
+      export UACLIENT_BEHAVE_PPA=${UA_STAGING_PPA}
+      export UACLIENT_BEHAVE_PPA_KEYID=${UA_STAGING_PPA_KEYID}
+  fi
 else
   create_pr_tar_file
 fi


### PR DESCRIPTION
Allow overriding PPA in integration tests via UACLIENT_BEHAVE_PPA and PPA_KEYID.

Cron jobs for release-* branches will use this facility to use ppa:ua-client/staging for test runs.
travis cron run here: https://travis-ci.com/github/canonical/ubuntu-advantage-client/builds/206425981