### PR TITLE
Fips post update cmds and notices

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -5,7 +5,6 @@ set -e
 . /etc/os-release  # For VERSION_ID
 
 
-MYRELEASE=$(lsb_release -sc)
 APT_TRUSTED_KEY_DIR="/etc/apt/trusted.gpg.d"
 UA_KEYRING_DIR="/usr/share/keyrings/"
 
@@ -39,7 +38,7 @@ from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 print(*ENTITLEMENT_CLASS_BY_NAME.keys(), sep=' ')
 ")
 
-    for file in `ls $DIR`; do
+    for file in "$DIR"/*; do
         release_name=""
         case "$file" in
             *-trusty*)
@@ -61,19 +60,38 @@ print(*ENTITLEMENT_CLASS_BY_NAME.keys(), sep=' ')
              for service in ${UA_SERVICES}; do
                  if [ "${file#*$service}" != "$file" ]; then
                       # Valid apt cfg file for an ubuntu-advantage service
-                      mv $DIR/$file $DIR/$new_file
+                      mv "$file" "$new_file"
                  fi
              done
          fi
     done
 }
 
-check_esm_infra_is_enabled() {
-    ua status | egrep -q 'esm-infra.*enabled' && return 0 || return 1
+
+# Check cached service status from status.json and return 0 if enabled else 1
+check_service_is_enabled() {
+    service_name=$1
+    _RET=$(python3 -c "
+import os
+import json
+from uaclient.config import UAConfig
+cfg = UAConfig()
+status = cfg.read_cache('status-cache')
+if status:
+    for service in status['services']:
+       if service['name'] == '${service_name}':
+           print(service['status'])
+")
+   if [ "${_RET}" = "enabled" ]; then
+       return  0
+   else
+       return  1
+   fi
 }
 
+
 unconfigure_esm() {
-    if ! check_esm_infra_is_enabled; then
+    if ! check_service_is_enabled esm-infra; then
         rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
         rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY
         rm -f $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
@@ -115,10 +133,27 @@ EOF
     fi
 }
 
+
+# If held fips packages exist, we are on a FIPS PRO machine with FIPS enabled
+mark_reboot_for_fips_pro() {
+    FIPS_HOLDS=$(apt-mark showholds | grep -E 'fips|libssl1|openssh-client|openssh-server|linux-fips|openssl|strongswan' || exit 0)
+    if [ "$FIPS_HOLDS" ]; then
+       mark_reboot_cmds_as_needed MESSAGE_FIPS_REBOOT_REQUIRED
+    fi
+}
+
+
 mark_reboot_cmds_as_needed() {
+    msg_name=$1
     if [ ! -f "$REBOOT_CMD_MARKER_FILE" ]; then
       touch $REBOOT_CMD_MARKER_FILE
     fi
+    python3 -c "
+from uaclient.config import UAConfig
+from uaclient.status import ${msg_name}
+cfg = UAConfig()
+cfg.add_notice(label='', description=${msg_name})
+"
 }
 
 case "$1" in
@@ -151,7 +186,7 @@ case "$1" in
               # ubuntu-advantage-pro package that should be installed
               . /usr/share/debconf/confmodule
               db_input high ubuntu-advantage-tools/suggest_pro_pkg || true
-              db_go
+              db_go || true
           fi
       fi
 
@@ -187,10 +222,10 @@ case "$1" in
 
       if [ "$VERSION_ID" = "16.04" ]; then
         if echo "$PREVIOUS_PKG_VER" | grep -q "14.04"; then
-          # trusty upgrade to xenial has known post-reboot operations required (livepatch)
-          mark_reboot_cmds_as_needed
+          mark_reboot_cmds_as_needed MESSAGE_LIVEPATCH_LTS_REBOOT_REQUIRED
         fi
       fi
+      mark_reboot_for_fips_pro
       ;;
 esac
 

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -42,6 +42,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
+        fips         +yes      +n/a      +NIST-certified FIPS modules
+        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
         livepatch    +yes      +n/a      +Canonical Livepatch service
         """
         And stderr matches regexp:

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -6,9 +6,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua refresh` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         When I run `ua refresh` with sudo
         Then I will see the following on stdout:
@@ -28,9 +28,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua disable livepatch` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         And I verify that running `ua disable livepatch` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -51,9 +51,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua disable foobar` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         And I verify that running `ua disable foobar` `with sudo` exits `1`
         And stderr matches regexp:
@@ -74,9 +74,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua detach` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         When I run `ua detach --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -116,9 +116,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua auto-attach` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         When I run `ua auto-attach` with sudo
         Then stderr matches regexp:
@@ -207,9 +207,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua disable esm-infra livepatch foobar` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         And I verify that running `ua disable esm-infra livepatch foobar` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -243,9 +243,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua disable esm-infra` `as non-root` exits `1`
-        Then I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
@@ -269,9 +269,9 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua disable esm-infra` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
@@ -335,6 +335,10 @@ Feature: Command behaviour when attached to an UA subscription
         Client to manage Ubuntu Advantage services on a machine.
          - esm-infra: UA Infra: Extended Security Maintenance \(ESM\)
            \(https://ubuntu.com/security/esm\)
+         - fips-updates: Uncertified security updates to FIPS modules
+           \(https://ubuntu.com/security/certifications#fips\)
+         - fips: NIST-certified FIPS modules
+           \(https://ubuntu.com/security/certifications#fips\)
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
         """
@@ -344,6 +348,10 @@ Feature: Command behaviour when attached to an UA subscription
         Client to manage Ubuntu Advantage services on a machine.
          - esm-infra: UA Infra: Extended Security Maintenance \(ESM\)
            \(https://ubuntu.com/security/esm\)
+         - fips-updates: Uncertified security updates to FIPS modules
+           \(https://ubuntu.com/security/certifications#fips\)
+         - fips: NIST-certified FIPS modules
+           \(https://ubuntu.com/security/certifications#fips\)
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
         """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -27,20 +27,20 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline: Attached enable a disabled beta service and unknown service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `ua enable fips foobar` `as non-root` exits `1`
+        Then I verify that running `ua enable cc-eal foobar` `as non-root` exits `1`
         And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        And I verify that running `ua enable fips foobar` `with sudo` exits `1`
+        And I verify that running `ua enable cc-eal foobar` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
             """
         And stderr matches regexp:
             """
-            Cannot enable unknown service 'foobar, fips'.
-            Try esm-infra, livepatch
+            Cannot enable unknown service 'foobar, cc-eal'.
+            Try esm-infra, fips, fips-updates, livepatch
             """
 
         Examples: ubuntu release
@@ -67,7 +67,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-infra, livepatch
+            Try esm-infra, fips, fips-updates, livepatch
             """
 
         Examples: ubuntu release
@@ -167,7 +167,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-infra, livepatch
+            Try esm-infra, fips, fips-updates, livepatch
             """
 
         Examples: ubuntu release
@@ -196,50 +196,44 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
         Examples: Un-supported services in containers
-           | release | service      | title        | flag                 |
-           | bionic  | livepatch    | Livepatch    |                      |
-           | bionic  | fips         | FIPS         | --assume-yes --beta  |
-           | bionic  | fips-updates | FIPS Updates | --assume-yes --beta  |
-           | focal   | livepatch    | Livepatch    |                      |
-           | focal   | fips         | FIPS         | --assume-yes --beta  |
-           | focal   | fips-updates | FIPS Updates | --assume-yes --beta  |
-           | trusty  | livepatch    | Livepatch    |                      |
-           | trusty  | fips         | FIPS         | --assume-yes --beta  |
-           | trusty  | fips-updates | FIPS Updates | --assume-yes --beta  |
-           | xenial  | livepatch    | Livepatch    |                      |
-           | xenial  | fips         | FIPS         | --assume-yes --beta  |
-           | xenial  | fips-updates | FIPS Updates | --assume-yes --beta  |
+           | release | service      | title        | flag         |
+           | bionic  | livepatch    | Livepatch    |              |
+           | bionic  | fips         | FIPS         | --assume-yes |
+           | bionic  | fips-updates | FIPS Updates | --assume-yes |
+           | focal   | livepatch    | Livepatch    |              |
+           | focal   | fips         | FIPS         | --assume-yes |
+           | focal   | fips-updates | FIPS Updates | --assume-yes |
+           | trusty  | livepatch    | Livepatch    |              |
+           | trusty  | fips         | FIPS         | --assume-yes |
+           | trusty  | fips-updates | FIPS Updates | --assume-yes |
+           | xenial  | livepatch    | Livepatch    |              |
+           | xenial  | fips         | FIPS         | --assume-yes |
+           | xenial  | fips-updates | FIPS Updates | --assume-yes |
 
     @series.all
     Scenario Outline:  Attached enable of non-container beta services in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `ua enable <service> <flag>` `as non-root` exits `1`
+        Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
         And I will see the following on stderr:
             """
             This command must be run as root (try using sudo)
             """
-        And I verify that running `ua enable <service> <flag>` `with sudo` exits `1`
+        And I verify that running `ua enable cc-eal` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
             """
         And stderr matches regexp:
             """
-            Cannot enable unknown service '<service>'.
-            Try esm-infra, livepatch
+            Cannot enable unknown service 'cc-eal'.
+            Try esm-infra, fips, fips-updates, livepatch
             """
-
-        Examples: beta services in containers
-           | release | service      | flag         |
-           | bionic  | fips         | --assume-yes |
-           | bionic  | fips-updates | --assume-yes |
-           | focal   | fips         | --assume-yes |
-           | focal   | fips-updates | --assume-yes |
-           | trusty  | fips         | --assume-yes |
-           | trusty  | fips-updates | --assume-yes |
-           | xenial  | fips         | --assume-yes |
-           | xenial  | fips-updates | --assume-yes |
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
 
     @series.all
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
@@ -274,13 +268,13 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario: Attached enable of vm-based services in a focal lxd vm
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `ua enable fips --assume-yes --beta` `with sudo` exits `1`
+        Then I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
             FIPS is not available for Ubuntu 20.04 LTS (Focal Fossa).
             """
-        And I verify that running `ua enable fips-updates --assume-yes --beta` `with sudo` exits `1`
+        And I verify that running `ua enable fips-updates --assume-yes` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -363,7 +357,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             Canonical livepatch enabled
             """
         When I run `ua disable livepatch` with sudo
-        And I run `ua enable fips --assume-yes --beta` with sudo
+        And I run `ua enable fips --assume-yes` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -391,7 +385,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             Installing canonical-livepatch snap
             Canonical livepatch enabled
             """
-        And I verify that running `ua enable fips --assume-yes --beta` `with sudo` exits `1`
+        And I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
         And I will see the following on stdout
             """
             One moment, checking your subscription first
@@ -411,7 +405,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             Canonical livepatch enabled
             """
         When I run `ua disable livepatch` with sudo
-        And I run `ua enable fips-updates --assume-yes --beta` with sudo
+        And I run `ua enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -420,7 +414,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             FIPS Updates enabled
             A reboot is required to complete install
             """
-        When I verify that running `ua enable fips --assume-yes --beta` `with sudo` exits `1`
+        When I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
         Then I will see the following on stdout
             """
             One moment, checking your subscription first

--- a/features/environment.py
+++ b/features/environment.py
@@ -485,7 +485,7 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
             ]
 
     if len(deb_paths):
-        print("--- Reusing debs")
+        print("--- Reusing debs: {}".format(", ".join(deb_paths)))
     else:
         print("--- Could not find any debs to reuse. Building it locally")
         print(

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -63,7 +63,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         And I run `ua disable livepatch` with sudo
         And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
-        When I run `ua enable <fips-service> --assume-yes --beta` with sudo
+        When I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
             Updating package lists
@@ -134,7 +134,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         When I attach `contract_token_staging` with sudo
         And I run `ua disable livepatch` with sudo
         And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
-        When I run `ua enable <fips-service> --assume-yes --beta` with sudo
+        When I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
             Updating package lists
@@ -204,7 +204,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         When I attach `contract_token_staging` with sudo
         And I run `apt-get install lsof` with sudo
         And I run `ua disable livepatch` with sudo
-        And I run `ua enable <fips-service> --assume-yes --beta` with sudo
+        And I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
             Updating package lists

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -4,9 +4,9 @@ Feature: Command behaviour when unattached
     Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I verify that running `ua auto-attach` `as non-root` exits `1`
-        Then I will see the following on stderr:
+        Then stderr matches regexp:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root \(try using sudo\)
             """
         When I run `ua auto-attach` with sudo
         Then stderr matches regexp:

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -8,6 +8,8 @@ Feature: Unattached status
             """
             SERVICE       AVAILABLE  DESCRIPTION
             esm-infra     yes        UA Infra: Extended Security Maintenance \(ESM\)
+            fips          <fips>      +NIST-certified FIPS modules
+            fips-updates  <fips>      +Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
@@ -33,6 +35,8 @@ Feature: Unattached status
             """
             SERVICE       AVAILABLE  DESCRIPTION
             esm-infra     yes        UA Infra: Extended Security Maintenance \(ESM\)
+            fips          <fips>      +NIST-certified FIPS modules
+            fips-updates  <fips>      +Uncertified security updates to FIPS modules
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -98,7 +98,7 @@ class UAArgumentParser(argparse.ArgumentParser):
             )
         else:
             self.description = "\n".join(
-                [self.base_desc] + self.non_beta_services_desc
+                [self.base_desc] + sorted(self.non_beta_services_desc)
             )
 
         super().print_help(file=file)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -123,7 +123,7 @@ def assert_lock_file(lock_holder=None):
         def new_f(args, cfg, **kwargs):
             global _LOCK_FILE
             lock_file = cfg.data_path("lock")
-            (lock_pid, cur_lock_holder) = util.check_lock_info(lock_file)
+            (lock_pid, cur_lock_holder) = cfg.check_lock_info()
             if lock_pid > 0:
                 raise exceptions.LockHeldError(
                     lock_request=lock_holder,
@@ -131,9 +131,12 @@ def assert_lock_file(lock_holder=None):
                     pid=lock_pid,
                 )
             cfg.write_cache("lock", "{}:{}".format(os.getpid(), lock_holder))
+            notice_msg = "Operation in progress: {}".format(lock_holder)
+            cfg.add_notice("", notice_msg)
             _LOCK_FILE = lock_file  # Set _LOCK_FILE for cleanup
             retval = f(args, cfg, **kwargs)
             util.remove_file(lock_file)
+            cfg.remove_notice("", notice_msg)
             return retval
 
         return new_f

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -17,7 +17,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     repo_pin_priority = 1001
     repo_key_file = "ubuntu-advantage-fips.gpg"  # Same for fips & fips-updates
-    is_beta = True
 
     """
     Dictionary of conditional packages to be installed when

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -242,9 +242,13 @@ class RepoEntitlement(base.UAEntitlement):
 
         return True
 
-    def install_packages(self, package_list: "List[str]" = None) -> None:
+    def install_packages(
+        self, package_list: "List[str]" = None, cleanup_on_failure: bool = True
+    ) -> None:
         """Install contract recommended packages for the entitlement.
 
+        :param package_list: Optional package list to use instead of
+            self.packages.
         :param package_list: Optional package list to use instead of
             self.packages.
         """
@@ -269,7 +273,8 @@ class RepoEntitlement(base.UAEntitlement):
                 env=env,
             )
         except exceptions.UserFacingError:
-            self._cleanup()
+            if cleanup_on_failure:
+                self._cleanup()
             raise
 
     def setup_apt_config(self) -> None:

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -62,6 +62,10 @@ SERVICES_WRAPPED_HELP = textwrap.dedent(
 Client to manage Ubuntu Advantage services on a machine.
  - esm-infra: UA Infra: Extended Security Maintenance (ESM)
    (https://ubuntu.com/security/esm)
+ - fips: NIST-certified FIPS modules
+   (https://ubuntu.com/security/certifications#fips)
+ - fips-updates: Uncertified security updates to FIPS modules
+   (https://ubuntu.com/security/certifications#fips)
  - livepatch: Canonical Livepatch service
    (https://ubuntu.com/security/livepatch)
 """

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -14,6 +14,7 @@ import pytest
 from uaclient.cli import (
     action_help,
     assert_attached,
+    assert_lock_file,
     assert_not_attached,
     assert_root,
     get_parser,
@@ -304,6 +305,41 @@ class TestCLIParser:
         assert "No help available for 'test'" == str(excinfo.value)
         assert 1 == m_service_name.call_count
         assert 1 == m_available_resources.call_count
+
+
+M_PATH_UACONFIG = "uaclient.config.UAConfig."
+
+
+class TestAssertLockFile:
+    @mock.patch("os.getpid", return_value=123)
+    @mock.patch(M_PATH_UACONFIG + "remove_notice")
+    @mock.patch(M_PATH_UACONFIG + "add_notice")
+    @mock.patch(M_PATH_UACONFIG + "write_cache")
+    def test_assert_root_creates_lock_and_notice(
+        self,
+        m_write_cache,
+        m_add_notice,
+        m_remove_notice,
+        _m_getpid,
+        FakeConfig,
+    ):
+        arg, kwarg = mock.sentinel.arg, mock.sentinel.kwarg
+
+        @assert_lock_file("some operation")
+        def test_function(args, cfg):
+            assert arg == mock.sentinel.arg
+            assert kwarg == mock.sentinel.kwarg
+
+            return mock.sentinel.success
+
+        ret = test_function(arg, FakeConfig())
+        assert mock.sentinel.success == ret
+        lock_msg = "Operation in progress: some operation"
+        assert [mock.call("", lock_msg)] == m_add_notice.call_args_list
+        assert [mock.call("", lock_msg)] == m_remove_notice.call_args_list
+        assert [
+            mock.call("lock", "123:some operation")
+        ] == m_write_cache.call_args_list
 
 
 class TestAssertRoot:

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -62,9 +62,9 @@ SERVICES_WRAPPED_HELP = textwrap.dedent(
 Client to manage Ubuntu Advantage services on a machine.
  - esm-infra: UA Infra: Extended Security Maintenance (ESM)
    (https://ubuntu.com/security/esm)
- - fips: NIST-certified FIPS modules
-   (https://ubuntu.com/security/certifications#fips)
  - fips-updates: Uncertified security updates to FIPS modules
+   (https://ubuntu.com/security/certifications#fips)
+ - fips: NIST-certified FIPS modules
    (https://ubuntu.com/security/certifications#fips)
  - livepatch: Canonical Livepatch service
    (https://ubuntu.com/security/livepatch)

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -128,6 +128,7 @@ class TestActionDetach:
         m_client.return_value = fake_client
 
         m_cfg = mock.MagicMock()
+        m_cfg.check_lock_info.return_value = (-1, "")
         m_cfg.data_path.return_value = tmpdir.join("lock").strpath
         action_detach(mock.MagicMock(), m_cfg)
 
@@ -152,6 +153,7 @@ class TestActionDetach:
         m_client.return_value = fake_client
 
         m_cfg = mock.MagicMock()
+        m_cfg.check_lock_info.return_value = (-1, "")
         m_cfg.data_path.return_value = tmpdir.join("lock").strpath
         action_detach(mock.MagicMock(), m_cfg)
 
@@ -171,6 +173,7 @@ class TestActionDetach:
         m_client.return_value = fake_client
 
         m_cfg = mock.MagicMock()
+        m_cfg.check_lock_info.return_value = (-1, "")
         m_cfg.data_path.return_value = tmpdir.join("lock").strpath
         ret = action_detach(mock.MagicMock(), m_cfg)
 
@@ -226,6 +229,7 @@ class TestActionDetach:
         m_client.return_value = fake_client
 
         m_cfg = mock.MagicMock()
+        m_cfg.check_lock_info.return_value = (-1, "")
         m_cfg.data_path.return_value = tmpdir.join("lock").strpath
 
         action_detach(mock.MagicMock(), m_cfg)

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -49,8 +49,8 @@ class TestDisable:
 
             entitlements_obj.append(m_entitlement)
             entitlements_cls.append(m_entitlement_cls)
-
         m_cfg = mock.Mock()
+        m_cfg.check_lock_info.return_value = (-1, "")
         m_cfg.data_path.return_value = tmpdir.join("lock").strpath
 
         args_mock = mock.Mock()
@@ -101,6 +101,7 @@ class TestDisable:
         m_entitlements.RELEASED_ENTITLEMENTS_STR = "ent2, ent3"
 
         m_cfg = mock.Mock()
+        m_cfg.check_lock_info.return_value = (-1, "")
         m_cfg.data_path.return_value = tmpdir.join("lock").strpath
         args_mock = mock.Mock()
         args_mock.service = ["ent1", "ent2", "ent3"]

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -527,7 +527,7 @@ class TestDeleteCache:
 
 class TestStatus:
     esm_desc = ENTITLEMENT_CLASS_BY_NAME["esm-infra"].description
-    fips_desc = ENTITLEMENT_CLASS_BY_NAME["fips"].description
+    cc_eal_desc = ENTITLEMENT_CLASS_BY_NAME["cc-eal"].description
 
     def check_beta(self, cls, show_beta, uacfg=None):
         if not show_beta:
@@ -550,14 +550,14 @@ class TestStatus:
                 True,
                 [
                     {
+                        "available": "no",
+                        "name": "cc-eal",
+                        "description": cc_eal_desc,
+                    },
+                    {
                         "available": "yes",
                         "name": "esm-infra",
                         "description": esm_desc,
-                    },
-                    {
-                        "available": "no",
-                        "name": "fips",
-                        "description": fips_desc,
                     },
                 ],
             ),
@@ -587,7 +587,7 @@ class TestStatus:
         cfg = FakeConfig()
         m_get_available_resources.return_value = [
             {"name": "esm-infra", "available": True},
-            {"name": "fips", "available": False},
+            {"name": "cc-eal", "available": False},
         ]
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected["services"] = expected_services

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -2,11 +2,87 @@ import logging
 import mock
 import pytest
 
+from uaclient import exceptions
 from uaclient.util import ProcessExecutionError
-from lib.reboot_cmds import run_command
+
+from lib.reboot_cmds import main, fix_pro_pkg_holds, run_command
+
+M_FIPS_PATH = "uaclient.entitlements.fips.FIPSEntitlement."
 
 
-class TestRebootCmds:
+class TestMain:
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @mock.patch("lib.reboot_cmds.subp")
+    def test_main_unattached_removes_marker(
+        self, m_subp, FakeConfig, caplog_text
+    ):
+        cfg = FakeConfig()
+        cfg.write_cache("marker-reboot-cmds", "samplecontent")
+        main(args="notused", cfg=cfg)
+        assert None is cfg.read_cache("marker-reboot-cmds")
+        assert "Skipping reboot_cmds. Machine is unattached" in caplog_text()
+        assert 0 == m_subp.call_count
+
+    @mock.patch("lib.reboot_cmds.subp")
+    def test_main_noops_when_no_marker(self, m_subp, FakeConfig):
+        cfg = FakeConfig()
+        assert None is cfg.read_cache("marker-reboot-cmds")
+        main(args="notused", cfg=cfg)
+        assert 0 == m_subp.call_count
+
+    @mock.patch("lib.reboot_cmds.subp")
+    def test_main_unattached_removes_marker_file(
+        self, m_subp, FakeConfig, tmpdir
+    ):
+        cfg = FakeConfig.for_attached_machine()
+        assert None is cfg.read_cache("marker-reboot-cmds")
+        main(args="notused", cfg=cfg)
+        assert 0 == m_subp.call_count
+
+
+M_REPO_PATH = "uaclient.entitlements"
+
+
+class TestFixProPkgHolds:
+    def test_attempts_lock_file(self, FakeConfig):
+        cfg = FakeConfig()
+        with mock.patch("uaclient.config.UAConfig.check_lock_info") as m_lock:
+            m_lock.return_value = (123, "ua refresh")
+            with pytest.raises(exceptions.LockHeldError):
+                fix_pro_pkg_holds(args=None, cfg=cfg)
+
+    @pytest.mark.parametrize("caplog_text", [logging.WARN], indirect=True)
+    @pytest.mark.parametrize("fips_status", ("enabled", "disabled"))
+    @mock.patch("sys.exit")
+    @mock.patch(M_FIPS_PATH + "install_packages")
+    @mock.patch(M_FIPS_PATH + "setup_apt_config")
+    def test_calls_setup_apt_config_and_install_packages_when_enabled(
+        self,
+        setup_apt_config,
+        install_packages,
+        exit,
+        fips_status,
+        FakeConfig,
+        caplog_text,
+    ):
+        cfg = FakeConfig()
+        fake_status_cache = {
+            "services": [{"name": "fips", "status": fips_status}]
+        }
+        cfg.write_cache("status-cache", fake_status_cache)
+        fix_pro_pkg_holds(args=None, cfg=cfg)
+        if fips_status == "enabled":
+            assert [mock.call()] == setup_apt_config.call_args_list
+            assert [
+                mock.call(cleanup_on_failure=False)
+            ] == install_packages.call_args_list
+        else:
+            assert 0 == setup_apt_config.call_count
+            assert 0 == install_packages.call_count
+        assert 0 == exit.call_count
+
+
+class TestRunCommand:
     @pytest.mark.parametrize("caplog_text", [logging.WARN], indirect=True)
     @mock.patch("sys.exit")
     @mock.patch("lib.reboot_cmds.subp")

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -633,39 +633,3 @@ def is_config_value_true(config: "Dict[str, Any]", path_to_value: str):
 def should_reboot() -> bool:
     """Check if the system needs to be rebooted."""
     return os.path.exists(REBOOT_FILE_CHECK_PATH)
-
-
-def check_lock_info(lock_path: str) -> "Tuple[int, str]":
-    """Return lock info if config lock file is present the lock is active.
-
-    If process claiming the lock is no longer present, remove the lock file
-    and log a warning.
-
-    :param lock_path: Full path to the lock file.
-
-    :return: A tuple (pid, string describing lock holder)
-        If no active lock, pid will be -1.
-    """
-    no_lock = (-1, "")
-    if not os.path.exists(lock_path):
-        return no_lock
-    lock_content = load_file(lock_path)
-    [lock_pid, lock_holder] = lock_content.split(":")
-    try:
-        subp(["ps", lock_pid])
-        return (int(lock_pid), lock_holder)
-    except ProcessExecutionError:
-        if os.getuid() != 0:
-            logging.debug(
-                "Found stale lock file previously held by %s:%s",
-                lock_pid,
-                lock_holder,
-            )
-            return (int(lock_pid), lock_holder)
-        logging.warning(
-            "Removing stale lock file previously held by %s:%s",
-            lock_pid,
-            lock_holder,
-        )
-        os.unlink(lock_path)
-        return no_lock


### PR DESCRIPTION
Address FIPS support in two ways:
  - add debian/postinst awareness to create marker-reboot-cmd
  - add reboot_cmds.py function fix_pro_pkg_holds which will remove any FIPS apt-holds during reboot
  - add status notices to indicate on main status output that reboot is required per #1251 

Things to address, integration testing and more unit tests for reboot_cmds.py changes