### PR TITLE
serviceclient: add retry logic to avoid long timeouts during intermittent failures

### DIFF
--- a/uaclient/tests/test_serviceclient.py
+++ b/uaclient/tests/test_serviceclient.py
@@ -78,6 +78,10 @@ class TestRequestUrl:
             url += "?" + urlencode(m_kwargs)
         assert [
             mock.call(
-                url=url, data=None, headers=client.headers(), method=None
+                url=url,
+                data=None,
+                headers=client.headers(),
+                method=None,
+                timeout=10,
             )
         ] == m_readurl.call_args_list

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -458,7 +458,18 @@ class TestIsServiceUrl:
 
 
 class TestReadurl:
-    def test_simple_call_with_url_works(self):
+    @pytest.mark.parametrize("timeout", (None, 1))
+    def test_simple_call_with_url_and_timeout_works(self, timeout):
+        with mock.patch("uaclient.util.request.urlopen") as m_urlopen:
+            if timeout:
+                util.readurl("http://some_url", timeout=timeout)
+            else:
+                util.readurl("http://some_url")
+        assert [
+            mock.call(mock.ANY, timeout=timeout)
+        ] == m_urlopen.call_args_list
+
+    def test_call_with_timeout(self):
         with mock.patch("uaclient.util.request.urlopen") as m_urlopen:
             util.readurl("http://some_url")
         assert 1 == m_urlopen.call_count

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -425,6 +425,7 @@ def readurl(
     data: "Optional[bytes]" = None,
     headers: "Dict[str, str]" = {},
     method: "Optional[str]" = None,
+    timeout: "Optional[int]" = None,
 ) -> "Tuple[Any, Union[HTTPMessage, Mapping[str, str]]]":
     if data and not method:
         method = "POST"
@@ -436,7 +437,7 @@ def readurl(
         headers,
         data,
     )
-    resp = request.urlopen(req)
+    resp = request.urlopen(req, timeout=timeout)
     content = resp.read().decode("utf-8")
     if "application/json" in str(resp.headers.get("Content-type", "")):
         content = json.loads(content)


### PR DESCRIPTION
Add general retry logic to the service client to set a 10 second timeout and retry twice to avoid failure due to intermittent network/service outages


## Proposed Commit Message
rebase individual commits

## Test Steps
Since the service  API seems to have fairly frequent 30 second API timeouts, run the following a few times to reproduce the failure we have seen on integration test runs. Expect to a a retry log and success.
```bash
PYTHONPATH=. python3 -m uaclient.cli --debug ua fix USN-4539-1
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
