### PR TITLE
Override fips metapackage when on bionic cloud

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -143,32 +143,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     @uses.config.machine_type.azure.generic
     Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I create the file `/home/ubuntu/machine-token-overlay.json` with the following:
-        """
-        {
-            "machineTokenInfo": {
-                "contractInfo": {
-                    "resourceEntitlements": [
-                        {
-                            "type": "fips",
-                            "directives": {
-                                "additionalPackages": ["ubuntu-azure-fips"]
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-        """
-        And I append the following on uaclient config:
-        """
-        features:
-          machine_token_overlay: "/home/ubuntu/machine-token-overlay.json"
-        """
-        And I attach `contract_token_staging` with sudo
+        When I attach `contract_token_staging` with sudo
         And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
-        When I run `ua enable <fips-service> --assume-yes` with sudo
+        And I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
             Updating package lists
@@ -243,33 +221,11 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     @uses.config.machine_type.aws.generic
     Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I create the file `/home/ubuntu/machine-token-overlay.json` with the following:
-        """
-        {
-            "machineTokenInfo": {
-                "contractInfo": {
-                    "resourceEntitlements": [
-                        {
-                            "type": "fips",
-                            "directives": {
-                                "additionalPackages": ["ubuntu-aws-fips"]
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-        """
-        And I append the following on uaclient config:
-        """
-        features:
-          machine_token_overlay: "/home/ubuntu/machine-token-overlay.json"
-        """
-        And I attach `contract_token_staging` with sudo
+        When I attach `contract_token_staging` with sudo
         And I run `ua disable livepatch` with sudo
         And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
-        When I run `ua enable <fips-service> --assume-yes` with sudo
+        And I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
             Updating package lists

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -64,7 +64,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         if cloud_id is None:
             return False
 
-        return bool(cloud_id.lower() in ("azure", "gce"))
+        return bool(cloud_id in ("azure", "gce"))
 
     @property
     def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
@@ -105,8 +105,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             return packages
 
         cloud_id = get_cloud_type()
-        if cloud_id and cloud_id.lower() in ("azure", "aws"):
-            return ["ubuntu-{}-fips".format(cloud_id.lower())]
+        if cloud_id and cloud_id in ("azure", "aws"):
+            return ["ubuntu-{}-fips".format(cloud_id)]
 
         return packages
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -422,7 +422,7 @@ class TestFIPSEntitlementEnable:
         assert expected_msg.strip() in fake_stdout.getvalue().strip()
 
     @pytest.mark.parametrize("allow_xenial_fips_on_cloud", ((True), (False)))
-    @pytest.mark.parametrize("cloud_id", (("AWS"), ("GCE"), ("Azure"), (None)))
+    @pytest.mark.parametrize("cloud_id", (("aws"), ("gce"), ("azure"), (None)))
     @pytest.mark.parametrize(
         "series", (("trusty"), ("xenial"), ("bionic"), ("focal"))
     )
@@ -448,7 +448,7 @@ class TestFIPSEntitlementEnable:
         if all(
             [
                 not allow_xenial_fips_on_cloud,
-                cloud_id in ("Azure", "GCE"),
+                cloud_id in ("azure", "gce"),
                 series == "xenial",
             ]
         ):
@@ -749,7 +749,7 @@ class TestFipsEntitlementPackages:
     @pytest.mark.parametrize(
         "series", (("trusty"), ("xenial"), ("bionic"), ("focal"))
     )
-    @pytest.mark.parametrize("cloud_id", (("Azure"), ("AWS"), ("GCE"), (None)))
+    @pytest.mark.parametrize("cloud_id", (("azure"), ("aws"), ("gce"), (None)))
     @mock.patch(M_PATH + "get_cloud_type")
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.apt.get_installed_packages")
@@ -767,7 +767,7 @@ class TestFipsEntitlementPackages:
         m_installed_packages.return_value = []
         packages = entitlement.packages
 
-        if series == "bionic" and cloud_id in ("Azure", "AWS"):
-            assert packages == ["ubuntu-{}-fips".format(cloud_id.lower())]
+        if series == "bionic" and cloud_id in ("azure", "aws"):
+            assert packages == ["ubuntu-{}-fips".format(cloud_id)]
         else:
             assert packages == ["ubuntu-fips"]


### PR DESCRIPTION
Currently, the contract backend will always return the ubuntu-fips metapackage as the package to be installed when we enable fips.
However, we have specific metapackages for Bionic Azure and AWS instances, called ubuntu-aws-fips and ubuntu-azure-fips. Until we do not support that on the contracts backend, we will be performing this override directly on the uaclient code