### PR TITLE
Check proc file to verify if fips is enabled in a machine

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -100,8 +100,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
-        fips         +yes      +n/a      +NIST-certified FIPS modules
-        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
+        fips         +yes      +<fips_status>      +NIST-certified FIPS modules
+        fips-updates +yes      +<fips_status>      +Uncertified security updates to FIPS modules
         livepatch    +yes      +<lp_status>  +<lp_desc>
         """
         And stderr matches regexp:
@@ -110,11 +110,11 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
 
         Examples: ubuntu release livepatch status
-           | release | lp_status | lp_desc                       |
-           | trusty  | n/a       | Available with the HWE kernel |
-           | xenial  | enabled   | Canonical Livepatch service   |
-           | bionic  | enabled   | Canonical Livepatch service   |
-           | focal   | enabled   | Canonical Livepatch service   |
+           | release | fips_status |lp_status | lp_desc                       |
+           | trusty  | n/a         |n/a       | Available with the HWE kernel |
+           | xenial  | disabled    |enabled   | Canonical Livepatch service   |
+           | bionic  | disabled    |enabled   | Canonical Livepatch service   |
+           | focal   | n/a         |enabled   | Canonical Livepatch service   |
 
     @series.all
     @uses.config.machine_type.azure.generic

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -205,12 +205,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         .*Installed: \(none\)
         """
         When I reboot the `<release>` machine
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        0
-        """
-        And I verify that `openssh-server` installed version matches regexp `fips`
+        Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
         And I verify that `strongswan` installed version matches regexp `fips`
         And I verify that `openssh-server-hmac` installed version matches regexp `fips`
@@ -223,6 +218,11 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         openssh-server was already not hold.
         strongswan was already not hold.
         """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                disabled
+            """
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                        |
@@ -284,12 +284,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         .*Installed: \(none\)
         """
         When I reboot the `<release>` machine
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        0
-        """
-        And I verify that `openssh-server` installed version matches regexp `fips`
+        Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
         And I verify that `strongswan` installed version matches regexp `fips`
         And I verify that `openssh-server-hmac` installed version matches regexp `fips`
@@ -302,6 +297,11 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         openssh-server was already not hold.
         strongswan was already not hold.
         """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                disabled
+            """
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                        |

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -310,3 +310,68 @@ Feature: Enable command behaviour when attached to an UA staging subscription
            | release |
            | bionic  |
            | xenial  |
+
+    @series.xenial
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attached enable fips-updates on fips enabled vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token_staging` with sudo
+        And I run `ua disable livepatch` with sudo
+        And I run `apt-get install openssh-client openssh-server strongswan -y` with sudo, retrying exit [100]
+        And I run `ua enable fips --assume-yes` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing FIPS packages
+            FIPS enabled
+            A reboot is required to complete install
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            fips +yes                enabled
+            """
+        When I reboot the `<release>` machine
+        And  I run `ua enable fips-updates --assume-yes` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            fips +yes                n/a
+            """
+        And stdout matches regexp:
+            """
+            fips-updates +yes                enabled
+            """
+        When I reboot the `<release>` machine
+        Then I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `ubuntu-fips` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+        When  I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            fips
+            """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+
+        Examples: ubuntu release
+           | release | fips-apt-source                                                        |
+           | xenial  | https://esm.staging.ubuntu.com/fips-updates/ubuntu xenial-updates/main |
+           | bionic  | https://esm.staging.ubuntu.com/fips-updates/ubuntu bionic-updates/main |

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -107,12 +107,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         .*Installed: \(none\)
         """
         When I reboot the `<release>` machine
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        0
-        """
-        And I verify that `openssh-server` installed version matches regexp `fips`
+        Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
         And I verify that `strongswan` installed version matches regexp `fips`
         And I verify that `openssh-server-hmac` installed version matches regexp `fips`
@@ -125,6 +120,11 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         openssh-server was already not hold.
         strongswan was already not hold.
         """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                disabled
+            """
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                        |
@@ -178,12 +178,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             A reboot is required to complete disable operation
             """
         When I reboot the `<release>` machine
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        0
-        """
-        And I verify that `openssh-server` installed version matches regexp `fips`
+        Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
         And I verify that `strongswan` installed version matches regexp `fips`
         And I verify that `openssh-server-hmac` installed version matches regexp `fips`
@@ -196,6 +191,11 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         openssh-server was already not hold.
         strongswan was already not hold.
         """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                disabled
+            """
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                                        |

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -24,8 +24,8 @@ Feature: Command behaviour when attached to an UA subscription
             cis           +yes  +<cis-s>  +Center for Internet Security Audit Tools
             esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
-            fips          +yes +disabled +NIST-certified FIPS modules
-            fips-updates  +yes +disabled +Uncertified security updates to FIPS modules
+            fips          +yes +<fips-s> +NIST-certified FIPS modules
+            fips-updates  +yes +<fips-s> +Uncertified security updates to FIPS modules
             livepatch     +yes +enabled  +Canonical Livepatch service
             """
         When I run `apt-cache policy` with sudo
@@ -77,10 +77,10 @@ Feature: Command behaviour when attached to an UA subscription
             """
 
         Examples: ubuntu release
-           | release | cc-eal-s | cis-s    | infra-pkg | apps-pkg |
-           | xenial  | disabled | disabled | libkrad0  | jq       |
-           | bionic  | n/a      | disabled | libkrad0  | bundler  |
-           | focal   | n/a      | n/a      | hello     | ant      |
+           | release | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg |
+           | xenial  | disabled | disabled | disabled | libkrad0  | jq       |
+           | bionic  | disabled | n/a      | disabled | libkrad0  | bundler  |
+           | focal   | n/a      | n/a      | n/a      | hello     | ant      |
 
     @series.xenial
     @series.bionic


### PR DESCRIPTION
## Proposed Commit Message
Update check that verifies if fips is enabled

Currently, we to check if fips is enabled, we verify if the fips apt sources are present in the system and the fips kernel is being used. However, if the /proc/sys/crypto/fips_enabled file doesn't exist or is set to 0, the system will not be on fips mode. Because of that, we are checking the proc file instead of the running kernel to dictate if fips is enabled or not.

We are also updating our fips tests:

* We are no longer checking for the `/proc/sys/crypti/fips_enabled`  file after disabling fips
* Adding a test for enabling fips-updates on fips enabled machine

Fix: #1345 

## Test Steps
Just run the integration tests in this PR

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
