### PR TITLE
Remove package hold from fips updates test

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -123,10 +123,79 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
 
         Examples: ubuntu release
+           | release | fips-name    | fips-service |fips-apt-source                                        |
+           | xenial  | FIPS         | fips         |https://esm.staging.ubuntu.com/fips/ubuntu xenial/main |
+           | bionic  | FIPS         | fips         |https://esm.staging.ubuntu.com/fips/ubuntu bionic/main |
+
+    @series.xenial
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token_staging` with sudo
+        And I run `ua disable livepatch` with sudo
+        And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
+        When I run `ua enable <fips-service> --assume-yes --beta` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing <fips-name> packages
+            <fips-name> enabled
+            A reboot is required to complete install
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                enabled
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+        When I reboot the `<release>` machine
+        And  I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            fips
+            """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+        When I run `ua disable <fips-service> --assume-yes` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            A reboot is required to complete disable operation
+            """
+        When I reboot the `<release>` machine
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        0
+        """
+        And I verify that `openssh-server` installed version matches regexp `fips`
+        And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `openssh-server-hmac` installed version matches regexp `fips`
+        And I verify that `openssh-client-hmac` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
+        When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
+        Then I will see the following on stdout:
+        """
+        openssh-client was already not hold.
+        openssh-server was already not hold.
+        strongswan was already not hold.
+        """
+
+        Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                                        |
-           | xenial  | FIPS         | fips         |https://esm.staging.ubuntu.com/fips/ubuntu xenial/main                 |
            | xenial  | FIPS Updates | fips-updates |https://esm.staging.ubuntu.com/fips-updates/ubuntu xenial-updates/main |
-           | bionic  | FIPS         | fips         |https://esm.staging.ubuntu.com/fips/ubuntu bionic/main                 |
            | bionic  | FIPS Updates | fips-updates |https://esm.staging.ubuntu.com/fips-updates/ubuntu bionic-updates/main |
 
    @series.xenial


### PR DESCRIPTION
On the fips test, we are running apt-mark hold on some package
before enabling fips. This works for FIPS, because we unhold
those packages before we setup fips. However, this is not the case
for fips updates. We are now splitting the fips integration tests
to avoid this issue.