### PR TITLE
config: environment variable support for feature overrides

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -624,7 +624,14 @@ def parse_config(config_path=None):
     for key, value in os.environ.items():
         key = key.lower()
         if key.startswith("ua_"):
-            env_keys[key[3:]] = value  # Strip leading UA_
+            if "ua_features_" in key:
+                key = key[12:]  # String leading UA_FEATURES_
+                if "features" not in cfg:
+                    cfg["features"] = {key: value}
+                else:
+                    cfg["features"][key] = value
+            else:
+                env_keys[key[3:]] = value  # Strip leading UA_
     cfg.update(env_keys)
     cfg["log_level"] = cfg["log_level"].upper()
     cfg["data_dir"] = os.path.expanduser(cfg["data_dir"])

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1017,18 +1017,21 @@ class TestParseConfig:
             "ua_data_dir": "~/somedir",
             "Ua_LoG_FiLe": "some.log",
             "UA_LOG_LEVEL": "debug",
+            "UA_FEATURES_X_Y_Z": "XYZ_VAL",
+            "UA_FEATURES_A_B_C": "ABC_VAL",
         }
         with mock.patch.dict("uaclient.config.os.environ", values=user_values):
             config = parse_config()
         expanded_dir = os.path.expanduser("~")
-        expected_default_config = {
+        expected_config = {
             "contract_url": "https://contract",
             "security_url": "https://security",
             "data_dir": "{}/somedir".format(expanded_dir),
             "log_file": "some.log",
             "log_level": "DEBUG",
+            "features": {"a_b_c": "ABC_VAL", "x_y_z": "XYZ_VAL"},
         }
-        assert expected_default_config == config
+        assert expected_config == config
 
     @pytest.mark.parametrize(
         "env_var,env_value",

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -21,13 +21,20 @@ class TestGetVersion:
             assert "24.1~18.04.1" + suffix == get_version(features=features)
         assert 0 == m_subp.call_count
 
-    @mock.patch("uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION")
+    @pytest.mark.parametrize(
+        "features,suffix", (({}, ""), ({"on": True}, " +on"))
+    )
     @mock.patch("uaclient.version.os.path.exists", return_value=True)
     def test_get_version_returns_matching_git_describe_long(
-        self, m_exists, m_subp
+        self, m_exists, m_subp, features, suffix
     ):
         m_subp.return_value = ("24.1-5-g12345678", "")
-        assert "24.1-5-g12345678" == get_version()
+        with mock.patch(
+            "uaclient.version.PACKAGED_VERSION", "@@PACKAGED_VERSION"
+        ):
+            assert "24.1-5-g12345678" + suffix == get_version(
+                features=features
+            )
         assert [
             mock.call(
                 ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -38,7 +38,7 @@ def get_version(_args=None, features={}):
         cmd = ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
         try:
             out, _ = util.subp(cmd)
-            return out.strip()
+            return out.strip() + feature_suffix
         except util.ProcessExecutionError:
             # Rely on debian/changelog because we are in a git-ubuntu or other
             # packaging repo


### PR DESCRIPTION
Support environment vars of the format UA_FEATURES_SOME_NAME to
override uaclient.conf values.

For example:
UA_FEATURES_ALLOW_BETA=true ua enable cis

Fixes: #1395

## Proposed Commit Message
Use rebase and merge

## Test Steps
```bash
csmith@downtown:~/src/ubuntu-advantage-client (feature-overrides-in-env)$ PYTHONPATH=. python3 -m uaclient.cli version
20.3-355-gb867d073
csmith@downtown:~/src/ubuntu-advantage-client (feature-overrides-in-env)$ UA_FEATURES_ALLOW_BETA=true PYTHONPATH=. python3 -m uaclient.cli version
20.3-355-gb867d073 +allow_beta
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
