### PR TITLE
fips: add notice if running a deactivated FIPS kernel

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -170,7 +170,7 @@ class UAConfig:
                 notices.append((notice_label, notice_descr))
         if notices:
             self.write_cache("notices", notices)
-        else:
+        elif os.path.exists(self.data_path("notices")):
             util.remove_file(self.data_path("notices"))
 
     @property

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -164,18 +164,21 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     def application_status(self) -> "Tuple[status.ApplicationStatus, str]":
         super_status, super_msg = super().application_status()
-        if super_status != status.ApplicationStatus.ENABLED:
-            return super_status, super_msg
 
         if os.path.exists(self.FIPS_PROC_FILE):
             if util.load_file(self.FIPS_PROC_FILE).strip() == "1":
+                self.cfg.remove_notice(
+                    "", status.NOTICE_FIPS_MANUAL_DISABLE_URL
+                )
                 return super_status, super_msg
             else:
+                self.cfg.add_notice("", status.NOTICE_FIPS_MANUAL_DISABLE_URL)
                 return (
                     status.ApplicationStatus.DISABLED,
                     "{} is not set to 1".format(self.FIPS_PROC_FILE),
                 )
-
+        if super_status != status.ApplicationStatus.ENABLED:
+            return super_status, super_msg
         return (
             status.ApplicationStatus.ENABLED,
             "Reboot to FIPS kernel required",

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -187,6 +187,10 @@ MESSAGE_LIVEPATCH_LTS_REBOOT_REQUIRED = (
 MESSAGE_FIPS_REBOOT_REQUIRED = (
     "FIPS support requires system reboot to complete configuration."
 )
+NOTICE_FIPS_MANUAL_DISABLE_URL = """\
+FIPS kernel is running in a disabled state.
+  To manually remove fips kernel: https://discourse.ubuntu.com/t/20738
+"""
 PROMPT_FIPS_PRE_ENABLE = (
     """\
 Installation of additional packages are required to make this system FIPS


### PR DESCRIPTION
## Proposed Commit Message
Point to discourse documentation in notice messaging for
manual steps to remove the FIPS kernel from the system.

Fixes: #1348

## Test Steps
from this branch root:
```bash
git diff upstream/master > fips.patch
multipass launch daily:bionic -n dev-b
multipass transfer fips.patch dev-b:.
multipass connect dev-b
cd /usr/lib/python3/dist-packages/
sudo add-apt-repository ppa:canonical-server/ua-client-daily
sudo apt-get update
sudo apt-get install ubuntu-advantage-tools
sudo patch -p1 < /home/ubuntu/fips.patch
sudo ua attach <TOKEN>
sudo ua enable fips
sudo reboot
multipass connect dev-b
sudo ua status   # check that status says enabled
sudo ua disable fips
sudo reboot 
sudo ua status  # should show notice about FIPS in disabled state
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
