### PR TITLE
[WIP] config: overrides for entitlement is_beta

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -12,6 +12,10 @@ Feature: Command behaviour when attached to an UA subscription
         data_dir: /var/lib/ubuntu-advantage
         log_level: debug
         log_file: /var/log/ubuntu-advantage.log
+        features:
+          entitlements:
+            esm_apps:
+              is_beta: false
         """
         And I run `ua auto-attach` with sudo
         And I run `ua status --wait` as non-root
@@ -21,6 +25,16 @@ Feature: Command behaviour when attached to an UA subscription
             SERVICE       ENTITLED  STATUS    DESCRIPTION
             cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
             cis           +yes  +<cis-s>  +Center for Internet Security Audit Tools
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +<fips-s> +NIST-certified FIPS modules
+            fips-updates  +yes +<fips-s> +Uncertified security updates to FIPS modules
+            livepatch     +yes +enabled  +Canonical Livepatch service
+            """
+        When I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            SERVICE       ENTITLED  STATUS    DESCRIPTION
             esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
             fips          +yes +<fips-s> +NIST-certified FIPS modules

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -40,7 +40,17 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     assume_yes = False
 
     # Whether that entitlement is in beta stage
-    is_beta = False
+    _is_beta = False
+
+    @property
+    def is_beta(self) -> bool:
+        """Is this service beta (and hidden from status) or production"""
+        cfg_beta = self.cfg.features(
+            "entitlements.{}.is_beta".format(self.name.replace("-", "_"))
+        )
+        if cfg_beta is not None:
+            return bool(cfg_beta)
+        return self._is_beta
 
     # Help info message for the entitlement
     _help_info = None  # type: str

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -16,7 +16,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     title = "CC EAL2"
     description = "Common Criteria EAL2 Provisioning Packages"
     repo_key_file = "ubuntu-cc-keyring.gpg"
-    is_beta = True
+    _is_beta = True
 
     @property
     def messaging(

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -8,5 +8,5 @@ class CISEntitlement(repo.RepoEntitlement):
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"
     repo_key_file = "ubuntu-advantage-cis.gpg"
-    is_beta = True
+    _is_beta = True
     apt_noninteractive = True

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -18,7 +18,7 @@ class ESMAppsEntitlement(ESMBaseEntitlement):
     title = "ESM Apps"
     description = "UA Apps: Extended Security Maintenance (ESM)"
     repo_key_file = "ubuntu-advantage-esm-apps.gpg"
-    is_beta = True
+    _is_beta = True
 
 
 class ESMInfraEntitlement(ESMBaseEntitlement):

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -218,14 +218,14 @@ class TestParser:
         assert "Flags" == parser._optionals.title
 
     def test_attach_parser_stores_token(self):
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "attach", "token"]):
             args = full_parser.parse_args()
         assert "token" == args.token
 
     def test_attach_parser_allows_empty_required_token(self):
         """Token required but parse_args allows none due to action_attach"""
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "attach"]):
             args = full_parser.parse_args()
         assert None is args.token
@@ -234,14 +234,14 @@ class TestParser:
         self, capsys
     ):
         """Contracts' dashboard URL is referenced by ua attach --help."""
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "attach", "--help"]):
             with pytest.raises(SystemExit):
                 full_parser.parse_args()
         assert UA_AUTH_TOKEN_URL in capsys.readouterr()[0]
 
     def test_attach_parser_accepts_and_stores_no_auto_enable(self):
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch(
             "sys.argv", ["ua", "attach", "--no-auto-enable", "token"]
         ):
@@ -249,7 +249,7 @@ class TestParser:
         assert not args.auto_enable
 
     def test_attach_parser_defaults_to_auto_enable(self):
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "attach", "token"]):
             args = full_parser.parse_args()
         assert args.auto_enable

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -356,7 +356,7 @@ class TestParser:
         assert "auto-attach" == m_parser.prog
         assert "Flags" == m_parser._optionals.title
 
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "auto-attach"]):
             args = full_parser.parse_args()
         assert "auto-attach" == args.command

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -253,14 +253,14 @@ class TestParser:
         assert "Flags" == parser._optionals.title
 
     def test_detach_parser_accepts_and_stores_assume_yes(self):
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "detach", "--assume-yes"]):
             args = full_parser.parse_args()
 
         assert args.assume_yes
 
     def test_detach_parser_defaults_to_not_assume_yes(self):
-        full_parser = get_parser()
+        full_parser = get_parser(mock.Mock())
         with mock.patch("sys.argv", ["ua", "detach"]):
             args = full_parser.parse_args()
 

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -124,11 +124,11 @@ class TestActionEnable:
 
         m_entitlement_cls = mock.MagicMock()
         m_ent_is_beta = mock.PropertyMock(return_value=False)
-        type(m_entitlement_cls).is_beta = m_ent_is_beta
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "testitlement": m_entitlement_cls
         }
         m_entitlement_obj = m_entitlement_cls.return_value
+        type(m_entitlement_obj).is_beta = m_ent_is_beta
         m_entitlement_obj.enable.return_value = True
 
         cfg = FakeConfig.for_attached_machine()
@@ -166,15 +166,15 @@ class TestActionEnable:
 
         m_ent2_cls = mock.Mock()
         m_ent2_is_beta = mock.PropertyMock(return_value=False)
-        type(m_ent2_cls).is_beta = m_ent2_is_beta
         m_ent2_obj = m_ent2_cls.return_value
         m_ent2_obj.enable.return_value = False
+        type(m_ent2_obj).is_beta = m_ent2_is_beta
 
         m_ent3_cls = mock.Mock()
         m_ent3_is_beta = mock.PropertyMock(return_value=False)
-        type(m_ent3_cls).is_beta = m_ent3_is_beta
         m_ent3_obj = m_ent3_cls.return_value
         m_ent3_obj.enable.return_value = True
+        type(m_ent3_obj).is_beta = m_ent3_is_beta
 
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "ent2": m_ent2_cls,
@@ -244,14 +244,14 @@ class TestActionEnable:
 
         m_ent2_cls = mock.Mock()
         m_ent2_is_beta = mock.PropertyMock(return_value=True)
-        type(m_ent2_cls).is_beta = m_ent2_is_beta
         m_ent2_obj = m_ent2_cls.return_value
+        type(m_ent2_obj).is_beta = m_ent2_is_beta
         m_ent2_obj.enable.return_value = False
 
         m_ent3_cls = mock.Mock()
         m_ent3_is_beta = mock.PropertyMock(return_value=False)
-        type(m_ent3_cls).is_beta = m_ent3_is_beta
         m_ent3_obj = m_ent3_cls.return_value
+        type(m_ent3_obj).is_beta = m_ent3_is_beta
         m_ent3_obj.enable.return_value = True
 
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
@@ -382,11 +382,12 @@ class TestPerformEnable:
         m_user_cfg = mock.PropertyMock(return_value={})
         type(m_cfg).cfg = m_user_cfg
         m_is_beta = mock.PropertyMock(return_value=allow_beta)
-        type(m_entitlement_cls).is_beta = m_is_beta
 
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "testitlement": m_entitlement_cls
         }
+        m_entitlement = m_entitlement_cls.return_value
+        type(m_entitlement).is_beta = m_is_beta
 
         kwargs = {"allow_beta": allow_beta}
         if silent_if_inapplicable is not None:
@@ -397,7 +398,6 @@ class TestPerformEnable:
             mock.call(m_cfg, assume_yes=False)
         ] == m_entitlement_cls.call_args_list
 
-        m_entitlement = m_entitlement_cls.return_value
         if silent_if_inapplicable:
             expected_enable_call = mock.call(silent_if_inapplicable=True)
         else:
@@ -415,11 +415,12 @@ class TestPerformEnable:
         self, m_entitlements, silent_if_inapplicable
     ):
         m_entitlement_cls = mock.Mock()
+        m_entitlement_obj = m_entitlement_cls.return_value
         m_cfg = mock.Mock()
         m_user_cfg = mock.PropertyMock(return_value={})
         type(m_cfg).cfg = m_user_cfg
         m_is_beta = mock.PropertyMock(return_value=True)
-        type(m_entitlement_cls).is_beta = m_is_beta
+        type(m_entitlement_obj).is_beta = m_is_beta
 
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             "testitlement": m_entitlement_cls

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -539,7 +539,7 @@ class TestStatus:
                 if allow_beta:
                     return False
 
-            return cls.is_beta
+            return cls._is_beta
 
         return False
 
@@ -1067,13 +1067,15 @@ class TestFeatures:
             ),
         ),
     )
-    def test_features_are_a_property_of_uaconfig(self, cfg_features, expected):
+    def test_features_are_a_extracted_from_config(
+        self, cfg_features, expected
+    ):
         if cfg_features is None:
             user_cfg = None
         else:
             user_cfg = {"features": cfg_features}
         cfg = UAConfig(cfg=user_cfg)
-        assert expected == cfg.features
+        assert expected == cfg.features()
 
 
 class TestMachineTokenOverlay:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -627,16 +627,7 @@ def is_config_value_true(config: "Dict[str, Any]", path_to_value: str):
             path_to_value parameter can not be translated into either
             a 'False' or 'True' boolean value.
     """
-    value = config
-    default_value = {}  # type: Any
-    paths = path_to_value.split(".")
-    leaf_value = paths[-1]
-    for key in paths:
-        if key == leaf_value:
-            default_value = "false"
-
-        value = value.get(key, default_value)
-
+    value = get_value_from_dict(config, path_to_value, default=False)
     value_str = str(value)
     if value_str.lower() == "true":
         return True
@@ -650,6 +641,22 @@ def is_config_value_true(config: "Dict[str, Any]", path_to_value: str):
                 value=value_str,
             )
         )
+
+
+def get_value_from_dict(
+    config: "Dict[str, Any]", path_to_value: str, default: "Any" = None
+):
+    """Return the value present at a given path_to_value"""
+    value = config
+    default_value = {}  # type: Any
+    paths = path_to_value.split(".")
+    leaf_value = paths[-1]
+    for key in paths:
+        if key == leaf_value:
+            default_value = default
+
+        value = value.get(key, default_value)
+    return value
 
 
 def should_reboot() -> bool:


### PR DESCRIPTION
# todo: unit test fix and integration test.
Convert is_beta class attribute to a @property method.
Allow overriding in config with
features:
    entitlements.fips.is_beta: false

Any value not null will set the is_beta value on the entitlement.

## Proposed Commit Message
Convert is_beta class attribute to a @property method.
Allow overriding in config with
features:
    entitlements:
        esm_apps: 
            is_beta: false

Any value not null will set the is_beta value on the entitlement.

## Test Steps
```bash
# See esm-apps hidden from status
PYTHONPATH=. python3 -m uaclient.cli status   | grep esm-apps 
# add esm-apps to non-beta status
echo "features:\n  entitlements:\n    esm_apps:\n      is_beta: false" >> uaclient.conf
# See esm-apps as production
PYTHONPATH=. python3 -m uaclient.cli status   | grep esm-apps 

# Note that version will still contain +entitlements which we don't want on PRO 26.2 images
PYTHONPATH=. python3 -m uaclient.cli version
20.3-360-g5ff17394 +entitlements
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
