### PR TITLE
Fix bionic vm test when enable fips with livepatch

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -356,6 +356,9 @@ Feature: Enable command behaviour when attached to an UA subscription
         And I will see the following on stdout
             """
             One moment, checking your subscription first
+            """
+        And I will see the following on stderr
+            """
             Cannot enable FIPS when Livepatch is enabled
             """
 


### PR DESCRIPTION
## Proposed Commit Message
Fix bionic vm test when enable fips with livepatch

We have a bionic vm test where we enable livepatch and we try to enable fips afterwards. On that scenario, we also create a uaclient.conf directive to block disabling services on enable operations. We want to verify if in that situation, fips is not enabled
becaused livepatch is. However, we are checking the error message on stdout, but with the new incompatible services
abstraction, that message will be on stderr if we have the uaclient.conf directive

## Test Steps
Run the modifed integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [x] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
