### PR TITLE
Sync release 25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,66 @@ ubuntu-advantage-tools (26.0) UNRELEASED; urgency=medium
 
  -- Chad Smith <chad.smith@canonical.com>  Thu, 08 Oct 2020 15:29:13 -0600
 
+ubuntu-advantage-tools (25.0~20.10.1) groovy; urgency=medium
+
+  * Release version 25.0
+
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 04 Dec 2020 13:32:16 -0700
+
+ubuntu-advantage-tools (25.0~20.10.1beta3) groovy; urgency=medium
+
+  * New upstream release 25.0~beta3:
+    - upgrade-lts-conract: noop during do-release-upgrade on unattached
+      (GH: #1255)
+    - ua-auto-attach: order systemd unit before cloud-config.service
+    - Update FIPSUpdates pin origin
+    - fips: unmark held fips packages for ubuntu pro fips image support
+      (GH: #1109)
+    - repo: handle changes to additionalPackages contract deltas
+    - repo: move package installation to install_packages method
+    - pro: trigger auto-attach as soon as instance-data.json is available
+      (GH: #1234)
+    - Conditionally install packages when enabling FIPS
+    - fips: allow disable (GH: #1168)
+    - cli: add trailing newline to argparse errors (GH: #1236)
+    - Install fips metapacking when enabling service
+    - integration test improvements:
+      + upgrade-test: fix upgrade path restart failures on trusty (GH: #1257)
+      + Fix integration test setup scripts (GH: #1253)
+      + strict checking for command success on behave
+      + Update tests to use new pycloudlib LXD abstraction
+      + Add upgrade scenario tests when FIPS is enabled
+      + Improve FIPS tests for checking packages
+      + Update esm-infra xenial lxd test
+      + Fix vm tests as esm-apps is beta service
+      + Fix azure generic integration testing
+      + Update esm-apps check on staging_commands tests
+      + Install pycloudlib for azure jobs only
+      + Fix shell condition in run_azure_travis_integration_tests.sh
+      + Update azure jobs on travis
+      + Update travis url in README
+      + Update travis scripts to use ppa only on master
+      + Fix cron event type check on travis yaml
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 02 Dec 2020 13:43:16 -0700
+
+ubuntu-advantage-tools (25.0~20.10.1~beta2) groovy; urgency=medium
+
+  * New upstream release 25.0~beta2:
+    - help: update esm-infra help text (GH: #1212)
+    - apt-hook: update apt cli messaging for UA Infra: ESM and UA Apps: ESM
+      product names
+    - help: update fips help docs (GH: #1213)
+    - help: revert CIS help doc URL (GH: #1211)
+    - help: add new fips help URLs to CLI help docs (GH: #1210)
+    - Show error when enabling service with invalid repo [Lucas Moura]
+      (GH: #954)
+    - Update beta info for services (#1220) [Lucas Moura] (GH: #1216)
+    - Do not enable fips when fips-updates is active [Lucas Moura] (GH: #1209)
+    - Add vm test commands in tox.ini (#1204) [Lucas Moura]
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 26 Oct 2020 20:01:21 -0600
+
 ubuntu-advantage-tools (25.0~20.10.1~beta1) groovy; urgency=medium
 
   * Beta bug fix release

--- a/tools/base_travis_integration_tests.sh
+++ b/tools/base_travis_integration_tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+UA_STAGING_PPA=ppa:ua-client/staging
+UA_STAGING_PPA_KEYID=6E34E7116C0BC933
+
 remove_lxd() {
   sudo apt-get remove --yes --purge lxd lxd-client
   sudo rm -Rf /var/lib/lxd

--- a/tools/run_aws_travis_integration_tests.sh
+++ b/tools/run_aws_travis_integration_tests.sh
@@ -3,8 +3,13 @@ source tools/base_travis_integration_tests.sh
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   BUILD_PR=0
+  if [ "$TRAVIS_BRANCH" != "${TRAVIS_BRANCH/release-}" ]; then
+      # Run cron of release-XX branches against UA_STAGING_PPA
+      export UACLIENT_BEHAVE_PPA=${UA_STAGING_PPA}
+      export UACLIENT_BEHAVE_PPA_KEYID=${UA_STAGING_PPA_KEYID}
+  fi
 else
   create_pr_tar_file
 fi

--- a/tools/run_azure_travis_integration_tests.sh
+++ b/tools/run_azure_travis_integration_tests.sh
@@ -10,8 +10,13 @@ install_pycloudlib() {
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   BUILD_PR=0
+  if [ "$TRAVIS_BRANCH" != "${TRAVIS_BRANCH/release-}" ]; then
+      # Run cron of release-XX branches against UA_STAGING_PPA
+      export UACLIENT_BEHAVE_PPA=${UA_STAGING_PPA}
+      export UACLIENT_BEHAVE_PPA_KEYID=${UA_STAGING_PPA_KEYID}
+  fi
 else
   create_pr_tar_file
 fi

--- a/tools/run_lxd_travis_integration_tests.sh
+++ b/tools/run_lxd_travis_integration_tests.sh
@@ -9,8 +9,13 @@ install_lxd() {
 
 copy_deb_packages
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   BUILD_PR=0
+  if [ "$TRAVIS_BRANCH" != "${TRAVIS_BRANCH/release-}" ]; then
+      # Run cron of release-XX branches against UA_STAGING_PPA
+      export UACLIENT_BEHAVE_PPA=${UA_STAGING_PPA}
+      export UACLIENT_BEHAVE_PPA_KEYID=${UA_STAGING_PPA_KEYID}
+  fi
 else
   create_pr_tar_file
 fi


### PR DESCRIPTION
cherry-pick two functional changes from release-25:
 -    e7497b7512e2b93cf160305f902dc4b087ab8564 travis: cron runs on release-\d+ run against ppa:ua-client/staging
 - 7df8eebef8a806a2fe201230d5a71d7cb127220b tests: add ppa and ppa_keyid overrides for integration runs
 - import debian/changelog entries 