### PR TITLE
Show errors when behave test fails

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -113,6 +113,11 @@ def when_i_run_command(context, command, user_spec, verify_return=True):
         returncode=result.return_code,
     )
 
+    if verify_return and result.return_code != 0:
+        print("Error executing command: {}".format(command))
+        print("stdout: {}".format(result.stdout))
+        print("stderr: {}".format(result.stderr))
+
     if verify_return:
         assert_that(process.returncode, equal_to(0))
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -16,7 +16,7 @@ except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
 
-APT_HELPER_TIMEOUT = 20.0  # 20 second timeout used for apt-helper call
+APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
 APT_AUTH_COMMENT = "  # ubuntu-advantage-tools"
 APT_CONFIG_AUTH_FILE = "Dir::Etc::netrc/"
 APT_CONFIG_AUTH_PARTS_DIR = "Dir::Etc::netrcparts/"

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -148,7 +148,7 @@ class TestValidAptCredentials:
                 "http://user:pwd@fakerepo/ubuntu/pool/",
                 expected_path,
             ],
-            timeout=20,
+            timeout=60,
         )
         assert [apt_helper_call] == m_subp.call_args_list
 
@@ -219,7 +219,7 @@ class TestValidAptCredentials:
                 "http://user:pwd@fakerepo/ubuntu/pool/",
                 expected_path,
             ],
-            timeout=20,
+            timeout=60,
         )
         assert [apt_helper_call] == m_subp.call_args_list
 


### PR DESCRIPTION
When running the behave tests in Jenkins, it is pretty hard to debug why one of the steps failed. The reason is that we only output that the command returned a status different than 0. Now we are also going to print the stdout and stderr returned by the command in that situation, allowing us to better debug this issue.

Also, the current timeout for apt to download service credentials is 20 seconds. We are bumping that to 60 seconds in an attempt to reduce flaky errors on the Jenkins builds

