### PR TITLE
   jenkins: drop tox path add contract_token_staging and build_pr env vars

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,12 +84,12 @@ pipeline {
                         '''
                     }
                 }
-                stage("lxc vm 16.04") {
+                stage("lxc 16.04") {
                     steps {
                         sh '''
                         set +x
                         . /tmp/$VM_NAME/bin/activate
-                        tox --parallel--safe-build -e behave-vm-16.04
+                        tox --parallel--safe-build -e behave-16.04
                         '''
                     }
                 }


### PR DESCRIPTION
    After cleaning up jenkins workers and removing a stale py2-based tox
    installed in .local/bin on our systems, we can now use the tox installed
    on the jenkins worker without having to specify the full path.
    
    Also add the following integration testing environment vars:
      - UACLIENT_BEHAVE_BUILD_PR=1: force local building of the PR under test.
      - UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING: allow running our staging tests.