### PR TITLE
Remove grep for release in fips upgrade test

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -89,6 +89,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
+        fips         +yes      +n/a      +NIST-certified FIPS modules
+        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
         livepatch    +yes      +<lp_status>  +<lp_desc>
         """
         And stderr matches regexp:
@@ -121,7 +123,9 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
-        livepatch    +yes      +<lp_status>  +<lp_desc>
+        fips         +yes      +<fips_status> +NIST-certified FIPS modules
+        fips-updates +yes      +<fips_status> +Uncertified security updates to FIPS modules
+        livepatch    +yes      +<lp_status>  +Canonical Livepatch service
         """
         And stderr matches regexp:
         """
@@ -129,8 +133,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
 
         Examples: ubuntu release livepatch status
-           | release | lp_status | lp_desc                       |
-           | trusty  | disabled  | Canonical Livepatch service   |
-           | xenial  | n/a       | Canonical Livepatch service   |
-           | bionic  | n/a       | Canonical Livepatch service   |
-           | focal   | n/a       | Canonical Livepatch service   |
+           | release | lp_status | fips_status |
+           | trusty  | disabled  | n/a         |
+           | xenial  | n/a       | disabled    |
+           | bionic  | n/a       | disabled    |
+           | focal   | n/a       | n/a         |

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -291,6 +291,8 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stdout matches regexp:
         """
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
+        fips         +yes      +n/a      +NIST-certified FIPS modules
+        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
         livepatch    +yes      +enabled  +Canonical Livepatch service
         """
         When I run `ua disable livepatch` with sudo
@@ -304,6 +306,8 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stdout matches regexp:
         """
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
+        fips         +yes      +disabled +NIST-certified FIPS modules
+        fips-updates +yes      +disabled +Uncertified security updates to FIPS modules
         livepatch    +yes      +disabled +Canonical Livepatch service
         """
 

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -244,7 +244,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         <next_release>
         """
-        When I verify that running `egrep "<release>|disabled" /etc/apt/sources.list.d/<source-file>.list` `as non-root` exits `1`
+        When I verify that running `egrep "disabled" /etc/apt/sources.list.d/<source-file>.list` `as non-root` exits `1`
         Then I will see the following on stdout:
         """
         """


### PR DESCRIPTION
Currently, after we upgrade a release with fips enabled we run a grep command on the source list files to see
if we can find a disable or the name of the past release on them. However, the deb-src files are appearing commented
out with the past release. Since this is not an issue, we can remove grepping for the release on that part of the test