### PR TITLE
util: use lru_cache to avoid re-reading os-release and machine-id

### DIFF
--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -10,7 +10,7 @@ from urllib import error, request
 from urllib.parse import urlparse
 import uuid
 from contextlib import contextmanager
-from functools import wraps
+from functools import lru_cache, wraps
 from http.client import HTTPMessage  # noqa: F401
 
 from uaclient import exceptions
@@ -288,6 +288,7 @@ def get_dict_deltas(
     return deltas
 
 
+@lru_cache(maxsize=None)
 def get_machine_id(data_dir: str) -> str:
     """Get system's unique machine-id or create our own in data_dir."""
     # Generate, cache our own uuid if not present on the system
@@ -348,6 +349,7 @@ def get_platform_info() -> "Dict[str, str]":
     return platform_info
 
 
+@lru_cache(maxsize=None)
 def is_container(run_path: str = "/run") -> bool:
     """Checks to see if this code running in a container of some sort"""
     try:
@@ -385,6 +387,7 @@ def load_file(filename: str, decode: bool = True) -> str:
     return content.decode("utf-8")
 
 
+@lru_cache(maxsize=None)
 def parse_os_release(release_file: "Optional[str]" = None) -> "Dict[str, str]":
     if not release_file:
         release_file = "/etc/os-release"


### PR DESCRIPTION
## Proposed Commit Message
Use functools lru_cache to avoid repeated reading of files that will
not change except across reboot. This cuts down both on noisy
Reading file messages and costly, repeated processing of the same
static responses.

Fixes: #1329

## Test Steps
run the following in your cwd and expect to only see one log message on the console (because we are caching the response)
DEBUG: Reading file: /etc/machine-id

```bash
cat > test.py <<EOF
from uaclient.cli import setup_logging
from uaclient.util import get_machine_id
import logging
setup_logging(logging.DEBUG, logging.DEBUG, "/tmp/uaclient-test.log")

get_machine_id("/does/not/exist")
get_machine_id("/does/not/exist")
EOF
 PYTHONPATH=. python3 test.py
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
