### PR TITLE
Allow uaclient to disable services during enable

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -67,10 +67,10 @@ Feature: Command behaviour when attached to an UA subscription
         """
 
         Examples: ubuntu release
-           | release | cc-eal-s | cis-s | esm-a-s | infra-pkg | apps-pkg | fips-s | lp-s     | lp-d                          |
-           | xenial  | disabled | disabled | enabled | libkrad0  | jq       | n/a    | enabled  | Canonical Livepatch service |
-           | bionic  | n/a      | disabled | enabled | libkrad0  | bundler  | n/a    | enabled  | Canonical Livepatch service |
-           | focal   | n/a      | n/a      | enabled | hello     | ant      | n/a    | enabled  | Canonical Livepatch service |
+           | release | cc-eal-s | cis-s    | esm-a-s | infra-pkg | apps-pkg | fips-s   | lp-s     | lp-d                        |
+           | xenial  | disabled | disabled | enabled | libkrad0  | jq       | disabled | enabled  | Canonical Livepatch service |
+           | bionic  | n/a      | disabled | enabled | libkrad0  | bundler  | disabled | enabled  | Canonical Livepatch service |
+           | focal   | n/a      | n/a      | enabled | hello     | ant      | disabled | enabled  | Canonical Livepatch service |
 
     @series.trusty
     @uses.config.machine_type.aws.pro

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -42,30 +42,15 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     apt_noninteractive = True
 
     help_doc_url = "https://ubuntu.com/security/certifications#fips"
+    _incompatible_services = ["livepatch"]
 
     @property
     def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
         # Use a lambda so we can mock util.is_container in tests
-        from uaclient.entitlements.livepatch import LivepatchEntitlement
-
-        livepatch_ent = LivepatchEntitlement(self.cfg)
-        enabled_status = status.ApplicationStatus.ENABLED
-
-        is_livepatch_enabled = bool(
-            livepatch_ent.application_status()[0] == enabled_status
-        )
-
         return (
             (
                 "Cannot install {} on a container".format(self.title),
                 lambda: util.is_container(),
-                False,
-            ),
-            (
-                "Cannot enable {} when Livepatch is enabled".format(
-                    self.title
-                ),
-                lambda: is_livepatch_enabled,
                 False,
             ),
         )

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -258,6 +258,15 @@ MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"
 MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
+MESSAGE_INCOMPATIBLE_SERVICE = """\
+{service_being_enabled} cannot be enabled with {incompatible_service}.
+Disable {incompatible_service} and proceed to enable {service_being_enabled}? \
+(y/N)"""
+
+MESSAGE_INCOMPATIBLE_SERVICE_STOPS_ENABLE = """\
+Cannot enable {service_being_enabled} when {incompatible_service} is enabled
+"""
+
 ERROR_INVALID_CONFIG_VALUE = """\
 Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \
 Expected {expected_value}, found {value}."""


### PR DESCRIPTION
When we are enabling a service in uaclient, we may end up finding that we have an incompatible service
already enabled in the system. Currently, we alert the user about this issue and abort the enable operation.
We are updating that to allow the user to decide if the incompatible services should be disabled or not
before enabling the requested service.

To make that happen, we are creating a new abstraction called `incompatible_services`. Every entitlement that has an incompatible service needs to define this parameters, which is a list of strings containing the name of the incompatible services.

We are also adding the feature override named `block_disable_on_enable` to never allow a service to be disabled during an enable operation. Those flags were created due to testing purposes, since there is no easy way to simulate a user input on behave.

fix #1301 