### PR TITLE
Remove cis from beta services

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -333,6 +333,8 @@ Feature: Command behaviour when attached to an UA subscription
         Then stdout matches regexp:
         """
         Client to manage Ubuntu Advantage services on a machine.
+         - cis: Center for Internet Security Audit Tools
+           \(https://ubuntu.com/security/certifications#cis\)
          - esm-infra: UA Infra: Extended Security Maintenance \(ESM\)
            \(https://ubuntu.com/security/esm\)
          - livepatch: Canonical Livepatch service
@@ -342,6 +344,8 @@ Feature: Command behaviour when attached to an UA subscription
         Then stdout matches regexp:
         """
         Client to manage Ubuntu Advantage services on a machine.
+         - cis: Center for Internet Security Audit Tools
+           \(https://ubuntu.com/security/certifications#cis\)
          - esm-infra: UA Infra: Extended Security Maintenance \(ESM\)
            \(https://ubuntu.com/security/esm\)
          - livepatch: Canonical Livepatch service

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -67,7 +67,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-infra, livepatch
+            Try cis, esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -167,7 +167,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-infra, livepatch
+            Try cis, esm-infra, livepatch
             """
 
         Examples: ubuntu release
@@ -227,7 +227,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service '<service>'.
-            Try esm-infra, livepatch
+            Try cis, esm-infra, livepatch
             """
 
         Examples: beta services in containers

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -274,7 +274,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
     Scenario Outline: Attached enable of cis service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
-        And I verify that running `ua enable cis --beta` `with sudo` exits `0`
+        And I verify that running `ua enable cis` `with sudo` exits `0`
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -7,6 +7,7 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            cis           <cis>      +Center for Internet Security Audit Tools
             esm-infra     yes        UA Infra: Extended Security Maintenance \(ESM\)
             livepatch     yes        Canonical Livepatch service
 
@@ -32,6 +33,7 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            cis           <cis>      +Center for Internet Security Audit Tools
             esm-infra     yes        UA Infra: Extended Security Maintenance \(ESM\)
             livepatch     yes        Canonical Livepatch service
 

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -8,5 +8,4 @@ class CISEntitlement(repo.RepoEntitlement):
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"
     repo_key_file = "ubuntu-advantage-cis.gpg"
-    is_beta = True
     apt_noninteractive = True

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -59,6 +59,8 @@ Client to manage Ubuntu Advantage services on a machine.
 SERVICES_WRAPPED_HELP = textwrap.dedent(
     """
 Client to manage Ubuntu Advantage services on a machine.
+ - cis: Center for Internet Security Audit Tools
+   (https://ubuntu.com/security/certifications#cis)
  - esm-infra: UA Infra: Extended Security Maintenance (ESM)
    (https://ubuntu.com/security/esm)
  - livepatch: Canonical Livepatch service


### PR DESCRIPTION
Since we are now supporting cis, we need to remove it from beta services pool and allow users to see the service normally when running `ua status`
