### PR TITLE
Install pkg fixes when they are on standard pocket

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -179,3 +179,43 @@ Feature: Command behaviour when unattached
         Examples: ubuntu release
            | release |
            | trusty  |
+
+    @series.bionic
+    Scenario: Fix command on an unattached machine
+        Given a `bionic` machine with ubuntu-advantage-tools installed
+        When I run `apt-get install xterm=330-1ubuntu2 -y` with sudo
+        And I run `ua fix CVE-2021-27135` as non-root
+        Then stdout matches regexp:
+        """
+        CVE-2021-27135: xterm vulnerability
+        https://ubuntu.com/security/CVE-2021-27135
+        1 affected package is installed: xterm
+        \(1/1\) xterm:
+        A fix is available in Ubuntu standard updates.
+        The update is not yet installed.
+        Package fixes cannot be installed.
+        To install them, run this command as root \(try using sudo\)
+        """
+        When I run `ua fix CVE-2021-27135` with sudo
+        Then stdout matches regexp:
+        """
+        CVE-2021-27135: xterm vulnerability
+        https://ubuntu.com/security/CVE-2021-27135
+        1 affected package is installed: xterm
+        \(1/1\) xterm:
+        A fix is available in Ubuntu standard updates.
+        The update is not yet installed.
+        apt-get update
+        apt-get install --only-upgrade -y xterm
+        """
+        When I run `ua fix CVE-2021-27135` with sudo
+        Then stdout matches regexp:
+        """
+        CVE-2021-27135: xterm vulnerability
+        https://ubuntu.com/security/CVE-2021-27135
+        1 affected package is installed: xterm
+        \(1/1\) xterm:
+        A fix is available in Ubuntu standard updates.
+        The update is already installed.
+        .*✔.* CVE-2021-27135 is resolved.
+        """

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1,3 +1,4 @@
+import os
 import socket
 
 from uaclient.config import UAConfig
@@ -5,6 +6,7 @@ from uaclient import exceptions
 from uaclient import status
 from uaclient import serviceclient
 from uaclient import util
+from uaclient import apt
 
 CVE_OR_USN_REGEX = (
     r"((CVE|cve)-\d{4}-\d{4,7}$|(USN|usn|LSN|lsn)-\d{1,5}-\d{1,2}$)"
@@ -478,8 +480,22 @@ def upgrade_packages_and_attach(
     packages.
     """
     if upgrade_packages:
-        print(
-            "TODO: GH #1401: apt commands upgrading security/updates packages"
+        if os.getuid() != 0:
+            print(status.MESSAGE_SECURITY_APT_NON_ROOT)
+            return
+
+        apt.run_apt_command(
+            cmd=["apt-get", "update"],
+            error_msg=status.MESSAGE_APT_UPDATE_FAILED,
+            print_cmd=True,
+        )
+
+        apt.run_apt_command(
+            cmd=["apt-get", "install", "--only-upgrade", "-y"]
+            + upgrade_packages,
+            error_msg=status.MESSAGE_APT_INSTALL_FAILED,
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+            print_cmd=True,
         )
     if upgrade_packages_ua:
         if cfg.is_attached:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -307,6 +307,11 @@ Failed to find the machine token overlay file: {file_path}"""
 ERROR_JSON_DECODING_IN_FILE = """\
 Found error: {error} when reading json file: {file_path}"""
 
+MESSAGE_SECURITY_APT_NON_ROOT = """\
+Package fixes cannot be installed.
+To install them, run this command as root (try using sudo)
+"""
+
 
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""


### PR DESCRIPTION
## Proposed Commit Message
Install pkg fixes when they are on standard pocket

When running ua fix on a given USN/CVE we may need may find update that are present on the Ubuntu Standard Updates.
In that scenario, we can just install those updates. We are now allowing ua fix to do exactly that.

Fixes: #1401

## Test Steps
Run the new integration test added to this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
