### PR TITLE
Block enabling fips on GCP instances

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -312,18 +312,21 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
            | fips          |
            | fips-updates  |
 
+    @series.bionic
     @series.xenial
     @uses.config.machine_type.gcp.generic
-    Scenario Outline: Attached enable of vm-based services in an ubuntu lxd vm
-        Given a `xenial` machine with ubuntu-advantage-tools installed
+    Scenario Outline: Attached enable of fips services in an ubuntu gcp vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
         Then I verify that running `ua enable <fips_service> --assume-yes` `with sudo` exits `1`
         And stdout matches regexp:
         """
-        Ubuntu Xenial does not provide a GCP optimized FIPS kernel
+        Ubuntu <release_title> does not provide a GCP optimized FIPS kernel
         """
 
         Examples: fips
-           | fips_service  |
-           | fips          |
-           | fips-updates  |
+            | release | release_title | fips_service  |
+            | xenial  | Xenial        | fips          |
+            | xenial  | Xenial        | fips-updates  |
+            | bionic  | Bionic        | fips          |
+            | bionic  | Bionic        | fips-updates  |

--- a/features/environment.py
+++ b/features/environment.py
@@ -218,7 +218,7 @@ class UAClientBehaveConfig:
                 )
                 setattr(self, attr_name, None)
         timed_job_tag = datetime.datetime.utcnow().strftime(
-            "uaclient-ci-%m%d-"
+            "uaclient-ci-%m%d-%H%M-"
         )
         # Jenkinsfile provides us with UACLIENT_BEHAVE_JENKINS_BUILD_TAG
         job_suffix = os.environ.get("UACLIENT_BEHAVE_JENKINS_BUILD_TAG")

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -100,6 +100,7 @@ def given_a_machine(context, series):
                 )
 
     context.add_cleanup(cleanup_instance)
+    print("--- instance ip: {}".format(context.instance.ip))
 
 
 @when("I run `{command}` {user_spec}")

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -266,9 +266,8 @@ Cannot enable {service_being_enabled} when {incompatible_service} is enabled
 """
 
 MESSAGE_FIPS_BLOCK_ON_CLOUD = """\
-Ubuntu Xenial does not provide {cloud} optimized FIPS kernel
+Ubuntu {series} does not provide {cloud} optimized FIPS kernel
 For help see: https://ubuntu.com/advantage"""
-
 ERROR_INVALID_CONFIG_VALUE = """\
 Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \
 Expected {expected_value}, found {value}."""


### PR DESCRIPTION
Currently, we do not have a gcp optimized fips kernel. Installing the default fips kernel on those instances could case
performance or even system issues. Because of that, we are now blocking enabling fips on those instances until we have the
optimized kernel for gcp.

We can override this behavior but adding the following directive into `uaclient.conf`:
```
allow_default_fips_metapackage_on_gcp: true
```

Fix #1317 