### PR TITLE
Reboot cmd ordering

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -14,7 +14,10 @@ from hamcrest import (
     contains_string,
 )
 
-from features.environment import create_uat_image
+from features.environment import (
+    USERDATA_BLOCK_AUTO_ATTACH_TESTS,
+    create_uat_image,
+)
 from features.util import SLOW_CMDS, emit_spinner_on_travis, nullcontext
 
 from uaclient.defaults import DEFAULT_CONFIG_FILE
@@ -62,11 +65,16 @@ def given_a_machine(context, series):
     instance_name = (
         CONTAINER_PREFIX + pr_prefix + vm_prefix + series + date_prefix
     )
+    if "pro" in context.config.machine_type:
+        user_data = USERDATA_BLOCK_AUTO_ATTACH_TESTS
+    else:
+        user_data = ""
 
     context.instance = context.config.cloud_manager.launch(
         series=series,
         instance_name=instance_name,
         image_name=context.series_image_name[series],
+        user_data=user_data,
     )
 
     context.container_name = context.config.cloud_manager.get_instance_id(

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -65,6 +65,16 @@ Feature: Command behaviour when attached to an UA subscription
         \s*\*\*\* .* 500
         \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
+        When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
+        """
+        """
+        And I reboot the `<release>` machine
+        And  I verify that running `systemctl status ua-reboot-cmds.service` `as non-root` exits `0,3`
+
+        Then stdout matches regexp:
+            """
+            .*status=0\/SUCCESS.*
+            """
 
         Examples: ubuntu release
            | release | cc-eal-s | cis-s    | esm-a-s | infra-pkg | apps-pkg | fips-s   | lp-s     | lp-d                        |

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -1,25 +1,33 @@
 #!/usr/bin/env python3
 
 """
+Run configuration operations during system boot.
+
 Some uaclient operations cannot be fully completed by running a single
 command. For example, when upgrading uaclient from trusty to xenial,
 we may have a livepatch change in the contract, allowing livepatch to be
 enabled on xenial. However, during the upgrade we cannot install livepatch on
-the system, only after a reboot.
+the system because the running kernel version will not be updated until reboot.
 
-To allow uaclient to postpone commands that need to be executed in a system boot,
-we are using this script, which will basically try to reprocess contract deltas
-on boot time.
+UA client touches a flag file
+/var/lib/ubuntu-advantage/marker-reboot-cmds-required to indicate this script
+should run at next boot to process any pending/unresovled config operations.
 """
+
 import logging
 import os
 import sys
+import time
 
-from uaclient import config, entitlements, status
-from uaclient.exceptions import UserFacingError
+from uaclient import config, contract, entitlements, status
+from uaclient.exceptions import UserFacingError, LockHeldError
 
-from uaclient.util import subp, ProcessExecutionError
+from uaclient.util import subp, ProcessExecutionError, UrlError
 from uaclient.cli import setup_logging, assert_lock_file
+
+# Retry sleep backoff algorithm if lock is held.
+# Lock may be held by auto-attach on systems with ubuntu-advantage-pro.
+SLEEP_RETRIES_ON_LOCK_HELD = [1, 1, 5]
 
 
 def run_command(cmd, cfg):
@@ -42,8 +50,7 @@ def run_command(cmd, cfg):
         sys.exit(1)
 
 
-@assert_lock_file("ua-reboot-fix-pro-pkg-holds")
-def fix_pro_pkg_holds(args, cfg):
+def fix_pro_pkg_holds(cfg):
     status_cache = cfg.read_cache("status-cache")
     if not status_cache:
         return
@@ -63,13 +70,15 @@ def fix_pro_pkg_holds(args, cfg):
                     logging.debug(
                         "Successfully removed Ubuntu Pro FIPS package holds"
                     )
-                except:
+                except Exception as e:
+                    logging.exception(e)
                     logging.warning(
-                        "Failed to remove Ubuntu PRO FIPS package holds"
+                        "Could not remove Ubuntu PRO FIPS package holds"
                     )
                 try:
                     entitlement.install_packages(cleanup_on_failure=False)
                 except UserFacingError as e:
+                    logging.exception(e)
                     logging.warning(
                         "Failed to install packages at boot: {}".format(
                             ", ".join(entitlement.packages)
@@ -79,19 +88,24 @@ def fix_pro_pkg_holds(args, cfg):
                 cfg.remove_notice("", status.MESSAGE_FIPS_REBOOT_REQUIRED)
 
 
-def refresh_contract(args, cfg):
-    cmd = "ua refresh"
-    run_command(cmd=cmd, cfg=cfg)
+def refresh_contract(cfg):
+    try:
+        contract.request_updated_contract(cfg)
+    except UrlError as exc:
+        logging.exception(exc)
+        logging.warning(status.MESSAGE_REFRESH_FAILURE)
+        sys.exit(1)
 
 
-@assert_lock_file("ua-reboot-process-deltas")
-def process_remaining_deltas(args, cfg):
+def process_remaining_deltas(cfg):
     cmd = "/usr/bin/python3 /usr/lib/ubuntu-advantage/upgrade_lts_contract.py"
     run_command(cmd=cmd, cfg=cfg)
     cfg.remove_notice("", status.MESSAGE_LIVEPATCH_LTS_REBOOT_REQUIRED)
 
 
-def main(args, cfg):
+@assert_lock_file("ua-reboot-cmds")
+def process_reboot_operations(args, cfg):
+
     setup_logging(logging.INFO, logging.DEBUG)
     reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
 
@@ -106,9 +120,9 @@ def main(args, cfg):
     if os.path.exists(reboot_cmd_marker_file):
         logging.debug("Running process contract deltas on reboot ...")
 
-        fix_pro_pkg_holds(args, cfg)
-        refresh_contract(args, cfg)
-        process_remaining_deltas(args, cfg)
+        fix_pro_pkg_holds(cfg)
+        refresh_contract(cfg)
+        process_remaining_deltas(cfg)
 
         cfg.delete_cache_key("marker-reboot-cmds")
 
@@ -117,6 +131,29 @@ def main(args, cfg):
         )
 
 
+def main(cfg):
+    """Retry running process_reboot_operations on LockHeldError
+
+    :raises: LockHeldError when lock still held by auto-attach after retries.
+             UserFacingError for all other errors
+    """
+    while True:
+        try:
+            process_reboot_operations(args=None, cfg=cfg)
+            break
+        except LockHeldError as e:
+            logging.debug(
+                "Retrying ua-reboot-cmds {} times on held lock".format(
+                    len(SLEEP_RETRIES_ON_LOCK_HELD)
+                )
+            )
+            if SLEEP_RETRIES_ON_LOCK_HELD:
+                time.sleep(SLEEP_RETRIES_ON_LOCK_HELD.pop(0))
+            else:
+                logging.warning("Lock not released. %s", str(e.msg))
+                sys.exit(1)
+
+
 if __name__ == "__main__":
     cfg = config.UAConfig()
-    main(args=None, cfg=cfg)
+    main(cfg=cfg)

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -14,16 +14,14 @@ https://esm.ubuntu.com/ubuntu
 
 While on Xenial, the apt url is:
 
-https://esm.ubuntu.com/infra/ubuntu 
+https://esm.ubuntu.com/infra/ubuntu
 
 This script will detect differences like that and update the Xenial system
 to reflect them.
 """
 
 import time
-import contextlib
 import logging
-import os
 import sys
 
 from uaclient.cli import setup_logging
@@ -75,8 +73,7 @@ def process_contract_delta_after_apt_lock() -> None:
 
     retry_count = 0
     while out:
-        # Loop until that apt hold is released (at the end of the do-release-upgrade operation
-        # when a reboot is suggested)
+        # Loop until apt hold is released at the end of `do-release-upgrade`
         time.sleep(10)
         out, _err = subp(["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1])
         retry_count += 1

--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Ubuntu Advantage auto attach
 Before=cloud-config.service
-WantedBy=cloud-config.service
 
 [Service]
 Type=oneshot
@@ -9,4 +8,4 @@ ExecStart=/usr/bin/ua auto-attach
 TimeoutSec=0
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-config.service multi-user.target

--- a/systemd/ua-reboot-cmds.service
+++ b/systemd/ua-reboot-cmds.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Ubuntu Advantage reboot cmds
 ConditionPathExists=/var/lib/ubuntu-advantage/marker-reboot-cmds-required
+Wants=ua-auto-attach.service
+After=ua-auto-attach.service
 
 [Service]
 Type=oneshot

--- a/tox.ini
+++ b/tox.ini
@@ -41,13 +41,13 @@ setenv =
     vm: UACLIENT_BEHAVE_MACHINE_TYPE = lxd.vm
 commands =
     py3: py.test --junitxml=pytest_results.xml {posargs:--cov uaclient uaclient}
-    flake8: flake8 uaclient setup.py
+    flake8: flake8 uaclient lib setup.py
     flake8-bionic: flake8 features
     mypy: mypy --python-version 3.4 uaclient/
     mypy: mypy --python-version 3.5 uaclient/
     mypy: mypy --python-version 3.6 uaclient/ features/
     mypy-focal: mypy --python-version 3.7 uaclient/ features/
-    black: black --check --diff uaclient/ features/ setup.py
+    black: black --check --diff uaclient/ features/ lib/ setup.py
     behave-lxd-14.04: behave -v {posargs} --tags="series.trusty,series.all"  --tags="~upgrade"
     behave-lxd-16.04: behave -v {posargs} --tags="series.xenial,series.all" --tags="~upgrade"
     behave-lxd-18.04: behave -v {posargs} --tags="series.bionic,series.all" --tags="~upgrade"

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -58,8 +58,6 @@ class LockHeldError(UserFacingError):
 
     def __init__(self, lock_request: str, lock_holder: str, pid: int):
         lock_request = lock_request
-        lock_holder = lock_holder
-        pid = pid
         msg = "Unable to perform: {lock_request}.\n".format(
             lock_request=lock_request
         )


### PR DESCRIPTION
Fix multiple system unit issues with reboot cmds:

* Make system unit ordering explicit to avoid lockhelderror collisions by adding the following
  which orders ua-reboot-cmds after auto-attach:
    Add Wants=ua-auto-attach.service
    After=ua-auto-attach.service

* Fix ua-auto-attach.service moving WantedBy=cloud-config.service out of Unit and into Install section
* Add flake and black style checks of lib/ directory
* Add 3 retries on lock_held error in lib/reboot_cmds.py because auto-attach may still be running.

Fixes: #1331