### PR TITLE
gcp: update gcp ids for 26.0.1

### DIFF
--- a/features/gcp-ids.yaml
+++ b/features/gcp-ids.yaml
@@ -1,3 +1,3 @@
-xenial: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-1604-xenial-v20210128"
-bionic: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-1804-bionic-v20210128"
-focal: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-2004-focal-v20210128"
+xenial: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-1604-xenial-v20210205"
+bionic: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-1804-bionic-v20210205"
+focal: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-2004-focal-v20210205"


### PR DESCRIPTION
## Proposed Commit Message
gcp: update PRO image ids for integration testing of 26.0.1 release

Product images were published 02/05/2021 and can now be exercised
by our integration tests.

## Test Steps
UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_DEBS_PATH=/root/ubuntu-advantage-client/DEBS tox -e behave-gcppro-18.04 -- --no-capture --no-color --format=plain

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
