### PR TITLE
Fix auto-attach issue when comparing numeric iid

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -658,7 +658,7 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
     current_iid = identity.get_instance_id()
     if cfg.is_attached:
         prev_iid = cfg.read_cache("instance-id")
-        if current_iid == prev_iid:
+        if str(current_iid) == str(prev_iid):
             raise exceptions.AlreadyAttachedError(cfg)
         print("Re-attaching Ubuntu Advantage subscription on new instance")
         if _detach(cfg, assume_yes=True) != 0:


### PR DESCRIPTION
Given an attached machine, when we run auto-attach we verify if the current instance id matches the instance id in the uaclient
cache. If they do not match, we proceed with the auto-attach. If the instance id could be converted to a number we would have a problem, since we read the old instance id from a json file, which automatically converts the instance id to int while the current instance id always returns a string. Even if the instance id matches, we would say that they don't because of the type difference.
We are fixing that type mismatch comparison now

## Proposed Commit Message
Fix auto-attach issue when comparing numeric iid

## Test Steps
Run the new unit test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [x] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
