### PR TITLE
Fix/wire usn affected packages

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -127,19 +127,21 @@ Feature: Command behaviour when unattached
     @series.focal
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua fix USN-4539-1` as non-root
+        When I run `apt install -y libawl-php` with sudo
+        And I run `ua fix USN-4539-1` as non-root
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
-            https://ubuntu.com/security/notices/usn-4539-1.json
-            No affected packages are installed.
-            .*✔.* USN-4539-1 does not affect your system.
+            https://ubuntu.com/security/notices/USN-4539-1
+            1 affected package is installed: awl
+            \(1/1\) awl:
+            <usn_resolution>
             """
         When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
             """
             CVE-2020-28196: Kerberos vulnerability
-            https://ubuntu.com/security/cve-2020-28196.json
+            https://ubuntu.com/security/CVE-2020-28196
             1 affected package is installed: krb5
             \(1/1\) krb5:
             A fix is available in Ubuntu standard updates.
@@ -147,12 +149,12 @@ Feature: Command behaviour when unattached
             .*✔.* CVE-2020-28196 is resolved.
             """
 
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | trusty  |
-           | xenial  |
+        Examples: ubuntu release details
+           | release | usn_resolution |
+           | xenial  | Ubuntu security engineers are investigating this issue. |
+           | bionic  | Ubuntu security engineers are investigating this issue. |
+           | focal   | A fix is available in Ubuntu standard updates.\nThe update is already installed.\n.*✔.* USN-4539-1 is resolved. |
+
 
     @series.trusty
     Scenario Outline: Fix command on an unattached machine
@@ -161,7 +163,7 @@ Feature: Command behaviour when unattached
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
-            https://ubuntu.com/security/notices/usn-4539-1.json
+            https://ubuntu.com/security/notices/USN-4539-1
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """
@@ -169,7 +171,7 @@ Feature: Command behaviour when unattached
         Then stdout matches regexp:
             """
             CVE-2020-28196: Kerberos vulnerability
-            https://ubuntu.com/security/cve-2020-28196.json
+            https://ubuntu.com/security/CVE-2020-28196
             No affected packages are installed.
             .*✔.* CVE-2020-28196 does not affect your system.
             """

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1,3 +1,5 @@
+import socket
+
 from uaclient.config import UAConfig
 from uaclient import exceptions
 from uaclient import status
@@ -43,8 +45,21 @@ class SecurityAPIError(util.UrlError):
 
 class UASecurityClient(serviceclient.UAServiceClient):
 
+    url_timeout = 20
     cfg_url_base_attr = "security_url"
     api_error_cls = SecurityAPIError
+
+    @util.retry(socket.timeout, retry_sleeps=[1, 3, 5])
+    def request_url(
+        self, path, data=None, headers=None, method=None, query_params=None
+    ):
+        return super().request_url(
+            path=path,
+            data=data,
+            headers=headers,
+            method=method,
+            query_params=query_params,
+        )
 
     def get_cves(
         self,

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -152,10 +152,14 @@ class CVEPackageStatus:
     def status_message(self):
         if self.status == "needed":
             return "Sorry, no fix is available yet."
+        elif self.status == "needs-triage":
+            return "Ubuntu security engineers are investigating this issue."
         elif self.status == "pending":
             return "A fix is coming soon. Try again tomorrow."
         elif self.status in ("ignored", "deferred"):
             return "Sorry, no fix is available."
+        elif self.status == "DNE":
+            return "Source package does not exist on this release."
         elif self.status == "released":
             return status.MESSAGE_SECURITY_FIX_RELEASE_STREAM.format(
                 fix_stream=self.pocket_source

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -1,7 +1,6 @@
 import abc
 import json
 
-import socket
 from urllib import error
 from urllib.parse import urlencode
 from posixpath import join as urljoin
@@ -18,6 +17,9 @@ except ImportError:
 
 
 class UAServiceClient(metaclass=abc.ABCMeta):
+
+    url_timeout = None  # type: Optional[int]
+
     @property
     @abc.abstractmethod
     def api_error_cls(self) -> "Type[Exception]":
@@ -43,7 +45,6 @@ class UAServiceClient(metaclass=abc.ABCMeta):
             "content-type": "application/json",
         }
 
-    @util.retry(socket.timeout, retry_sleeps=[1, 3])
     def request_url(
         self, path, data=None, headers=None, method=None, query_params=None
     ):
@@ -61,10 +62,12 @@ class UAServiceClient(metaclass=abc.ABCMeta):
             url += "?" + urlencode(filtered_params)
         try:
             response, headers = util.readurl(
-                url=url, data=data, headers=headers, method=method, timeout=10
+                url=url,
+                data=data,
+                headers=headers,
+                method=method,
+                timeout=self.url_timeout,
             )
-        except socket.timeout:
-            raise
         except error.URLError as e:
             if hasattr(e, "read"):
                 try:

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -129,7 +129,7 @@ class TestGetCVEAffectedPackageStatus:
         (
             ("bionic", {}, {}),
             # installed package version has no bearing on status filtering
-            ("bionic",{"samba": "1000"}, SAMBA_CVE_STATUS_BIONIC),
+            ("bionic", {"samba": "1000"}, SAMBA_CVE_STATUS_BIONIC),
             # active series has a bearing on status filtering
             ("upstream", {"samba": "1000"}, SAMBA_CVE_STATUS_UPSTREAM),
             # not-affected status has a bearing on status filtering
@@ -351,6 +351,12 @@ class TestCVEPackageStatus:
     @pytest.mark.parametrize(
         "status,pocket,expected",
         (
+            ("DNE", "", "Source package does not exist on this release."),
+            (
+                "needs-triage",
+                "esm-infra",
+                "Ubuntu security engineers are investigating this issue.",
+            ),
             ("needed", "esm-infra", "Sorry, no fix is available yet."),
             (
                 "pending",

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -207,7 +207,8 @@ class TestCVE:
         cve = CVE(client, response)
         assert expected == getattr(cve, attr_name)
 
-    @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+    #  @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+    @mock.patch("uaclient.util.readurl")
     def test_get_url_header(self, request_url, FakeConfig):
         """CVE.get_url_header returns a string based on the CVE response."""
         client = UASecurityClient(FakeConfig())
@@ -221,8 +222,23 @@ class TestCVE:
             )
             == cve.get_url_header()
         )
+        headers = client.headers()
+        calls = []
+        for issue in ["USN-4559-1", "USN-4510-2", "USN-4510-1"]:
+            calls.append(
+                mock.call(
+                    url="https://ubuntu.com/security/notices/{}.json".format(
+                        issue
+                    ),
+                    data=None,
+                    headers=headers,
+                    method=None,
+                    timeout=20,
+                )
+            )
+        assert calls == request_url.call_args_list
 
-    @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+    @mock.patch("uaclient.security.UASecurityClient.request_url")
     def test_get_notices_metadata(self, request_url, FakeConfig):
         """CVE.get_notices_metadata is cached to avoid API round-trips."""
         client = UASecurityClient(FakeConfig())
@@ -282,7 +298,7 @@ class TestUSN:
         usn = USN(client, response)
         assert expected == getattr(usn, attr_name)
 
-    @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+    @mock.patch("uaclient.security.UASecurityClient.request_url")
     def test_get_cves_metadata(self, request_url, FakeConfig):
         """USN.get_cves_metadata is cached to avoid API round-trips."""
         client = UASecurityClient(FakeConfig())
@@ -379,7 +395,8 @@ class TestCVEPackageStatus:
         assert expected == pkg_status.status_message
 
 
-@mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+# @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+@mock.patch("uaclient.security.UASecurityClient.request_url")
 class TestUASecurityClient:
     @pytest.mark.parametrize(
         "m_kwargs,expected_error",

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -2,6 +2,7 @@ import copy
 import mock
 import os
 import pytest
+import textwrap
 
 from uaclient.security import (
     API_V1_CVES,
@@ -12,7 +13,9 @@ from uaclient.security import (
     CVEPackageStatus,
     UASecurityClient,
     USN,
+    get_cve_affected_packages_status,
     query_installed_source_pkg_versions,
+    version_cmp_le,
 )
 
 
@@ -49,6 +52,28 @@ CVE_ESM_PACKAGE_STATUS_RESPONSE = {
 }
 
 
+SAMBA_CVE_STATUS_BIONIC = {
+    "component": None,
+    "description": "2:4.7.6+dfsg~ubuntu-0ubuntu2.19",
+    "pocket": None,
+    "release_codename": "bionic",
+    "status": "released",
+}
+SAMBA_CVE_STATUS_FOCAL = {
+    "component": None,
+    "description": "2:4.11.6+dfsg-0ubuntu1.4",
+    "pocket": None,
+    "release_codename": "focal",
+    "status": "not-affected",
+}
+SAMBA_CVE_STATUS_UPSTREAM = {
+    "component": None,
+    "description": "",
+    "pocket": None,
+    "release_codename": "upstream",
+    "status": "needs-triage",
+}
+
 SAMPLE_CVE_RESPONSE = {
     "bugs": ["https://bugzilla.samba.org/show_bug.cgi?id=14497"],
     "description": "\nAn elevation of privilege vulnerability exists ...",
@@ -61,40 +86,9 @@ SAMPLE_CVE_RESPONSE = {
             "name": "samba",
             "source": "https://ubuntu.com/security/cve?package=samba",
             "statuses": [
-                {
-                    "component": None,
-                    "description": "2:4.7.6+dfsg~ubuntu-0ubuntu2.19",
-                    "pocket": None,
-                    "release_codename": "bionic",
-                    "status": "released",
-                },
-                {
-                    "component": None,
-                    "description": "2:4.11.6+dfsg-0ubuntu1.4",
-                    "pocket": None,
-                    "release_codename": "focal",
-                    "status": "not-affected",
-                },
-                {
-                    "component": None,
-                    "description": "2:4.12.5+dfsg-3ubuntu3",
-                    "pocket": None,
-                    "release_codename": "groovy",
-                    "status": "not-affected",
-                },
-                {
-                    "component": None,
-                    "description": "",
-                    "pocket": None,
-                    "release_codename": "precise",
-                },
-                {
-                    "component": None,
-                    "description": "",
-                    "pocket": None,
-                    "release_codename": "upstream",
-                    "status": "needs-triage",
-                },
+                SAMBA_CVE_STATUS_BIONIC,
+                SAMBA_CVE_STATUS_FOCAL,
+                SAMBA_CVE_STATUS_UPSTREAM,
             ],
         }
     ],
@@ -129,6 +123,58 @@ SAMPLE_USN_RESPONSE = {
 }
 
 
+class TestGetCVEAffectedPackageStatus:
+    @pytest.mark.parametrize(
+        "series,installed_packages,expected_status",
+        (
+            ("bionic", {}, {}),
+            # installed package version has no bearing on status filtering
+            ("bionic",{"samba": "1000"}, SAMBA_CVE_STATUS_BIONIC),
+            # active series has a bearing on status filtering
+            ("upstream", {"samba": "1000"}, SAMBA_CVE_STATUS_UPSTREAM),
+            # not-affected status has a bearing on status filtering
+            ("focal", {"samba": "1000"}, {}),
+        ),
+    )
+    @mock.patch("uaclient.security.util.get_platform_info")
+    def test_affected_packages_status_filters_installed_pkgs_and_not_affected(
+        self,
+        get_platform_info,
+        series,
+        installed_packages,
+        expected_status,
+        FakeConfig,
+    ):
+        """Package statuses are filterd if not installed or == not-affected"""
+        get_platform_info.return_value = {"series": series}
+        client = UASecurityClient(FakeConfig())
+        cve = CVE(client, SAMPLE_CVE_RESPONSE)
+        affected_packages = get_cve_affected_packages_status(
+            cve, installed_packages=installed_packages
+        )
+        if expected_status:
+            package_status = affected_packages["samba"]
+            assert expected_status == package_status.response
+        else:
+            assert expected_status == affected_packages
+
+
+class TestVersionCmpLe:
+    @pytest.mark.parametrize(
+        "ver1,ver2,is_lessorequal",
+        (
+            ("1.0", "2.0", True),
+            ("2.0", "2.0", True),
+            ("2.1~18.04.1", "2.1", True),
+            ("2.1", "2.1~18.04.1", False),
+            ("2.1", "2.0", False),
+        ),
+    )
+    def test_version_cmp_le(self, ver1, ver2, is_lessorequal):
+        """version_cmp_le returns True when ver1 less than or equal to ver2."""
+        assert is_lessorequal is version_cmp_le(ver1, ver2)
+
+
 class TestCVE:
     def test_cve_init_attributes(self, FakeConfig):
         """CVE.__init__ saves client and response on instance."""
@@ -160,6 +206,21 @@ class TestCVE:
         client = UASecurityClient(FakeConfig())
         cve = CVE(client, response)
         assert expected == getattr(cve, attr_name)
+
+    @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+    def test_get_url_header(self, request_url, FakeConfig):
+        """CVE.get_url_header returns a string based on the CVE response."""
+        client = UASecurityClient(FakeConfig())
+        cve = CVE(client, SAMPLE_CVE_RESPONSE)
+        request_url.return_value = (SAMPLE_USN_RESPONSE, "header")
+        assert (
+            textwrap.dedent(
+                """\
+                CVE-2020-1472: Samba vulnerability
+                https://ubuntu.com/security/CVE-2020-1472"""
+            )
+            == cve.get_url_header()
+        )
 
     @mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
     def test_get_notices_metadata(self, request_url, FakeConfig):
@@ -243,6 +304,17 @@ class TestUSN:
         # no extra calls being made
         usn.get_cves_metadata()
         assert 1 == request_url.call_count
+
+    def test_get_url_header(self, FakeConfig):
+        """USN.get_url_header returns a string based on the USN response."""
+        client = UASecurityClient(FakeConfig())
+        usn = CVE(client, SAMPLE_USN_RESPONSE)
+        assert (
+            textwrap.dedent(
+                """USN-4510-2: None\nhttps://ubuntu.com/security/USN-4510-2"""
+            )
+            == usn.get_url_header()
+        )
 
 
 class TestCVEPackageStatus:

--- a/uaclient/tests/test_serviceclient.py
+++ b/uaclient/tests/test_serviceclient.py
@@ -82,6 +82,6 @@ class TestRequestUrl:
                 data=None,
                 headers=client.headers(),
                 method=None,
-                timeout=10,
+                timeout=None,
             )
         ] == m_readurl.call_args_list


### PR DESCRIPTION
## Proposed Commit Message
WIre USN affected packages checks to inspect each related CVE.

Previous implementation was stubbed out.

This PR addresses a couple of concerns:

- Refactor CVE/USN.get_url_headers and common deb version comparison
- Add CVE package status DNE and needs-triage response messages

- Integration test fixes:
  * uaclient/serviceclient now adds two retries to API calls to avoid #1374
  * Add ua fix usn changes

Fixes: #1374 

## Test Steps
```bash
UACLIENT_BEHAVE_BUILD_PR=1  tox -e behave-lxd-18.04 features/unattached_commands.feature:155
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [x] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [n/a] I have updated or added any documentation accordingly
