### PR TITLE
Fix FIPS message when disable operation fails

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -232,7 +232,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 ["apt-get", "remove", "--assume-yes"]
                 + apt_options
                 + list(remove_packages),
-                status.MESSAGE_ENABLED_FAILED_TMPL.format(title=self.title),
+                status.MESSAGE_DISABLE_FAILED_TMPL.format(title=self.title),
                 env=env,
             )
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -586,6 +586,21 @@ class TestFIPSEntitlementRemovePackages:
         else:
             assert 0 == m_subp.call_count
 
+    @mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
+    @mock.patch(M_PATH + "util.subp")
+    @mock.patch(M_PATH + "apt.get_installed_packages")
+    def test_remove_packages_output_message_when_fail(
+        self, m_get_installed_packages, m_subp, _m_get_platform, entitlement
+    ):
+        m_get_installed_packages.return_value = ["ubuntu-fips"]
+        m_subp.side_effect = util.ProcessExecutionError(cmd="test")
+        expected_msg = "Could not disable {}.".format(entitlement.title)
+
+        with pytest.raises(exceptions.UserFacingError) as exc_info:
+            entitlement.remove_packages()
+
+        assert exc_info.value.msg.strip() == expected_msg
+
 
 @mock.patch(M_REPOPATH + "handle_message_operations", return_value=True)
 @mock.patch("uaclient.util.should_reboot", return_value=True)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -163,6 +163,7 @@ MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)"
 MESSAGE_ALREADY_DISABLED_TMPL = """\
 {title} is not currently enabled\nSee: sudo ua status"""
 MESSAGE_ENABLED_FAILED_TMPL = "Could not enable {title}."
+MESSAGE_DISABLE_FAILED_TMPL = "Could not disable {title}."
 MESSAGE_ENABLED_TMPL = "{title} enabled"
 MESSAGE_ALREADY_ATTACHED = """\
 This machine is already attached to '{account_name}'


### PR DESCRIPTION
## Proposed Commit Message
Fix FIPS message when disable operation fails

As seen in #1389, FIPS is incorrectly using an enable message when the disable operations fails. We are now updating that to display the right disable message

## Test Steps
Run the new unit test added in this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
