### PR TITLE
fix: make subcommand public and remove --beta required flag

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -127,7 +127,7 @@ Feature: Command behaviour when unattached
     @series.focal
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua fix --beta USN-4539-1` as non-root
+        When I run `ua fix USN-4539-1` as non-root
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
@@ -135,7 +135,7 @@ Feature: Command behaviour when unattached
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """
-        When I run `ua fix --beta CVE-2020-28196` as non-root
+        When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
             """
             CVE-2020-28196: Kerberos vulnerability
@@ -151,12 +151,13 @@ Feature: Command behaviour when unattached
            | release |
            | bionic  |
            | focal   |
+           | trusty  |
            | xenial  |
 
     @series.trusty
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua fix --beta USN-4539-1` as non-root
+        When I run `ua fix USN-4539-1` as non-root
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
@@ -164,7 +165,7 @@ Feature: Command behaviour when unattached
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """
-        When I run `ua fix --beta CVE-2020-28196` as non-root
+        When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
             """
             CVE-2020-28196: Kerberos vulnerability

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -226,16 +226,10 @@ def attach_parser(parser):
 def fix_parser(parser):
     """Build or extend an arg parser for fix subcommand."""
     parser.usage = USAGE_TMPL.format(
-        name=NAME, command="fix --beta <CVE-yyyy-nnnn+>|<USN-nnnn-d+>"
+        name=NAME, command="fix <CVE-yyyy-nnnn+>|<USN-nnnn-d+>"
     )
     parser.prog = "fix"
     parser._optionals.title = "Flags"
-    parser.add_argument(
-        "--beta",
-        required=True,
-        action="store_true",
-        help="allow using this beta command",
-    )
     parser.add_argument(
         "security_issue",
         help=(
@@ -837,7 +831,8 @@ def get_parser():
         help="refresh Ubuntu Advantage services from contracts server",
     )
     parser_fix = subparsers.add_parser(
-        "fix"  # BETA omit help string to hide subcommand from help
+        "fix",
+        help="check for and mitigate the impact of a CVE/USN on this system",
     )
     parser_fix.set_defaults(action=action_fix)
     fix_parser(parser_fix)


### PR DESCRIPTION
## Proposed Commit Message

Since we won't release until `ua fix` is production ready,
we can remove the --beta param and allow this command to show
in ua --help.



## Test Steps
CI should cover this, just a revert of a previous accepted commit.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [*] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [*] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
