### PR TITLE
Block enabling FIPS on clouds using Xenial

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -339,3 +339,35 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                        |
            | bionic  | FIPS         | fips         |https://esm.staging.ubuntu.com/fips/ubuntu bionic/main |
+
+    @series.xenial
+    @uses.config.machine_type.azure.generic
+    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
+        Given a `xenial` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token_staging` with sudo
+        Then I verify that running `ua enable <fips_service> --assume-yes` `with sudo` exits `1`
+        And stdout matches regexp:
+        """
+        Ubuntu Xenial does not provide an Azure optimized FIPS kernel
+        """
+
+        Examples: fips
+           | fips_service  |
+           | fips          |
+           | fips-updates  |
+
+    @series.xenial
+    @uses.config.machine_type.gcp.generic
+    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
+        Given a `xenial` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token_staging` with sudo
+        Then I verify that running `ua enable <fips_service> --assume-yes` `with sudo` exits `1`
+        And stdout matches regexp:
+        """
+        Ubuntu Xenial does not provide a GCP optimized FIPS kernel
+        """
+
+        Examples: fips
+           | fips_service  |
+           | fips          |
+           | fips-updates  |

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -267,6 +267,10 @@ MESSAGE_INCOMPATIBLE_SERVICE_STOPS_ENABLE = """\
 Cannot enable {service_being_enabled} when {incompatible_service} is enabled
 """
 
+MESSAGE_FIPS_BLOCK_ON_CLOUD = """\
+Ubuntu Xenial does not provide {cloud} optimized FIPS kernel
+For help see: https://ubuntu.com/advantage"""
+
 ERROR_INVALID_CONFIG_VALUE = """\
 Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \
 Expected {expected_value}, found {value}."""


### PR DESCRIPTION
Currently, Azure and GCP do not have fips specific kernel versions for the xenial kernel. Because of that, when enabling fips on
those instances, we would end up installing the stock fips kernel on them, which is problematic, since that kernel is not optimized
for those clouds and could generate problems for the user. Therefore, we are now blocking enabling FIPS on Azure and GCP cloud instances.

We are still missing the GCP integration tests and defining what the message will be when we block FIPS because of this problem