### PR TITLE
Set pip version for testing older releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ ifneq (,$(findstring trusty,$(TOXENV)))
 	pip install virtualenv==20.0.31
 endif
 	pip install tox
+	pip install tox-pip-version
 
 travis-deb-install:
 	git fetch --unshallow

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,21 @@
 [tox]
 envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic}, mypy, black
 
+[testenv:flake8-trusty]
+pip_version = 9.0.2
+
+[testenv:flake8-bionic]
+pip_version = 9.0.2
+
+[testenv:flake8-xenial]
+pip_version = 9.0.2
+
+[testenv:py3-xenial]
+pip_version = 9.0.2
+
+[testenv:py3-bionic]
+pip_version = 9.0.2
+
 [testenv]
 deps =
     -rrequirements.txt


### PR DESCRIPTION
When we run flake8 and pytest jobs using dependencies based on older ubuntu releases, we must ensure that
we are using an older version of pip. If we do not do that, new versions of pip will not be able to parse the specified
dependencies tree and it will fail to run the test

To pin the pip version, I had to add a dependency to a tox plugin called `tox-pip-version`. Initially I thought about using the `VIRTUALENV_PIP` variable to set this, but it is not working as I expected, since pip is always being upgrade to the latest  version anyway