### PR TITLE
fix: correct installed_pkgs query. prompt when unattached

### DIFF
--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -132,7 +132,7 @@ STATUS_COLOR = {
 
 MESSAGE_SECURITY_FIX_RELEASE_STREAM = "A fix is available in {fix_stream}."
 MESSAGE_SECURITY_UPDATE_NOT_INSTALLED = "The update is not yet installed."
-MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_UNATTACHED = """\
+MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION = """\
 The update is not installed because this system is not attached to a
 subscription that covers these packages.
 """

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -132,6 +132,10 @@ STATUS_COLOR = {
 
 MESSAGE_SECURITY_FIX_RELEASE_STREAM = "A fix is available in {fix_stream}."
 MESSAGE_SECURITY_UPDATE_NOT_INSTALLED = "The update is not yet installed."
+MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_UNATTACHED = """\
+The update is not installed because this system is not attached to a
+subscription that covers these packages.
+"""
 MESSAGE_SECURITY_UPDATE_INSTALLED = "The update is already installed."
 MESSAGE_SECURITY_ISSUE_RESOLVED = OKGREEN_CHECK + " {issue} is resolved."
 MESSAGE_SECURITY_ISSUE_UNAFFECTED = (

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -399,6 +399,24 @@ def parse_os_release(release_file: "Optional[str]" = None) -> "Dict[str, str]":
     return data
 
 
+def prompt_choices(msg: str = "", valid_choices: "List[str]" = []) -> str:
+    """Interactive prompt message, returning a valid choice from msg.
+
+    Expects a structured msg which designates choices with square brackets []
+    around the characters which indicate a valid choice.
+
+    Uppercase and lowercase responses are allowed. Loop on invalid choices.
+
+    :return: Valid response character chosen.
+    """
+    value = ""
+    if msg[-1] != " ":
+        msg += " "
+    while value not in valid_choices:
+        value = input(msg).lower().strip()
+    return value
+
+
 def prompt_for_confirmation(msg: str = "", assume_yes: bool = False) -> bool:
     """
     Display a confirmation prompt, returning a bool indicating the response


### PR DESCRIPTION
Prompt for ua attach when unattached and `ua fix CVE-XX` reports
an available package affected.

Add a util.prompt_choices function which defines the input string
and desirable choices/responses. prompt_choices will loop until the
valid choice is provided.

In testing ua fix CVE-2021-27135 it was noted that xterm wasn't
listed as installed. Fix dpkg-query to determine package name based
on either ${Source} or ${Package} if Source is not set.

Fixes: #1397, #1398

## Proposed Commit Message
Rebase and merge

## Test Steps
```bash
cat > 1.yaml <<EOF
#cloud-config                                                                   
package_upgrade: true                                                           
apt:                                                                            
  sources:                                                                      
    ua.list:                                                                    
       source: deb http://ppa.launchpad.net/canonical-server/ua-client-daily/ubuntu $RELEASE main
       keyid: 94E187AD53A59D1847E4880F8A295C4FB8B190B7 
packages: [ubuntu-advantage-tools]
EOF

tox -e lxc launch ubuntu-daily:bionic dev-b -c user.user-data="$(cat 1.yaml)"
lxc file push uaclient/security.py dev-b/usr/lib/python3/dist-packages/uaclient/
lxc file push uaclient/status.py dev-b/usr/lib/python3/dist-packages/uaclient/
lxc file push uaclient/util.py dev-b/usr/lib/python3/dist-packages/uaclient/

# downgrade xterm
lxc exec dev-b apt-get install xterm=330-1ubuntu2
lxc exec dev-b ua fix CVE-2021-27135
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly # maybe will add them after initial review
 - [ ] I have updated or added any documentation accordingly
