### PR TITLE
Drop traceback checks on fips integration tests

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -81,7 +81,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             FIPS support requires system reboot to complete configuration
             """
         And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
         And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
@@ -171,7 +170,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             <fips-service> +yes                enabled
             """
         And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
         And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
@@ -370,7 +368,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             """
         When I reboot the `<release>` machine
         Then I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `ubuntu-fips` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`


### PR DESCRIPTION
## Proposed Commit Message
Drop traceback checks on fips integration tests

Currently, afer we enable FIPS and reboot the machine, we check uaclient logs to see if any traceback was raised during this
process. However, unrelated tracebacks can also make this test fail. For example, timeouts issues may create tracebacks on the logs but they are not directly related to FIPS problems. Since I believe our test already looks at different aspects of FIPS enablement, we can drop the traceback check from these tests

Using a practical example, this is one scenario where the test failed:
```
2021-02-24 13:39:11,527 - util.py:(438) [DEBUG]: URL [POST]: https://contracts.staging.canonical.com/v1/context/machines/token, headers: {'content-type': 'application/json', 'accept': 'application/json',        'Authorization': 'Bearer TOKEN', 'user-agent': 'UA-Client/27.0-945~gedf4a7e~ubuntu16.04.1'}, data: b'{"os": {"type": "Linux", "series": "xenial", "distribution": "Ubuntu", "release": "16.04", "version": "16.04 LTS (Xenial Xerus)", "kernel": "4.15.0-133-generic"}, "architecture": "amd64", "machineId": "ID"}'
2021-02-24 13:39:23,015 - contract.py:(377) [ERROR]: _ssl.c:629: The handshake operation timed out 
Traceback (most recent call last):
  File "/usr/lib/python3.5/urllib/request.py", line 1261, in do_open
    h.request(req.get_method(), req.selector, req.data, headers)
  File "/usr/lib/python3.5/http/client.py", line 1151, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.5/http/client.py", line 1196, in _send_request
    self.endheaders(body)
  File "/usr/lib/python3.5/http/client.py", line 1147, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python3.5/http/client.py", line 950, in _send_output
    self.send(msg)
  File "/usr/lib/python3.5/http/client.py", line 893, in send
    self.connect()
  File "/usr/lib/python3.5/http/client.py", line 1305, in connect
    server_hostname=server_hostname)
  File "/usr/lib/python3.5/ssl.py", line 377, in wrap_socket
    _context=self)
  File "/usr/lib/python3.5/ssl.py", line 752, in __init__
    self.do_handshake()
  File "/usr/lib/python3.5/ssl.py", line 988, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/lib/python3.5/ssl.py", line 633, in do_handshake
    self._sslobj.do_handshake()
socket.timeout: _ssl.c:629: The handshake operation timed out 
```

We can see that we had a timeout trying to access the contracts backend, which is not a FIPS related issue but caused the test to fail

## Test Steps
Run any of the modified integration tests in this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [x] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
