### PR TITLE
fix: correct regex to be more permissive and strict

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -246,6 +246,7 @@ def action_fix(args, cfg, **kwargs):
             "Invalid issue format: {}".format(args.security_issue)
         )
     security.fix_security_issue_id(cfg, args.security_issue)
+    return 0
 
 
 def detach_parser(parser):

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -4,7 +4,9 @@ from uaclient import status
 from uaclient import serviceclient
 from uaclient import util
 
-CVE_OR_USN_REGEX = r"(CVE-\d{4}-\d{4,7}|(USN|LSN)-\d{1,5}-\d{1,2})"
+CVE_OR_USN_REGEX = (
+    r"((CVE|cve)-\d{4}-\d{4,7}$|(USN|usn|LSN|lsn)-\d{1,5}-\d{1,2}$)"
+)
 
 try:
     from typing import Any, Dict, List, Optional  # noqa: F401

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -1,0 +1,50 @@
+import mock
+
+import pytest
+
+from uaclient import exceptions
+
+from uaclient.cli import action_fix
+
+M_PATH = "uaclient.cli."
+
+
+class TestActionFix:
+    @pytest.mark.parametrize(
+        "issue,is_valid",
+        (
+            ("CVE-2020-1234", True),
+            ("cve-2020-12345", True),
+            ("cve-1234-123456", True),
+            ("CVE-2020-1234567", True),
+            ("USN-1234-1", True),
+            ("usn-1234-12", True),
+            ("USN-12345-1", True),
+            ("usn-12345-12", True),
+            ("lsn-1234-1", True),
+            ("LSN-1234-12", True),
+            ("LSN-1234-123", False),
+            ("cve-1234-123", False),
+            ("CVE-1234-12345678", False),
+            ("USA-1234-12345678", False),
+        ),
+    )
+    @mock.patch("uaclient.security.fix_security_issue_id")
+    def test_attached(
+        self, m_fix_security_issue_id, issue, is_valid, FakeConfig
+    ):
+        """Check that root and non-root will emit attached status"""
+        cfg = FakeConfig()
+        args = mock.MagicMock(security_issue=issue)
+        if is_valid:
+            assert 0 == action_fix(args, cfg)
+            assert [
+                mock.call(cfg, issue)
+            ] == m_fix_security_issue_id.call_args_list
+        else:
+            with pytest.raises(exceptions.UserFacingError) as excinfo:
+                action_fix(args, cfg)
+            assert "Invalid issue format: {}".format(issue) == str(
+                excinfo.value
+            )
+            assert 0 == m_fix_security_issue_id.call_count


### PR DESCRIPTION
## Proposed Commit Message
fix: correct regex to be permissive of upper and lowercase

Now allow for case insensitive matching if CVE, LSN and USN.
Make sure the regex for valid formats is strict for matches and
add unit tests for this validation.

## Test Steps
Unit tests cover this changeset.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
