### PR TITLE
UA Fix spike: New UASecurityClient for querying CVE and USNs basic CLI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING = credentials(
             'ua-contract-token-staging'
         )
+        JOB_SUFFIX = sh(returnStdout: true, script: "basename ${JOB_NAME}| cut -d'-' -f2").trim()
     }
 
     stages {
@@ -33,7 +34,6 @@ pipeline {
                 python3 -m venv $TMPDIR
                 . $TMPDIR/bin/activate
                 pip install tox  # for tox supporting --parallel--safe-build
-                dpkg-source -b .
                 '''
             }
         }
@@ -81,65 +81,85 @@ pipeline {
             parallel {
                 stage ('Package build: 14.04') {
                     environment {
-                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "trusty"
+                        SERIES_VERSION = "14.04"
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
+                        NEW_PKG_VERSION = "${PKG_VERSION}~${SERIES_VERSION}~${JOB_SUFFIX}"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
                     steps {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~14.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
-                        cp ./ubuntu-advantage-tools*14.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
-                        cp ./ubuntu-advantage-pro*14.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
+                        cp debian/changelog ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        sed -i "s/${PKG_VERSION}/${NEW_PKG_VERSION}/" ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        dpkg-source -l${WORKSPACE}/debian/changelog-${SERIES_VERSION} -b .
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~${SERIES_VERSION}  ../ubuntu-advantage-tools*${NEW_PKG_VERSION}*dsc
+                        cp ./ubuntu-advantage-tools*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
+                        cp ./ubuntu-advantage-pro*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
                     }
                 }
                 stage ('Package build: 16.04') {
                     environment {
-                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "xenial"
+                        SERIES_VERSION = "16.04"
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
+                        NEW_PKG_VERSION = "${PKG_VERSION}~${SERIES_VERSION}~${JOB_SUFFIX}"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
                     steps {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~16.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
-                        cp ./ubuntu-advantage-tools*16.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
-                        cp ./ubuntu-advantage-pro*16.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
+                        cp debian/changelog ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        sed -i "s/${PKG_VERSION}/${NEW_PKG_VERSION}/" ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        dpkg-source -l${WORKSPACE}/debian/changelog-${SERIES_VERSION} -b .
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~${SERIES_VERSION}  ../ubuntu-advantage-tools*${NEW_PKG_VERSION}*dsc
+                        cp ./ubuntu-advantage-tools*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
+                        cp ./ubuntu-advantage-pro*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
                     }
                 }
                 stage ('Package build: 18.04') {
                     environment {
-                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "bionic"
+                        SERIES_VERSION = "18.04"
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
+                        NEW_PKG_VERSION = "${PKG_VERSION}~${SERIES_VERSION}~${JOB_SUFFIX}"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
                     steps {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~18.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
-                        cp ./ubuntu-advantage-tools*18.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
-                        cp ./ubuntu-advantage-pro*18.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
+                        cp debian/changelog ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        sed -i "s/${PKG_VERSION}/${NEW_PKG_VERSION}/" ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        dpkg-source -l${WORKSPACE}/debian/changelog-${SERIES_VERSION} -b .
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~${SERIES_VERSION}  ../ubuntu-advantage-tools*${NEW_PKG_VERSION}*dsc
+                        cp ./ubuntu-advantage-tools*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
+                        cp ./ubuntu-advantage-pro*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
                     }
                 }
                 stage ('Package build: 20.04') {
                     environment {
-                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "focal"
+                        SERIES_VERSION = "20.04"
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
+                        NEW_PKG_VERSION = "${PKG_VERSION}~${SERIES_VERSION}~${JOB_SUFFIX}"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
                     steps {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~20.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
-                        cp ./ubuntu-advantage-tools*20.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
-                        cp ./ubuntu-advantage-pro*20.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
+                        cp debian/changelog ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        sed -i "s/${PKG_VERSION}/${NEW_PKG_VERSION}/" ${WORKSPACE}/debian/changelog-${SERIES_VERSION}
+                        dpkg-source -l${WORKSPACE}/debian/changelog-${SERIES_VERSION} -b .
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~${SERIES_VERSION}  ../ubuntu-advantage-tools*${NEW_PKG_VERSION}*dsc
+                        cp ./ubuntu-advantage-tools*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
+                        cp ./ubuntu-advantage-pro*${SERIES_VERSION}*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
                     }
                 }

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -207,7 +207,7 @@ Feature: Command behaviour when attached to an UA subscription
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         And I verify that running `apt update` `with sudo` exits `0`
-        When I run `apt install -y <infra-pkg>/<release>-infra-security>` with sudo, retrying exit [100]
+        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo, retrying exit [100]
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
@@ -218,7 +218,7 @@ Feature: Command behaviour when attached to an UA subscription
         """
         Installed: .*[~+]esm
         """
-        When I run `apt install -y <apps-pkg>/<release>-apps-security>` with sudo, retrying exit [100]
+        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo, retrying exit [100]
         And I run `apt-cache policy <apps-pkg>` as non-root
         Then stdout matches regexp:
         """

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -207,7 +207,7 @@ Feature: Command behaviour when attached to an UA subscription
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         And I verify that running `apt update` `with sudo` exits `0`
-        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo
+        When I run `apt install -y <infra-pkg>/<release>-infra-security>` with sudo, retrying exit [100]
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
@@ -218,7 +218,7 @@ Feature: Command behaviour when attached to an UA subscription
         """
         Installed: .*[~+]esm
         """
-        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo
+        When I run `apt install -y <apps-pkg>/<release>-apps-security>` with sudo, retrying exit [100]
         And I run `apt-cache policy <apps-pkg>` as non-root
         Then stdout matches regexp:
         """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -127,7 +127,7 @@ Feature: Command behaviour when unattached
     @series.focal
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua fix USN-4539-1` as non-root
+        When I run `ua fix --beta USN-4539-1` as non-root
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
@@ -135,7 +135,7 @@ Feature: Command behaviour when unattached
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """
-        When I run `ua fix CVE-2020-28196` as non-root
+        When I run `ua fix --beta CVE-2020-28196` as non-root
         Then stdout matches regexp:
             """
             CVE-2020-28196: Kerberos vulnerability
@@ -151,13 +151,12 @@ Feature: Command behaviour when unattached
            | release |
            | bionic  |
            | focal   |
-           | trusty  |
            | xenial  |
 
     @series.trusty
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua fix USN-4539-1` as non-root
+        When I run `ua fix --beta USN-4539-1` as non-root
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
@@ -165,7 +164,7 @@ Feature: Command behaviour when unattached
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """
-        When I run `ua fix CVE-2020-28196` as non-root
+        When I run `ua fix --beta CVE-2020-28196` as non-root
         Then stdout matches regexp:
             """
             CVE-2020-28196: Kerberos vulnerability

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -121,3 +121,59 @@ Feature: Command behaviour when unattached
            | focal   |
            | trusty  |
            | xenial  |
+
+    @series.xenial
+    @series.bionic
+    @series.focal
+    Scenario Outline: Fix command on an unattached machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `ua fix USN-4539-1` as non-root
+        Then stdout matches regexp:
+            """
+            USN-4539-1: AWL vulnerability
+            https://ubuntu.com/security/notices/usn-4539-1.json
+            No affected packages are installed.
+            .*✔.* USN-4539-1 does not affect your system.
+            """
+        When I run `ua fix CVE-2020-28196` as non-root
+        Then stdout matches regexp:
+            """
+            CVE-2020-28196: Kerberos vulnerability
+            https://ubuntu.com/security/cve-2020-28196.json
+            1 affected package is installed: krb5
+            \(1/1\) krb5:
+            A fix is available in Ubuntu standard updates.
+            The update is already installed.
+            .*✔.* CVE-2020-28196 is resolved.
+            """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
+
+    @series.trusty
+    Scenario Outline: Fix command on an unattached machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `ua fix USN-4539-1` as non-root
+        Then stdout matches regexp:
+            """
+            USN-4539-1: AWL vulnerability
+            https://ubuntu.com/security/notices/usn-4539-1.json
+            No affected packages are installed.
+            .*✔.* USN-4539-1 does not affect your system.
+            """
+        When I run `ua fix CVE-2020-28196` as non-root
+        Then stdout matches regexp:
+            """
+            CVE-2020-28196: Kerberos vulnerability
+            https://ubuntu.com/security/cve-2020-28196.json
+            No affected packages are installed.
+            .*✔.* CVE-2020-28196 does not affect your system.
+            """
+
+        Examples: ubuntu release
+           | release |
+           | trusty  |

--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -1,5 +1,6 @@
 # Development UA Client config file. YAML
 contract_url: 'https://contracts.staging.canonical.com'
+security_url: 'https://ubuntu.com/security'
 data_dir: /var/tmp/uaclient
 log_level: debug
 log_file: ubuntu-advantage-devel.log

--- a/uaclient.conf
+++ b/uaclient.conf
@@ -1,5 +1,6 @@
 # Ubuntu-Advantage client config file.
 contract_url: 'https://contracts.canonical.com'
+security_url: 'https://ubuntu.com/security'
 data_dir: /var/lib/ubuntu-advantage
 log_level: debug
 log_file: /var/log/ubuntu-advantage.log

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -226,15 +226,21 @@ def attach_parser(parser):
 def fix_parser(parser):
     """Build or extend an arg parser for fix subcommand."""
     parser.usage = USAGE_TMPL.format(
-        name=NAME, command="fix <CVE-yyyy-nnnn>|<USN-nnnn>"
+        name=NAME, command="fix --beta <CVE-yyyy-nnnn+>|<USN-nnnn-d+>"
     )
     parser.prog = "fix"
     parser._optionals.title = "Flags"
     parser.add_argument(
+        "--beta",
+        required=True,
+        action="store_true",
+        help="allow using this beta command",
+    )
+    parser.add_argument(
         "security_issue",
         help=(
             "Security vulnerability ID to inspect and resolve on this system."
-            " Format: CVE-yyyy-nnnn or USN-nnnn"
+            " Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
         ),
     )
     return parser
@@ -242,9 +248,8 @@ def fix_parser(parser):
 
 def action_fix(args, cfg, **kwargs):
     if not re.match(security.CVE_OR_USN_REGEX, args.security_issue):
-        # TODO(review of error messaging to reduce output)
         raise exceptions.UserFacingError(
-            "Invalid issue format issue: {}".format(args.security_issue)
+            "Invalid issue format: {}".format(args.security_issue)
         )
     security.fix_security_issue_id(cfg, args.security_issue)
 
@@ -832,7 +837,7 @@ def get_parser():
         help="refresh Ubuntu Advantage services from contracts server",
     )
     parser_fix = subparsers.add_parser(
-        "fix", help="fix CVE and USN security issues on this machine"
+        "fix"  # BETA omit help string to hide subcommand from help
     )
     parser_fix.set_defaults(action=action_fix)
     fix_parser(parser_fix)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -93,6 +93,10 @@ class UAConfig:
     def contract_url(self):
         return self.cfg.get("contract_url", "https://contracts.canonical.com")
 
+    @property
+    def security_url(self):
+        return self.cfg.get("security_url", "https://ubuntu.com/security")
+
     def check_lock_info(self) -> "Tuple[int, str]":
         """Return lock info if config lock file is present the lock is active.
 
@@ -624,12 +628,11 @@ def parse_config(config_path=None):
     cfg.update(env_keys)
     cfg["log_level"] = cfg["log_level"].upper()
     cfg["data_dir"] = os.path.expanduser(cfg["data_dir"])
-    if not util.is_service_url(cfg["contract_url"]):
-        raise exceptions.UserFacingError(
-            "Invalid url in config. contract_url: {}".format(
-                cfg["contract_url"]
+    for key in ("contract_url", "security_url"):
+        if not util.is_service_url(cfg[key]):
+            raise exceptions.UserFacingError(
+                "Invalid url in config. {}: {}".format(key, cfg[key])
             )
-        )
     return cfg
 
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -1,5 +1,4 @@
 import logging
-import urllib
 
 from uaclient import clouds
 from uaclient import exceptions
@@ -97,7 +96,7 @@ class UAContractClient(serviceclient.UAServiceClient):
             "kernel": platform["kernel"],
         }
         resource_response, headers = self.request_url(
-            API_V1_RESOURCES + "?" + urllib.parse.urlencode(query_params)
+            API_V1_RESOURCES, query_params=query_params
         )
         return resource_response
 

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -10,9 +10,11 @@ DEFAULT_CONFIG_FILE = UAC_ETC_PATH + "uaclient.conf"
 DEFAULT_HELP_FILE = UAC_ETC_PATH + "help_data.yaml"
 DEFAULT_UPGRADE_CONTRACT_FLAG_FILE = UAC_ETC_PATH + "request-update-contract"
 BASE_CONTRACT_URL = "https://contracts.canonical.com"
+BASE_SECURITY_URL = "https://ubuntu.com/security"
 
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,
+    "security_url": BASE_SECURITY_URL,
     "data_dir": "/var/lib/ubuntu-advantage",
     "log_level": "INFO",
     "log_file": "/var/log/ubuntu-advantage.log",

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -18,6 +18,7 @@ from uaclient import exceptions
 
 
 M_PATH = "uaclient.entitlements.fips."
+M_LIVEPATCH_PATH = "uaclient.entitlements.livepatch.LivepatchEntitlement."
 M_REPOPATH = "uaclient.entitlements.repo."
 M_GETPLATFORM = M_REPOPATH + "util.get_platform_info"
 FIPS_ADDITIONAL_PACKAGES = ["ubuntu-fips"]
@@ -373,9 +374,17 @@ class TestFIPSEntitlementEnable:
         assert expected_msg.strip() in fake_stdout.getvalue().strip()
 
     @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch(
+        M_LIVEPATCH_PATH + "application_status",
+        return_value=((status.ApplicationStatus.DISABLED, "")),
+    )
     @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_fips_update_service_is_enabled(
-        self, m_is_container, m_handle_message_op, entitlement_factory
+        self,
+        m_is_container,
+        m_livepatch,
+        m_handle_message_op,
+        entitlement_factory,
     ):
         m_handle_message_op.return_value = True
         fips_entitlement = entitlement_factory(FIPSEntitlement)

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -608,21 +608,6 @@ class TestFIPSEntitlementDisable:
         assert [mock.call()] == m_remove_apt_config.call_args_list
         assert [mock.call()] == m_remove_packages.call_args_list
 
-    def test_disable_on_can_disable_true_removes_packages(
-        self,
-        _m_platform_info,
-        m_handle_message_operations,
-        entitlement,
-        tmpdir,
-    ):
-        """When can_disable, disable removes apt configuration"""
-        with mock.patch.object(entitlement, "can_disable", return_value=True):
-            with mock.patch.object(
-                entitlement, "remove_apt_config"
-            ) as m_remove_apt_config:
-                assert entitlement.disable(True)
-        assert [mock.call()] == m_remove_apt_config.call_args_list
-
 
 class TestFIPSEntitlementApplicationStatus:
     @pytest.mark.parametrize(

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1,0 +1,394 @@
+from uaclient.config import UAConfig
+from uaclient import exceptions
+from uaclient import status
+from uaclient import serviceclient
+from uaclient import util
+
+CVE_OR_USN_REGEX = r"(CVE-\d{4}-\d{4,7}|(USN|LSN)-\d{1,5}-\d{1,2})"
+
+try:
+    from typing import Any, Dict, List, Optional  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
+API_V1_CVES = "cves.json"
+API_V1_CVE_TMPL = "cves/{cve}.json"
+API_V1_NOTICES = "notices.json"
+API_V1_NOTICE_TMPL = "notices/{notice}.json"
+
+
+class SecurityAPIError(util.UrlError):
+    def __init__(self, e, error_response):
+        super().__init__(e, e.code, e.headers, e.url)
+        self.message = error_response.get("message", "")
+
+    def __contains__(self, error_code):
+        return bool(error_code in self.message)
+
+    def __get__(self, error_str, default=None):
+        if error_str in self.message:
+            return self.message
+        return default
+
+    def __str__(self):
+        prefix = super().__str__()
+        details = [self.message]
+        if details:
+            return prefix + ": [" + self.url + "] " + ", ".join(details)
+        return prefix + ": [" + self.url + "]"
+
+
+class UASecurityClient(serviceclient.UAServiceClient):
+
+    cfg_url_base_attr = "security_url"
+    api_error_cls = SecurityAPIError
+
+    def get_cves(
+        self,
+        query: "Optional[str]" = None,
+        priority: "Optional[str]" = None,
+        package: "Optional[str]" = None,
+        limit: "Optional[int]" = None,
+        offset: "Optional[int]" = None,
+        component: "Optional[str]" = None,
+        version: "Optional[str]" = None,
+        status: "Optional[List[str]]" = None,
+    ) -> "List[CVE]":
+        """Query to match multiple-CVEs.
+
+        @return: List of CVE instances based on the the JSON response.
+        """
+        query_params = {
+            "q": query,
+            "priority": priority,
+            "package": package,
+            "limit": limit,
+            "offset": offset,
+            "component": component,
+            "version": version,
+            "status": status,
+        }
+        cves_response, _headers = self.request_url(
+            API_V1_CVES, query_params=query_params
+        )
+        return [CVE(client=self, response=cve_md) for cve_md in cves_response]
+
+    def get_cve(self, cve_id: str) -> "CVE":
+        """Query to match single-CVE.
+
+        @return: CVE instance for JSON response from the Security API.
+        """
+        cve_response, _headers = self.request_url(
+            API_V1_CVE_TMPL.format(cve=cve_id)
+        )
+        return CVE(client=self, response=cve_response)
+
+    def get_notices(
+        self,
+        details: "Optional[str]" = None,
+        release: "Optional[str]" = None,
+        limit: "Optional[int]" = None,
+        offset: "Optional[int]" = None,
+        order: "Optional[str]" = None,
+    ) -> "List[USN]":
+        """Query to match multiple-USNs.
+
+        @return: List of USN instances based on the the JSON response.
+        """
+        query_params = {
+            "details": details,
+            "release": release,
+            "limit": limit,
+            "offset": offset,
+            "order": order,
+        }
+        usns_response, _headers = self.request_url(
+            API_V1_NOTICES, query_params=query_params
+        )
+        return [USN(client=self, response=usn_md) for usn_md in usns_response]
+
+    def get_notice(self, notice_id: str) -> "USN":
+        """Query to match single-USN.
+
+        @return: USN instance representing the JSON response.
+        """
+        notice_response, _headers = self.request_url(
+            API_V1_NOTICE_TMPL.format(notice=notice_id)
+        )
+        return USN(client=self, response=notice_response)
+
+
+# Model for Security API responses
+class CVEPackageStatus:
+    """Class representing specific CVE PackageStatus on an Ubuntu series"""
+
+    def __init__(self, cve_response: "Dict[str, str]"):
+        self.response = cve_response
+
+    @property
+    def description(self):
+        return self.response["description"]
+
+    @property
+    def fixed_version(self):
+        return self.description
+
+    @property
+    def pocket(self):
+        return self.response["pocket"]
+
+    @property
+    def release_codename(self):
+        return self.response["release_codename"]
+
+    @property
+    def status(self):
+        return self.response["status"]
+
+    @property
+    def status_message(self):
+        if self.status == "needed":
+            return "Sorry, no fix is available yet."
+        elif self.status == "pending":
+            return "A fix is coming soon. Try again tomorrow."
+        elif self.status in ("ignored", "deferred"):
+            return "Sorry, no fix is available."
+        elif self.status == "released":
+            return status.MESSAGE_SECURITY_FIX_RELEASE_STREAM.format(
+                fix_stream=self.pocket_source
+            )
+        return "UNKNOWN: {}".format(self.status)
+
+    @property
+    def pocket_source(self):
+        """Human-readable string representing where the fix is published."""
+        if self.pocket == "esm-infra":
+            fix_source = "UA Infra"
+        elif self.pocket == "esm-apps":
+            fix_source = "UA Apps"
+        elif self.pocket in ("updates", "security"):
+            fix_source = "Ubuntu standard updates"
+        else:
+            # TODO(drop this once pockets are supplied from Security Team)
+            if "esm" in self.fixed_version:
+                fix_source = "UA Infra"
+            else:
+                fix_source = "Ubuntu standard updates"
+        return fix_source
+
+
+class CVE:
+    """Class representing CVE response from the SecurityClient"""
+
+    def __init__(self, client: UASecurityClient, response: "Dict[str, Any]"):
+        self.response = response
+        self.client = client
+
+    @property
+    def id(self):
+        return self.response.get("id", "UNKNOWN_CVE_ID").upper()
+
+    def _get_related_notices(self):
+        if hasattr(self, "notices"):
+            return self.notices
+        self.notices = {}
+        for notice_id in self.response.get("notices", []):
+            self.notices[notice_id] = self.client.get_notice(
+                notice_id=notice_id
+            )
+        return self.notices
+
+    @property
+    def notice_ids(self):
+        notices_md = self._get_related_notices()
+        return list(notices_md.keys())
+
+    @property
+    def title(self):
+        descr = self.response.get("description", "UNKNOWN_CVE_DESCRIPTION")
+        notices = self._get_related_notices()
+        if not notices:
+            return descr
+        # TODO(If multiple notices, which title to use?)
+        for key in sorted(notices):
+            return notices[key].title
+        return descr
+
+    @property
+    def packages_status(self) -> "Dict[str, CVEPackageStatus]":
+        """Dict of package status dicts for the current Ubuntu series.
+
+        Top-level keys are source packages names and each value is a
+        CVEPackageStatus object
+        """
+        if hasattr(self, "_packages_status"):
+            return self._packages_status  # type: ignore
+        self._packages_status = {}
+        series = util.get_platform_info()["series"]
+        for package in self.response["packages"]:
+            for pkg_status in package["statuses"]:
+                if pkg_status["release_codename"] == series:
+                    self._packages_status[package["name"]] = CVEPackageStatus(
+                        pkg_status
+                    )
+        return self._packages_status
+
+
+class USN:
+    """Class representing USN response from the SecurityClient"""
+
+    def __init__(self, client: UASecurityClient, response: "Dict[str, str]"):
+        self.response = response
+        self.client = client
+
+    @property
+    def id(self):
+        return self.response.get("id", "UNKNOWN_USN_ID").upper()
+
+    @property
+    def title(self):
+        return self.response.get("title")
+
+
+def query_installed_source_pkg_versions() -> "Dict[str, str]":
+    """Return a dict of all source packages installed on the system.
+
+    The dict keys will be source package name: "krb5". The value will be the
+    package version.
+    """
+    out, _err = util.subp(
+        ["dpkg-query", "-f=${Source},${Version},${db:Status-Status}\n", "-W"]
+    )
+    installed_packages = {}  # type: Dict[str, str]
+    for pkg_line in out.splitlines():
+        source_pkg_name, pkg_version, status = pkg_line.split(",")
+        if status != "installed":
+            continue
+        installed_packages[source_pkg_name] = pkg_version
+    return installed_packages
+
+
+def fix_security_issue_id(cfg: UAConfig, issue_id: str) -> None:
+    issue_id = issue_id.upper()
+    client = UASecurityClient(cfg=cfg)
+    installed_packages = query_installed_source_pkg_versions()
+    if "CVE" in issue_id:
+        affected_pkg_status = get_cve_affected_packages_status(
+            client=client,
+            issue_id=issue_id,
+            installed_packages=installed_packages,
+        )
+    else:  # USN
+        affected_pkg_status = get_usn_affected_packages_status(
+            client=client, issue_id=issue_id
+        )
+    prompt_for_affected_packages(
+        issue_id=issue_id,
+        affected_pkg_status=affected_pkg_status,
+        installed_packages=installed_packages,
+    )
+
+
+def get_usn_affected_packages_status(
+    client: UASecurityClient, issue_id: str
+) -> "Dict[str, CVEPackageStatus]":
+    """Walk CVEs related to a USN and determine if all are fixed."""
+    affected_pkg_versions = {}  # type: Dict[str, CVEPackageStatus]
+    try:
+        usn = client.get_notice(notice_id=issue_id)
+    except SecurityAPIError as e:
+        raise exceptions.UserFacingError(str(e))
+    print(
+        status.MESSAGE_SECURITY_URL.format(
+            issue=usn.id,
+            title=usn.title,
+            url_path="notices/{}.json".format(usn.id.lower()),
+        )
+    )
+    return affected_pkg_versions  # TODO(walk USN CVEs for affected packages)
+
+
+def get_cve_affected_packages_status(
+    client: UASecurityClient,
+    issue_id: str,
+    installed_packages: "Dict[str,str]",
+) -> "Dict[str, CVEPackageStatus]":
+    try:
+        cve = client.get_cve(cve_id=issue_id)
+    except SecurityAPIError as e:
+        raise exceptions.UserFacingError(str(e))
+    print(
+        status.MESSAGE_SECURITY_URL.format(
+            issue=cve.id,
+            title=cve.title,
+            url_path="{}.json".format(cve.id.lower()),
+        )
+    )
+    affected_pkg_versions = {}
+    for source_pkg, package_status in cve.packages_status.items():
+        if source_pkg in installed_packages:
+            if package_status.status != "not-affected":
+                affected_pkg_versions[source_pkg] = package_status
+    return affected_pkg_versions
+
+
+def prompt_for_affected_packages(
+    issue_id: str,
+    affected_pkg_status: "Dict[str, CVEPackageStatus]",
+    installed_packages: "Dict[str,str]",
+) -> None:
+    """Process security CVE dict returning a CVEStatus object.
+
+    Since CVEs point to a USN if active, get_notice may be called to fill in
+    CVE title details.
+    """
+    count = len(affected_pkg_status)
+    if count == 0:
+        print(
+            status.MESSAGE_SECURITY_AFFECTED_PKGS.format(
+                count="No", plural_str="s are"
+            )
+            + "."
+        )
+        print(status.MESSAGE_SECURITY_ISSUE_UNAFFECTED.format(issue=issue_id))
+        return
+
+    if count == 1:
+        plural_str = " is"
+    else:
+        plural_str = "s are"
+    msg = status.MESSAGE_SECURITY_AFFECTED_PKGS.format(
+        count=count, plural_str=plural_str
+    )
+    msg_suffix = ": " + ", ".join(affected_pkg_status.keys())
+    msgs = [msg + msg_suffix]
+    for pkg_num, pkg_name in enumerate(affected_pkg_status.keys(), 1):
+        msgs.append("({}/{}) {}:".format(pkg_num, count, pkg_name))
+        pkg_status = affected_pkg_status[pkg_name]
+        msgs.append(pkg_status.status_message)
+        if pkg_status.status == "released":
+            try:  # get_pkg_install_status_messages
+                util.subp(
+                    [
+                        "dpkg",
+                        "--compare-versions",
+                        pkg_status.fixed_version,
+                        "le",
+                        installed_packages[pkg_name],
+                    ]
+                )
+                fix_installed = True
+            except util.ProcessExecutionError:
+                fix_installed = False
+            if fix_installed:
+                msgs.append(status.MESSAGE_SECURITY_UPDATE_INSTALLED)
+                msgs.append(
+                    status.MESSAGE_SECURITY_ISSUE_RESOLVED.format(
+                        issue=issue_id
+                    )
+                )
+            else:
+                msgs.append(status.MESSAGE_SECURITY_UPDATE_NOT_INSTALLED)
+    for msg in msgs:
+        print(msg)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -15,6 +15,10 @@ class TxtColor:
     ENDC = "\033[0m"
 
 
+OKGREEN_CHECK = TxtColor.OKGREEN + "✔" + TxtColor.ENDC
+FAIL_X = TxtColor.FAIL + "✘" + TxtColor.ENDC
+
+
 @enum.unique
 class ApplicationStatus(enum.Enum):
     """
@@ -126,6 +130,21 @@ STATUS_COLOR = {
     ADVANCED: TxtColor.OKGREEN + ADVANCED + TxtColor.ENDC,
 }
 
+MESSAGE_SECURITY_FIX_RELEASE_STREAM = "A fix is available in {fix_stream}."
+MESSAGE_SECURITY_UPDATE_NOT_INSTALLED = "The update is not yet installed."
+MESSAGE_SECURITY_UPDATE_INSTALLED = "The update is already installed."
+MESSAGE_SECURITY_ISSUE_RESOLVED = OKGREEN_CHECK + " {issue} is resolved."
+MESSAGE_SECURITY_ISSUE_UNAFFECTED = (
+    OKGREEN_CHECK + " {issue} does not affect your system."
+)
+MESSAGE_SECURITY_AFFECTED_PKGS = (
+    "{count} affected package{plural_str} installed"
+)
+MESSAGE_USN_FIXED = "{issue} is addressed."
+MESSAGE_CVE_FIXED = "{issue} is resolved."
+MESSAGE_SECURITY_URL = (
+    "{issue}: {title}\nhttps://ubuntu.com/security/{url_path}"
+)
 MESSAGE_APT_INSTALL_FAILED = "APT install failed."
 MESSAGE_APT_UPDATE_FAILED = "APT update failed."
 MESSAGE_APT_UPDATE_INVALID_URL_CONFIG = (

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -18,12 +18,15 @@ class FakeContractClient(UAContractClient):
         if responses:
             self._responses = responses
 
-    def request_url(self, path, data=None, headers=None, method=None):
+    def request_url(
+        self, path, data=None, headers=None, method=None, query_params=None
+    ):
         request = {
             "path": path,
             "data": data,
             "headers": headers,
             "method": method,
+            "query_params": method,
         }
         self._requests.append(request)
         # Return a response if we have one or empty

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -3,7 +3,6 @@ import logging
 import mock
 import pytest
 import socket
-import urllib
 
 from uaclient.contract import (
     API_V1_CONTEXT_MACHINE_TOKEN,
@@ -197,13 +196,7 @@ class TestGetAvailableResources:
         """Call UAContractClient.request_resources to get updated resources."""
         cfg = FakeConfig()
 
-        platform = util.get_platform_info()
-        resource_params = {
-            "architecture": platform["arch"],
-            "series": platform["series"],
-            "kernel": platform["kernel"],
-        }
-        url = API_V1_RESOURCES + "?" + urllib.parse.urlencode(resource_params)
+        url = API_V1_RESOURCES
 
         new_resources = [{"name": "new_resource", "available": False}]
 

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -1,0 +1,257 @@
+import mock
+import pytest
+
+from uaclient.security import (
+    API_V1_CVES,
+    API_V1_CVE_TMPL,
+    API_V1_NOTICES,
+    API_V1_NOTICE_TMPL,
+    CVE,
+    CVEPackageStatus,
+    UASecurityClient,
+    USN,
+    query_installed_source_pkg_versions,
+)
+
+
+M_PATH = "uaclient.contract."
+M_REPO_PATH = "uaclient.entitlements.repo.RepoEntitlement."
+
+
+SAMPLE_GET_CVES_QUERY_PARAMS = {
+    "query": "vq",
+    "priority": "vpr",
+    "package": "vpa",
+    "limit": 1,
+    "offset": 2,
+    "component": "vc",
+    "version": "vv",
+    "status": "vs",
+}
+
+SAMPLE_GET_NOTICES_QUERY_PARAMS = {
+    "details": "vd",
+    "release": "vq",
+    "limit": 1,
+    "offset": 2,
+    "order": "vo",
+}
+
+
+CVE_ESM_PACKAGE_STATUS_RESPONSE = {
+    "component": None,
+    "description": "1.17-6ubuntu4.1+esm1",
+    "pocket": "esm-infra",
+    "release_codename": "focal",
+    "status": "released",
+}
+
+
+class TestCVEPackageStatus:
+    def test_simple_properties_from_response(self):
+        pkg_status = CVEPackageStatus(
+            cve_response=CVE_ESM_PACKAGE_STATUS_RESPONSE
+        )
+        assert CVE_ESM_PACKAGE_STATUS_RESPONSE == pkg_status.response
+        assert pkg_status.response["description"] == pkg_status.description
+        assert pkg_status.description == pkg_status.fixed_version
+        assert pkg_status.response["pocket"] == pkg_status.pocket
+        assert (
+            pkg_status.response["release_codename"]
+            == pkg_status.release_codename
+        )
+        assert pkg_status.response["status"] == pkg_status.status
+
+    @pytest.mark.parametrize(
+        "pocket,description,expected",
+        (
+            ("esm-infra", "1.2", "UA Infra"),
+            ("esm-apps", "1.2", "UA Apps"),
+            ("updates", "1.2esm", "Ubuntu standard updates"),
+            ("security", "1.2esm", "Ubuntu standard updates"),
+            (None, "1.2", "Ubuntu standard updates"),
+            (None, "1.2esm", "UA Infra"),
+        ),
+    )
+    def test_pocket_source_from_response(self, pocket, description, expected):
+        cve_response = {"pocket": pocket, "description": description}
+        pkg_status = CVEPackageStatus(cve_response=cve_response)
+        assert expected == pkg_status.pocket_source
+
+    @pytest.mark.parametrize(
+        "status,pocket,expected",
+        (
+            ("needed", "esm-infra", "Sorry, no fix is available yet."),
+            (
+                "pending",
+                "esm-infra",
+                "A fix is coming soon. Try again tomorrow.",
+            ),
+            ("ignored", "esm-infra", "Sorry, no fix is available."),
+            ("released", "esm-infra", "A fix is available in UA Infra."),
+            (
+                "released",
+                "security",
+                "A fix is available in Ubuntu standard updates.",
+            ),
+            ("bogus", "1.2", "UNKNOWN: bogus"),
+        ),
+    )
+    def test_status_message_from_response(self, status, pocket, expected):
+        cve_response = {"pocket": pocket, "status": status}
+        pkg_status = CVEPackageStatus(cve_response=cve_response)
+        assert expected == pkg_status.status_message
+
+
+@mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+class TestUASecurityClient:
+    @pytest.mark.parametrize(
+        "m_kwargs,expected_error",
+        (
+            ({}, None),
+            ({"query": "vq"}, None),
+            (SAMPLE_GET_CVES_QUERY_PARAMS, None),
+            ({"invalidparam": "vv"}, TypeError),
+        ),
+    )
+    def test_get_cves_sets_query_params_on_get_cves_route(
+        self, request_url, m_kwargs, expected_error, FakeConfig
+    ):
+        """GET CVE instances from API_V1_CVES route with querystrings"""
+        client = UASecurityClient(FakeConfig())
+        if expected_error:
+            with pytest.raises(expected_error) as exc:
+                client.get_cves(**m_kwargs)
+            assert (
+                "get_cves() got an unexpected keyword argument 'invalidparam'"
+            ) == str(exc.value)
+            assert 0 == request_url.call_count
+        else:
+            for key in SAMPLE_GET_CVES_QUERY_PARAMS:
+                if key not in m_kwargs:
+                    m_kwargs[key] = None
+            request_url.return_value = (["body1", "body2"], "headers")
+            [cve1, cve2] = client.get_cves(**m_kwargs)
+            assert isinstance(cve1, CVE)
+            assert isinstance(cve2, CVE)
+            assert "body1" == cve1.response
+            assert "body2" == cve2.response
+            # get_cves transposes "query" to "q"
+            m_kwargs["q"] = m_kwargs.pop("query")
+            assert [
+                mock.call(API_V1_CVES, query_params=m_kwargs)
+            ] == request_url.call_args_list
+
+    @pytest.mark.parametrize(
+        "m_kwargs,expected_error",
+        (
+            ({}, None),
+            ({"details": "vd"}, None),
+            (SAMPLE_GET_NOTICES_QUERY_PARAMS, None),
+            ({"invalidparam": "vv"}, TypeError),
+        ),
+    )
+    def test_get_notices_sets_query_params_on_get_cves_route(
+        self, request_url, m_kwargs, expected_error, FakeConfig
+    ):
+        """GET body from API_V1_NOTICES route with appropriate querystring"""
+        client = UASecurityClient(FakeConfig())
+        if expected_error:
+            with pytest.raises(expected_error) as exc:
+                client.get_notices(**m_kwargs)
+            assert (
+                "get_notices() got an unexpected keyword argument"
+                " 'invalidparam'"
+            ) == str(exc.value)
+            assert 0 == request_url.call_count
+        else:
+            for key in SAMPLE_GET_NOTICES_QUERY_PARAMS:
+                if key not in m_kwargs:
+                    m_kwargs[key] = None
+            request_url.return_value = (["body1", "body2"], "headers")
+            [usn1, usn2] = client.get_notices(**m_kwargs)
+            assert isinstance(usn1, USN)
+            assert isinstance(usn2, USN)
+            assert "body1" == usn1.response
+            assert "body2" == usn2.response
+            assert [
+                mock.call(API_V1_NOTICES, query_params=m_kwargs)
+            ] == request_url.call_args_list
+
+    @pytest.mark.parametrize(
+        "m_kwargs,expected_error",
+        (({}, TypeError), ({"cve_id": "CVE-1"}, None)),
+    )
+    def test_get_cve_provides_response_from_cve_json_route(
+        self, request_url, m_kwargs, expected_error, FakeConfig
+    ):
+        """GET body from API_V1_CVE_TMPL route with required cve_id."""
+        client = UASecurityClient(FakeConfig())
+        if expected_error:
+            with pytest.raises(expected_error) as exc:
+                client.get_cve(**m_kwargs)
+            assert (
+                "get_cve() missing 1 required positional argument: 'cve_id'"
+            ) == str(exc.value)
+            assert 0 == request_url.call_count
+        else:
+            request_url.return_value = ("body", "headers")
+            cve = client.get_cve(**m_kwargs)
+            assert isinstance(cve, CVE)
+            assert "body" == cve.response
+            assert [
+                mock.call(API_V1_CVE_TMPL.format(cve=m_kwargs["cve_id"]))
+            ] == request_url.call_args_list
+
+    @pytest.mark.parametrize(
+        "m_kwargs,expected_error",
+        (({}, TypeError), ({"notice_id": "USN-1"}, None)),
+    )
+    def test_get_notice_provides_response_from_notice_json_route(
+        self, request_url, m_kwargs, expected_error, FakeConfig
+    ):
+        """GET body from API_V1_NOTICE_TMPL route with required notice_id."""
+        client = UASecurityClient(FakeConfig())
+        if expected_error:
+            with pytest.raises(expected_error) as exc:
+                client.get_notice(**m_kwargs)
+            assert (
+                "get_notice() missing 1 required positional argument:"
+                " 'notice_id'"
+            ) == str(exc.value)
+            assert 0 == request_url.call_count
+        else:
+            request_url.return_value = ("body", "headers")
+            assert "body" == client.get_notice(**m_kwargs).response
+            assert [
+                mock.call(
+                    API_V1_NOTICE_TMPL.format(notice=m_kwargs["notice_id"])
+                )
+            ] == request_url.call_args_list
+
+
+class TestQueryInstalledPkgSources:
+    @pytest.mark.parametrize(
+        "dpkg_out,results",
+        (
+            (
+                "a,1.2,installed\nzip,3.0-1,installed\nb,1.2,config-files",
+                {"a": "1.2", "zip": "3.0-1"},
+            ),
+        ),
+    )
+    @mock.patch("uaclient.security.util.subp")
+    def test_result_keyed_by_source_package_name(
+        self, subp, dpkg_out, results
+    ):
+        subp.return_value = dpkg_out, ""
+        assert results == query_installed_source_pkg_versions()
+        assert [
+            mock.call(
+                [
+                    "dpkg-query",
+                    "-f=${Source},${Version},${db:Status-Status}\n",
+                    "-W",
+                ]
+            )
+        ] == subp.call_args_list


### PR DESCRIPTION
Add a full UASecurityClient to allow querying applicability of CVEs against a running machine.
Add basic `ua fix CVE` subcommand which will introspect the running system against a known CVE and 
report whether or not the CVE affects the given system.

USN handling is non-functional in this PR.

This is a simple spike intended to build very basic functionality and allow us to iterate on CLI flow.
Expect additional PRs to improve functionality for prompt the user about required CVE update actions.


Test steps:
- ua fix --help
```bash
PYTHONPATH=. python3 -m uaclient.cli fix --help
```
- ua fix invalid-value
```bash
PYTHONPATH=. python3 -m uaclient.cli fix USN-bogus
```
- ua fix valid already installed CVE on Focal
```bash
PYTHONPATH=. python3 -m uaclient.cli fix CVE-2020-28196
```
- ua fix dummy "does not affect" response for USNs
```bash
PYTHONPATH=. python3 -m uaclient.cli fix USN-4539-1
```