### PR TITLE
Add reboot notices for fips operations

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -76,6 +76,10 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             """
             <fips-service> +yes                enabled
             """
+        And stdout matches regexp:
+            """
+            FIPS support requires system reboot to complete configuration
+            """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
@@ -95,11 +99,21 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         1
         """
+        When I run `ua status --all` with sudo
+        Then stdout does not match regexp:
+            """
+            FIPS support requires system reboot to complete configuration
+            """
         When I run `ua disable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
             Updating package lists
             A reboot is required to complete disable operation
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            Disabling FIPS requires system reboot to complete operation
             """
         When I run `apt-cache policy ubuntu-fips` as non-root
         Then stdout matches regexp:
@@ -124,6 +138,10 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Then stdout matches regexp:
             """
             <fips-service> +yes                disabled
+            """
+        Then stdout does not match regexp:
+            """
+            Disabling FIPS requires system reboot to complete operation
             """
 
         Examples: ubuntu release

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -206,6 +206,9 @@ MESSAGE_LIVEPATCH_LTS_REBOOT_REQUIRED = (
 MESSAGE_FIPS_REBOOT_REQUIRED = (
     "FIPS support requires system reboot to complete configuration."
 )
+MESSAGE_FIPS_DISABLE_REBOOT_REQUIRED = (
+    "Disabling FIPS requires system reboot to complete operation."
+)
 NOTICE_FIPS_MANUAL_DISABLE_URL = """\
 FIPS kernel is running in a disabled state.
   To manually remove fips kernel: https://discourse.ubuntu.com/t/20738


### PR DESCRIPTION
## Proposed Commit Message
Add reboot notices for fips operations

When we enable/disable fips, we need to restart the system to properly configure it. We are now adding notices that will
remember users that fips needs to be rebooted after unable/disable operation.

Fix #1368

## Test Steps
Run the modified integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
