### PR TITLE
notices: clear lock file and notice when encountering any exception

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -50,10 +50,10 @@ DEFAULT_LOG_FORMAT = (
 STATUS_FORMATS = ["tabular", "json"]
 
 
-# Set a module-level variable here so we don't have to reinstantiate
+# Set a module-level callable here so we don't have to reinstantiate
 # UAConfig in order to determine dynamic data_path exception handling of
 # main_error_handler
-_LOCK_FILE = None
+_CLEAR_LOCK_FILE = None
 
 
 class UAArgumentParser(argparse.ArgumentParser):
@@ -121,8 +121,7 @@ def assert_lock_file(lock_holder=None):
     def wrapper(f):
         @wraps(f)
         def new_f(args, cfg, **kwargs):
-            global _LOCK_FILE
-            lock_file = cfg.data_path("lock")
+            global _CLEAR_LOCK_FILE
             (lock_pid, cur_lock_holder) = cfg.check_lock_info()
             if lock_pid > 0:
                 raise exceptions.LockHeldError(
@@ -133,10 +132,10 @@ def assert_lock_file(lock_holder=None):
             cfg.write_cache("lock", "{}:{}".format(os.getpid(), lock_holder))
             notice_msg = "Operation in progress: {}".format(lock_holder)
             cfg.add_notice("", notice_msg)
-            _LOCK_FILE = lock_file  # Set _LOCK_FILE for cleanup
+            _CLEAR_LOCK_FILE = cfg.delete_cache_key
             retval = f(args, cfg, **kwargs)
-            util.remove_file(lock_file)
-            cfg.remove_notice("", notice_msg)
+            cfg.delete_cache_key("lock")
+            _CLEAR_LOCK_FILE = None  # Unset due to successful lock delete
             return retval
 
         return new_f
@@ -940,8 +939,8 @@ def main_error_handler(func):
             with util.disable_log_to_console():
                 logging.exception("KeyboardInterrupt")
             print("Interrupt received; exiting.", file=sys.stderr)
-            if _LOCK_FILE:
-                util.remove_file(_LOCK_FILE)
+            if _CLEAR_LOCK_FILE:
+                _CLEAR_LOCK_FILE("lock")
             sys.exit(1)
         except util.UrlError as exc:
             with util.disable_log_to_console():
@@ -952,19 +951,23 @@ def main_error_handler(func):
                     msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_TMPL
                 logging.exception(msg_tmpl.format(**msg_args))
             print(ua_status.MESSAGE_CONNECTIVITY_ERROR, file=sys.stderr)
+            if _CLEAR_LOCK_FILE:
+                _CLEAR_LOCK_FILE("lock")
             sys.exit(1)
         except exceptions.UserFacingError as exc:
             with util.disable_log_to_console():
                 logging.exception(exc.msg)
             print("{}".format(exc.msg), file=sys.stderr)
-            if _LOCK_FILE:
-                util.remove_file(_LOCK_FILE)
+            if _CLEAR_LOCK_FILE:
+                if not isinstance(exc, exceptions.LockHeldError):
+                    # Only clear the lock if it is ours.
+                    _CLEAR_LOCK_FILE("lock")
             sys.exit(exc.exit_code)
         except Exception:
             with util.disable_log_to_console():
                 logging.exception("Unhandled exception, please file a bug")
-            if _LOCK_FILE:
-                util.remove_file(_LOCK_FILE)
+            if _CLEAR_LOCK_FILE:
+                _CLEAR_LOCK_FILE("lock")
             print(ua_status.MESSAGE_UNEXPECTED_ERROR, file=sys.stderr)
             sys.exit(1)
 


### PR DESCRIPTION
When the commandline encounters an unexpected error, the
main_error_handler needs to call UAConfig.delete_cache_key("lock")
to ensure any Operation in progress notices messages are also
removed. This most often happens during auto-attach on PRO machines
because it raises a UserFacingError saying:

This machine is already attached to <some-account>

Since main_error_handler doesn't have direct access to an
instantiated UAConfig, we store that UAConfig.delte_cache_key
callable on _CLEAR_LOCK_FILE

Fixes: #1326

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

* Launch an Ubuntu PRO Machine with this branch
```bash
UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_DESTROY_INSTANCES=0 
UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID=<YOUR_AWS_ACCESS_KEY_ID>  UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY=<YOUR_AWS_SECRET_ACCESS_KEY> tox -e behave-awspro-18.04 
--no-capture
```
* That run should leave around a test PRO bionic instance lying around after test, you can ssh to it with your ec2-uaclient-ci-0127-dev-0126-220857.pem in the local directory
`ls -ltr ec2*pem`
* Reboot the machine and run status afterward to confirm no "Operation in progress: auto-attach" message 
```bash
ssh -i ec2.....pem ubuntu@<PRO_IP_ADDRESS>  sudo reboot
ssh -i ec2.....pem ubuntu@<PRO_IP_ADDRESS>  sudo ua status

```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly