### PR TITLE
Add https_proxy to passenv in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ passenv =
     UACLIENT_BEHAVE_*
     TRAVIS
     TRAVIS_*
+    https_proxy
 setenv =
     awsgeneric: UACLIENT_BEHAVE_MACHINE_TYPE = aws.generic
     awspro: UACLIENT_BEHAVE_MACHINE_TYPE = aws.pro


### PR DESCRIPTION
To run GCP behave tests in Jenkins, we need to setup the https_proxy env variable. However, tox only pass env variables
to the test environments if they are specified on passenv. We are now adding that variable there to unblock the GCP tests