### PR TITLE
Check machine id on detach from machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+artifacts/*
 *debhelper*
 debian/ubuntu-advantage-tools/
 debian/ubuntu-advantage-tools.substvars

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,7 @@ pipeline {
             parallel {
                 stage ('Package build: 14.04') {
                     environment {
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "trusty"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
@@ -88,7 +89,7 @@ pipeline {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~14.04 ../ubuntu-advantage-tools*.dsc
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~14.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
                         cp ./ubuntu-advantage-tools*14.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
                         cp ./ubuntu-advantage-pro*14.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
@@ -96,6 +97,7 @@ pipeline {
                 }
                 stage ('Package build: 16.04') {
                     environment {
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "xenial"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
@@ -103,7 +105,7 @@ pipeline {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~16.04 ../ubuntu-advantage-tools*.dsc
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~16.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
                         cp ./ubuntu-advantage-tools*16.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
                         cp ./ubuntu-advantage-pro*16.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
@@ -111,6 +113,7 @@ pipeline {
                 }
                 stage ('Package build: 18.04') {
                     environment {
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "bionic"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
@@ -118,7 +121,7 @@ pipeline {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~18.04 ../ubuntu-advantage-tools*.dsc
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~18.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
                         cp ./ubuntu-advantage-tools*18.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
                         cp ./ubuntu-advantage-pro*18.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''
@@ -126,6 +129,7 @@ pipeline {
                 }
                 stage ('Package build: 20.04') {
                     environment {
+                        PKG_VERSION = sh(returnStdout: true, script: "dpkg-parsechangelog --show-field Version").trim()
                         BUILD_SERIES = "focal"
                         ARTIFACT_DIR = "${TMPDIR}${BUILD_SERIES}"
                     }
@@ -133,7 +137,7 @@ pipeline {
                         sh '''
                         set -x
                         mkdir ${ARTIFACT_DIR}
-                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~20.04 ../ubuntu-advantage-tools*.dsc
+                        sbuild --nolog --verbose --dist=${BUILD_SERIES} --no-run-lintian --append-to-version=~20.04 ../ubuntu-advantage-tools*${PKG_VERSION}*.dsc
                         cp ./ubuntu-advantage-tools*20.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-tools-${BUILD_SERIES}.deb
                         cp ./ubuntu-advantage-pro*20.04*.deb ${ARTIFACT_DIR}/ubuntu-advantage-pro-${BUILD_SERIES}.deb
                         '''


### PR DESCRIPTION
## Proposed Commit Message
contract: check machine id on detach

When we running a detach operation we also call the contracts backend to delete the machine from there as well. However, if we detect a machine id change in the system, that call will not succeed, failing the entire operation. To avoid that, we are now checking if the machine id in the cache and current machine id match before doing the detach call to the contracts backend

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
