### PR TITLE
Fix invalid ppa integration test

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -408,9 +408,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` with sudo
-        And I run `add-apt-repository ppa:canonical-server/ua-client-daily -y` with sudo
+        And I run `add-apt-repository ppa:ua-client/staging -y` with sudo
         And I run `apt update` with sudo
-        And I run `sed -i 's/ubuntu/ubun/' /etc/apt/sources.list.d/<ppa_file>-<release>.list` with sudo
+        And I run `sed -i 's/ubuntu/ubun/' /etc/apt/sources.list.d/<ppa_file>.list` with sudo
         And I run `ua enable esm-infra` with sudo
         Then stdout matches regexp:
         """
@@ -418,12 +418,12 @@ Feature: Command behaviour when attached to an UA subscription
         Updating package lists
         APT update failed.
         APT update failed to read APT config for the following URL:
-        - http://ppa.launchpad.net/canonical-server/ua-client-daily/ubun
+        - http://ppa.launchpad.net/ua-client/staging/ubun
         """
 
         Examples: ubuntu release
-           | release | ppa_file                                |
-           | trusty  | canonical-server-ua-client-daily        |
-           | xenial  | canonical-server-ubuntu-ua-client-daily |
-           | bionic  | canonical-server-ubuntu-ua-client-daily |
-           | focal   | canonical-server-ubuntu-ua-client-daily |
+           | release | ppa_file                        |
+           | trusty  | ua-client-staging-trusty        |
+           | xenial  | ua-client-ubuntu-staging-xenial |
+           | bionic  | ua-client-ubuntu-staging-bionic |
+           | focal   | ua-client-ubuntu-staging-focal  |


### PR DESCRIPTION
We have a test to verify if uaclient is behaving as expected if we have an invalid ppa in the
system. To produce that invalid ppa, we add the uaclient daily ppa and we use a sed to edit it.
However, the path we were using on the sed command changes, breaking the test.