### PR TITLE
Do not install pro debs on non-pro instances

### DIFF
--- a/tools/constraints-mypy.txt
+++ b/tools/constraints-mypy.txt
@@ -1,2 +1,3 @@
 mypy
 pytest==6.1.2
+importlib-metadata==3.3.0


### PR DESCRIPTION
Currently, when performing integration tests, we install both the default package and the pro package in the same
instance. However, now that we are running the auto-attach init script before cloud-init process the userdata, we are no longer ensuring that this script will not run. Since the auto-attach command will fail on non-pro instances, we must avoid installing the pro
package on those instances.

Related to bug #1297 