### PR TITLE
Create config to add extra params to security url

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -626,6 +626,19 @@ def parse_config(config_path=None):
         if key.startswith("ua_"):
             if "ua_features_" in key:
                 key = key[12:]  # String leading UA_FEATURES_
+
+                # Users can provide a yaml file to override
+                # config behavor. If they do, we are going
+                # to load that yaml and update the config
+                # with it
+                if value.endswith("yaml"):
+                    if os.path.exists(value):
+                        value = yaml.safe_load(util.load_file(value))
+                    else:
+                        raise exceptions.UserFacingError(
+                            "Could not find yaml file: {}".format(value)
+                        )
+
                 if "features" not in cfg:
                     cfg["features"] = {key: value}
                 else:

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -417,19 +417,30 @@ class TestCVEPackageStatus:
 @mock.patch("uaclient.security.UASecurityClient.request_url")
 class TestUASecurityClient:
     @pytest.mark.parametrize(
-        "m_kwargs,expected_error",
+        "m_kwargs,expected_error, extra_security_params",
         (
-            ({}, None),
-            ({"query": "vq"}, None),
-            (SAMPLE_GET_CVES_QUERY_PARAMS, None),
-            ({"invalidparam": "vv"}, TypeError),
+            ({}, None, None),
+            ({"query": "vq"}, None, {"test": "blah"}),
+            (SAMPLE_GET_CVES_QUERY_PARAMS, None, None),
+            ({"invalidparam": "vv"}, TypeError, None),
         ),
     )
     def test_get_cves_sets_query_params_on_get_cves_route(
-        self, request_url, m_kwargs, expected_error, FakeConfig
+        self,
+        request_url,
+        m_kwargs,
+        expected_error,
+        extra_security_params,
+        FakeConfig,
     ):
         """GET CVE instances from API_V1_CVES route with querystrings"""
-        client = UASecurityClient(FakeConfig())
+        cfg = FakeConfig()
+        if extra_security_params:
+            cfg.override_features(
+                {"extra_security_params": extra_security_params}
+            )
+
+        client = UASecurityClient(cfg)
         if expected_error:
             with pytest.raises(expected_error) as exc:
                 client.get_cves(**m_kwargs)
@@ -449,24 +460,36 @@ class TestUASecurityClient:
             assert "body2" == cve2.response
             # get_cves transposes "query" to "q"
             m_kwargs["q"] = m_kwargs.pop("query")
+
             assert [
                 mock.call(API_V1_CVES, query_params=m_kwargs)
             ] == request_url.call_args_list
 
     @pytest.mark.parametrize(
-        "m_kwargs,expected_error",
+        "m_kwargs,expected_error, extra_security_params",
         (
-            ({}, None),
-            ({"details": "vd"}, None),
-            (SAMPLE_GET_NOTICES_QUERY_PARAMS, None),
-            ({"invalidparam": "vv"}, TypeError),
+            ({}, None, None),
+            ({"details": "vd"}, None, None),
+            (SAMPLE_GET_NOTICES_QUERY_PARAMS, None, {"test": "blah"}),
+            ({"invalidparam": "vv"}, TypeError, None),
         ),
     )
     def test_get_notices_sets_query_params_on_get_cves_route(
-        self, request_url, m_kwargs, expected_error, FakeConfig
+        self,
+        request_url,
+        m_kwargs,
+        expected_error,
+        extra_security_params,
+        FakeConfig,
     ):
         """GET body from API_V1_NOTICES route with appropriate querystring"""
-        client = UASecurityClient(FakeConfig())
+        cfg = FakeConfig()
+        if extra_security_params:
+            cfg.override_features(
+                {"extra_security_params": extra_security_params}
+            )
+
+        client = UASecurityClient(cfg)
         if expected_error:
             with pytest.raises(expected_error) as exc:
                 client.get_notices(**m_kwargs)
@@ -490,14 +513,24 @@ class TestUASecurityClient:
             ] == request_url.call_args_list
 
     @pytest.mark.parametrize(
-        "m_kwargs,expected_error",
-        (({}, TypeError), ({"cve_id": "CVE-1"}, None)),
+        "m_kwargs,expected_error, extra_security_params",
+        (({}, TypeError, None), ({"cve_id": "CVE-1"}, None, {"test": "blah"})),
     )
     def test_get_cve_provides_response_from_cve_json_route(
-        self, request_url, m_kwargs, expected_error, FakeConfig
+        self,
+        request_url,
+        m_kwargs,
+        expected_error,
+        extra_security_params,
+        FakeConfig,
     ):
         """GET body from API_V1_CVE_TMPL route with required cve_id."""
-        client = UASecurityClient(FakeConfig())
+        cfg = FakeConfig()
+        if extra_security_params:
+            cfg.override_features(
+                {"extra_security_params": extra_security_params}
+            )
+        client = UASecurityClient(cfg)
         if expected_error:
             with pytest.raises(expected_error) as exc:
                 client.get_cve(**m_kwargs)
@@ -515,14 +548,28 @@ class TestUASecurityClient:
             ] == request_url.call_args_list
 
     @pytest.mark.parametrize(
-        "m_kwargs,expected_error",
-        (({}, TypeError), ({"notice_id": "USN-1"}, None)),
+        "m_kwargs,expected_error, extra_security_params",
+        (
+            ({}, TypeError, None),
+            ({"notice_id": "USN-1"}, None, {"test": "blah"}),
+        ),
     )
     def test_get_notice_provides_response_from_notice_json_route(
-        self, request_url, m_kwargs, expected_error, FakeConfig
+        self,
+        request_url,
+        m_kwargs,
+        expected_error,
+        extra_security_params,
+        FakeConfig,
     ):
         """GET body from API_V1_NOTICE_TMPL route with required notice_id."""
-        client = UASecurityClient(FakeConfig())
+        cfg = FakeConfig()
+        if extra_security_params:
+            cfg.override_features(
+                {"extra_security_params": extra_security_params}
+            )
+
+        client = UASecurityClient(cfg)
         if expected_error:
             with pytest.raises(expected_error) as exc:
                 client.get_notice(**m_kwargs)


### PR DESCRIPTION
## Proposed Commit Message
Create config to add extra params to security url

We are now creating a feature config that will allow users to pass extra params to the security url we are using on ua fix

## Test Steps
Run the modified unit tests on this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
