### PR TITLE
Allow printing usefull cmds on uaclient operations

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -129,7 +129,10 @@ def _parse_apt_update_for_invalid_apt_config(apt_error: str) -> str:
 
 
 def run_apt_command(
-    cmd: "List[str]", error_msg: str, env: "Optional[Dict[str, str]]" = {}
+    cmd: "List[str]",
+    error_msg: str,
+    env: "Optional[Dict[str, str]]" = {},
+    print_cmd: bool = False,
 ) -> str:
     """Run an apt command, retrying upon failure APT_RETRIES times.
 
@@ -137,11 +140,15 @@ def run_apt_command(
     :param error_msg: The string to raise as UserFacingError when all retries
        are exhausted in failure.
     :param env: Optional dictionary of environment variables to pass to subp.
+    :param print_cmd: If true, print the apt command that will be run
 
     :return: stdout from successful run of the apt command.
     :raise UserFacingError: on issues running apt-cache policy.
     """
     try:
+        if print_cmd:
+            print(" ".join(cmd))
+
         out, _err = util.subp(
             cmd, capture=True, retry_sleeps=APT_RETRIES, env=env
         )


### PR DESCRIPTION
## Proposed Commit Message
Allow printing apt commands

For ua fix, we will need to print some useful apt commands that we are performing to the user, such as `apt update`, `apt upgrade`. We are now allowing the run_apt_command function to print those commands when needed

## Discussion

As discussed in issue #1400, we will only need to print a subset of the commands that we run on uaclient. They are:

* uaclient top level commands (`attach`, `enable`
* Apt commands like `apt update`, `apt upgrade <pkg-name>`

Because of that, I think `ua fix` will be able to control how to print those commands directly by adding this functionality

## Test Steps
Run the new unit test introduced in the PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
