### PR TITLE
Add Google Cloud Platform support.

### DIFF
--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -1,0 +1,49 @@
+import os
+
+from urllib.error import HTTPError
+
+try:
+    from typing import Any, Dict  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
+from uaclient.clouds import AutoAttachCloudInstance
+from uaclient import util
+
+
+TOKEN_URL = (
+    "http://metadata/computeMetadata/v1/instance/service-accounts/"
+    "default/identity?audience=contracts.canonical.com&"
+    "format=full&licenses=TRUE"
+)
+
+DMI_PRODUCT_NAME = "/sys/class/dmi/id/product_name"
+GCP_PRODUCT_NAME = "Google Compute Engine"
+
+
+class UAAutoAttachGCPInstance(AutoAttachCloudInstance):
+
+    # mypy does not handle @property around inner decorators
+    # https://github.com/python/mypy/issues/1362
+    @property  # type: ignore
+    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
+    def identity_doc(self) -> "Dict[str, Any]":
+        url_response, _headers = util.readurl(
+            TOKEN_URL, headers={"Metadata-Flavor": "Google"}
+        )
+        return {"identityToken": url_response}
+
+    @property
+    def cloud_type(self) -> str:
+        return "gcp"
+
+    @property
+    def is_viable(self) -> bool:
+        """This machine is a viable GCPInstance"""
+        if os.path.exists(DMI_PRODUCT_NAME):
+            product_name = util.load_file(DMI_PRODUCT_NAME)
+            if GCP_PRODUCT_NAME == product_name.strip():
+                return True
+
+        return False

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -8,7 +8,7 @@ from uaclient import status
 from uaclient import util
 
 try:
-    from typing import Optional  # noqa: F401
+    from typing import Dict, Optional, Type  # noqa: F401
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -70,7 +70,7 @@ def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
         "aws-gov": aws.UAAutoAttachAWSInstance,
         "azure": azure.UAAutoAttachAzureInstance,
         "gce": gcp.UAAutoAttachGCPInstance,
-    }
+    }  # type: Dict[str, Type[clouds.AutoAttachCloudInstance]]
 
     cloud_type = get_cloud_type()
     if not cloud_type:

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -19,7 +19,7 @@ CLOUDINIT_INSTANCE_ID_FILE = "/var/lib/cloud/data/instance-id"
 
 
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
-DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws", "gce": "gce"}
+DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws", "gce": "gcp"}
 
 
 def get_instance_id(

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -19,7 +19,7 @@ CLOUDINIT_INSTANCE_ID_FILE = "/var/lib/cloud/data/instance-id"
 
 
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
-DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws"}
+DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws", "gce": "gce"}
 
 
 def get_instance_id(
@@ -62,12 +62,14 @@ def get_cloud_type() -> "Optional[str]":
 def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
     from uaclient.clouds import aws
     from uaclient.clouds import azure
+    from uaclient.clouds import gcp
 
     cloud_instance_map = {
         "aws": aws.UAAutoAttachAWSInstance,
         "aws-china": aws.UAAutoAttachAWSInstance,
         "aws-gov": aws.UAAutoAttachAWSInstance,
         "azure": azure.UAAutoAttachAzureInstance,
+        "gce": gcp.UAAutoAttachGCPInstance,
     }
 
     cloud_type = get_cloud_type()

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -1,0 +1,104 @@
+import logging
+import mock
+from io import BytesIO
+from urllib.error import HTTPError
+
+import pytest
+
+from uaclient.clouds.gcp import TOKEN_URL, UAAutoAttachGCPInstance
+
+M_PATH = "uaclient.clouds.gcp."
+
+
+class TestUAAutoAttachGCPInstance:
+    def test_cloud_type(self):
+        """cloud_type is returned as GCP."""
+        instance = UAAutoAttachGCPInstance()
+        assert "gcp" == instance.cloud_type
+
+    @mock.patch(M_PATH + "util.readurl")
+    def test_identity_doc_from_gcp_url(self, readurl):
+        """Return attested signature and compute info as GCP identity doc"""
+        readurl.return_value = "attestedWOOT!===", {"header": "stuff"}
+        instance = UAAutoAttachGCPInstance()
+        assert {"identityToken": "attestedWOOT!==="} == instance.identity_doc
+        assert [
+            mock.call(TOKEN_URL, headers={"Metadata-Flavor": "Google"})
+        ] == readurl.call_args_list
+
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @pytest.mark.parametrize("fail_count,exception", ((3, False), (4, True)))
+    @mock.patch(M_PATH + "util.time.sleep")
+    @mock.patch(M_PATH + "util.readurl")
+    def test_retry_backoff_on_failed_identity_doc(
+        self, readurl, sleep, fail_count, exception, caplog_text
+    ):
+        """Retries backoff before failing to get GCP.identity_doc"""
+
+        def fake_someurlerrors(url, headers):
+            if readurl.call_count <= fail_count:
+                raise HTTPError(
+                    "http://me",
+                    700 + readurl.call_count,
+                    "funky error msg",
+                    None,
+                    BytesIO(),
+                )
+
+            return "attestedWOOT!===", {"header": "stuff"}
+
+        readurl.side_effect = fake_someurlerrors
+
+        instance = UAAutoAttachGCPInstance()
+        if exception:
+            with pytest.raises(HTTPError) as excinfo:
+                instance.identity_doc
+            assert 704 == excinfo.value.code
+        else:
+            assert {
+                "identityToken": "attestedWOOT!==="
+            } == instance.identity_doc
+
+        expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
+        assert expected_sleep_calls == sleep.call_args_list
+
+        expected_logs = [
+            "HTTP Error 701: funky error msg Retrying 3 more times.",
+            "HTTP Error 702: funky error msg Retrying 2 more times.",
+            "HTTP Error 703: funky error msg Retrying 1 more times.",
+        ]
+        logs = caplog_text()
+        for log in expected_logs:
+            assert log in logs
+
+    @pytest.mark.parametrize(
+        "product_name,viable",
+        (
+            (None, False),
+            ("Google Compute Engine", True),
+            ("CoolCloudCorp", False),
+        ),
+    )
+    @mock.patch(M_PATH + "os.path.exists")
+    @mock.patch(M_PATH + "util.load_file")
+    def test_is_viable_based_on_dmi_product_name(
+        self, load_file, m_exists, product_name, viable
+    ):
+        """Platform viable if product name matches."""
+
+        def fake_exists(f_name):
+            if f_name == "/sys/class/dmi/id/product_name":
+                return bool(product_name is not None)
+            raise AssertionError("Invalid os.path.exist of {}".format(f_name))
+
+        m_exists.side_effect = fake_exists
+
+        def fake_load_file(f_name):
+            if f_name == "/sys/class/dmi/id/product_name":
+                return product_name
+            raise AssertionError("Invalid load_file of {}".format(f_name))
+
+        load_file.side_effect = fake_load_file
+
+        instance = UAAutoAttachGCPInstance()
+        assert viable is instance.is_viable


### PR DESCRIPTION
This adds the ability to detect if on a Google Cloud Platform system
using a combination of the cloud-init datasource and DMI data using the
product name. The client will retreive a JWT token and send it to the
contract service for verification.

A note on naming, the contract service is expect 'gcp'. cloud-id and
cloud-init datasources use 'gce'.