### PR TITLE
Remove expiry check from contract update

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import logging
 import urllib
 
@@ -348,7 +347,7 @@ def request_updated_contract(
     contract_client = UAContractClient(cfg)
     if contract_token:  # We are a mid ua-attach and need to get machinetoken
         try:
-            new_token = contract_client.request_contract_machine_attach(
+            contract_client.request_contract_machine_attach(
                 contract_token=contract_token
             )
         except util.UrlError as e:
@@ -369,15 +368,9 @@ def request_updated_contract(
     else:
         machine_token = orig_token["machineToken"]
         contract_id = orig_token["machineTokenInfo"]["contractInfo"]["id"]
-        new_token = contract_client.request_machine_token_update(
+        contract_client.request_machine_token_update(
             machine_token=machine_token, contract_id=contract_id
         )
-    expiry = new_token["machineTokenInfo"]["contractInfo"].get("effectiveTo")
-    if expiry:
-        if datetime.strptime(expiry, "%Y-%m-%dT%H:%M:%SZ") < datetime.utcnow():
-            raise exceptions.UserFacingError(
-                status.MESSAGE_CONTRACT_EXPIRED_ERROR
-            )
 
     process_entitlements_delta(
         orig_entitlements, cfg.entitlements, allow_enable

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -218,7 +218,8 @@ STATUS_HEADER = "SERVICE       ENTITLED  STATUS    DESCRIPTION"
 STATUS_TMPL = "{name: <14}{entitled: <19}{status: <19}{description}"
 
 MESSAGE_ATTACH_EXPIRED_TOKEN = """\
-Expired token. To obtain a new token visit: https://ubuntu.com/advantage"""
+Expired token or contract. To obtain a new token visit: \
+https://ubuntu.com/advantage"""
 MESSAGE_ATTACH_INVALID_TOKEN = """\
 Invalid token. See https://ubuntu.com/advantage"""
 MESSAGE_ATTACH_REQUIRES_TOKEN = """\
@@ -232,9 +233,6 @@ MESSAGE_ATTACH_SUCCESS_TMPL = """\
 This machine is now attached to '{contract_name}'
 """
 
-MESSAGE_CONTRACT_EXPIRED_ERROR = """\
-Subscription has expired
-To obtain a token please visit: https://ubuntu.com/advantage"""
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} unknown service '{name}'.
 {service_msg}"""


### PR DESCRIPTION
The contract backend will now allow contract token that have expired to keep working for 14 days. Also, the contract
backend already covers the situation were the contract is no longer valid, which will return a 403 error that is already
treated in the code. Because of that, we are dropping the expiry check for contracts

fix #1335 