### PR TITLE
Add pytest constraint for pytest on mypy tests

### DIFF
--- a/tools/constraints-mypy.txt
+++ b/tools/constraints-mypy.txt
@@ -1,0 +1,2 @@
+mypy
+pytest==6.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     xenial: -ctools/constraints-xenial.txt
     bionic: -ctools/constraints-bionic.txt
     mypy: mypy
+    mypy: -ctools/constraints-mypy.txt
     black: -rdev-requirements.txt
     behave: -rintegration-requirements.txt
 passenv =
@@ -28,7 +29,7 @@ commands =
     mypy: mypy --python-version 3.4 uaclient/
     mypy: mypy --python-version 3.5 uaclient/
     mypy: mypy --python-version 3.6 uaclient/ features/
-    mypy: mypy --python-version 3.7 uaclient/ features/
+    mypy-focal: mypy --python-version 3.7 uaclient/ features/
     black: black --check --diff uaclient/ features/ setup.py
     behave-lxd-14.04: behave -v {posargs} --tags="series.trusty,series.all"  --tags="~upgrade"
     behave-lxd-16.04: behave -v {posargs} --tags="series.xenial,series.all" --tags="~upgrade"


### PR DESCRIPTION
pytest was recently updated to a version that breaks the mypy tests. The reason for that is because the new version of pytest uses a type annotation that is only supported on python3.6 and later. Therefore we cannot run all of the mypy tests using the latest version. Because of that we are now splitting the mypy test for each release, making sure the command is respecting the release dependencies freezes, which include pytest

File on pytest with type annotation:
https://github.com/pytest-dev/pytest/blob/6.2.x/src/_pytest/assertion/__init__.py#L86