### PR TITLE
Fix trusty upgrade test

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -47,7 +47,7 @@ Feature: Command behaviour when attached to an UA subscription
            | xenial  |
 
     @series.all
-    Scenario Outline: Attached disable of an unknown service in a ubuntu machine
+    Scenario Outline: Attached disable of a service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua disable foobar` `as non-root` exits `1`
@@ -61,12 +61,27 @@ Feature: Command behaviour when attached to an UA subscription
             Cannot disable unknown service 'foobar'.
             Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch
             """
+        And I verify that running `ua disable esm-infra` `as non-root` exits `1`
+        And stderr matches regexp:
+            """
+            This command must be run as root \(try using sudo\)
+            """
+        When I run `ua disable esm-infra` with sudo
+        Then I will see the following on stdout:
+            """
+            Updating package lists
+            """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+            """
+            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance \(ESM\)
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
 
         Examples: ubuntu release
            | release |
            | bionic  |
            | focal   |
-           | trusty  |
            | xenial  |
 
     @series.all
@@ -236,39 +251,22 @@ Feature: Command behaviour when attached to an UA subscription
            | trusty  |
            | xenial  |
 
-    @series.xenial
-    @series.bionic
-    @series.focal
-    Scenario Outline: Attached disable of an already enabled service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua disable esm-infra` `as non-root` exits `1`
-        And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\)
-            """
-        When I run `ua disable esm-infra` with sudo
-        Then I will see the following on stdout:
-            """
-            Updating package lists
-            """
-        When I run `ua status` with sudo
-        Then stdout matches regexp:
-            """
-            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance \(ESM\)
-            """
-
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-
     @series.trusty
     Scenario: Attached disable of an already enabled service in a trusty machine
         Given a `trusty` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `ua disable esm-infra` `as non-root` exits `1`
+        Then I verify that running `ua disable foobar` `as non-root` exits `1`
+        And stderr matches regexp:
+            """
+            This command must be run as root \(try using sudo\)
+            """
+        And I verify that running `ua disable foobar` `with sudo` exits `1`
+        And stderr matches regexp:
+            """
+            Cannot disable unknown service 'foobar'.
+            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch
+            """
+        And I verify that running `ua disable esm-infra` `as non-root` exits `1`
         And stderr matches regexp:
             """
             This command must be run as root \(try using sudo\)

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -16,6 +16,16 @@ Feature: Enable command behaviour when attached to an UA subscription
             One moment, checking your subscription first
             <msg>
             """
+        And I verify that running `ua enable cc-eal` `with sudo` exits `1`
+        And I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable unknown service 'cc-eal'.
+            Try esm-infra, fips, fips-updates, livepatch
+            """
 
         Examples: ubuntu release
            | release | msg                                                            |
@@ -148,38 +158,6 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.all
     @uses.config.machine_type.lxd.container
-    Scenario Outline: Attached enable a disabled, enable and unknown service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua enable livepatch esm-infra foobar` `as non-root` exits `1`
-        And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        And I verify that running `ua enable livepatch esm-infra foobar` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Cannot install Livepatch on a container
-            ESM Infra is already enabled.
-            See: sudo ua status
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar'.
-            Try esm-infra, fips, fips-updates, livepatch
-            """
-
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | trusty  |
-           | xenial  |
-
-
-    @series.all
-    @uses.config.machine_type.lxd.container
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -209,31 +187,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | xenial  | livepatch    | Livepatch    |              |
            | xenial  | fips         | FIPS         | --assume-yes |
            | xenial  | fips-updates | FIPS Updates | --assume-yes |
-
-    @series.all
-    Scenario Outline:  Attached enable of non-container beta services in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
-        And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        And I verify that running `ua enable cc-eal` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable unknown service 'cc-eal'.
-            Try esm-infra, fips, fips-updates, livepatch
-            """
-           | release |
-           | bionic  |
-           | focal   |
-           | trusty  |
-           | xenial  |
 
     @series.all
     Scenario Outline: Attached enable not entitled service in a ubuntu machine

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -177,7 +177,7 @@ def when_i_reboot_the_machine(context, series):
         context.instance.shutdown(wait=True)
         context.instance.start(wait=False)
         # Trusty -> Xenial upgrades would raise a Paths no run_dir attr failure
-        context.instance.wait(raise_on_cloudinit_failure=False)
+        context.instance.wait()
     else:
         context.instance.restart(wait=True)
 


### PR DESCRIPTION
When rebooting the machine on trusty, we were using the raise_on_failure as False to not raise exceptions if cloud-init failed to successfully complete. However, pycloudlib does not throw those exceptions anymore and no longer support that parameter
either. We are removing it from the method call.

Also, some of our integration tests are redundant, in the sense that they are already being test by other scenario or they can be integrated into an existing test. We are now removing those redundant tests.