### PR TITLE
integration: block auto-attach on PRO base images

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -31,10 +31,6 @@ bootcmd:
  - cp /usr/bin/ua /usr/bin/ua.orig
  - 'echo "#!/bin/sh\ndate >> /root/ua-calls\n" > /usr/bin/ua'
  - chmod 755 /usr/bin/ua
-"""
-
-USERDATA_BLOCK_AUTO_ATTACH_TESTS = """\
-#cloud-config
 write_files:
   - path: /etc/ubuntu-advantage/uaclient.conf
     content: |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -15,10 +15,7 @@ from hamcrest import (
     contains_string,
 )
 
-from features.environment import (
-    USERDATA_BLOCK_AUTO_ATTACH_TESTS,
-    create_uat_image,
-)
+from features.environment import create_uat_image
 from features.util import SLOW_CMDS, emit_spinner_on_travis, nullcontext
 
 from uaclient.defaults import DEFAULT_CONFIG_FILE
@@ -66,16 +63,11 @@ def given_a_machine(context, series):
     instance_name = (
         CONTAINER_PREFIX + pr_prefix + vm_prefix + series + date_prefix
     )
-    if "pro" in context.config.machine_type:
-        user_data = USERDATA_BLOCK_AUTO_ATTACH_TESTS
-    else:
-        user_data = ""
 
     context.instance = context.config.cloud_manager.launch(
         series=series,
         instance_name=instance_name,
         image_name=context.series_image_name[series],
-        user_data=user_data,
     )
 
     context.container_name = context.config.cloud_manager.get_instance_id(


### PR DESCRIPTION
## Proposed Commit Message
integration: block auto-attach on PRO base images

Currently, we only create the disable_auto_attach entry on uaclient.conf when we are launching the test image. This is not working on trusty because cloud-init is editing that file after we have already run the auto-attach script. Therefore, we are moving the creation of this directive to the base image (the one that will be snapshoted), which will guarantee that the directive will be there once the test image runs

## Test Steps
Run both AWS and Azure trusty PRO integration tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
