### PR TITLE
Show beta services in status if they are enabled

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -15,7 +15,17 @@ Feature: Command behaviour when attached to an UA subscription
         """
         And I run `ua auto-attach` with sudo
         And I run `ua status --wait` as non-root
-        And I run `ua status --all` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            SERVICE       ENTITLED  STATUS    DESCRIPTION
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +<fips-s> +NIST-certified FIPS modules
+            fips-updates  +yes +<fips-s> +Uncertified security updates to FIPS modules
+            livepatch     +yes +enabled  +Canonical Livepatch service
+            """
+        When I run `ua status --all` as non-root
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION
@@ -96,7 +106,17 @@ Feature: Command behaviour when attached to an UA subscription
         """
         And I run `ua auto-attach` with sudo
         And I run `ua status --wait` as non-root
-        And I run `ua status --all` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            SERVICE       ENTITLED  STATUS    DESCRIPTION
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +<fips-s> +NIST-certified FIPS modules
+            fips-updates  +yes +<fips-s> +Uncertified security updates to FIPS modules
+            livepatch     +yes +enabled  +Canonical Livepatch service
+            """
+        When I run `ua status --all` as non-root
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION
@@ -177,7 +197,17 @@ Feature: Command behaviour when attached to an UA subscription
         """
         And I run `ua auto-attach` with sudo
         And I run `ua status --wait` as non-root
-        And I run `ua status --all` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            SERVICE       ENTITLED  STATUS    DESCRIPTION
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +<fips-s> +NIST-certified FIPS modules
+            fips-updates  +yes +<fips-s> +Uncertified security updates to FIPS modules
+            livepatch     +yes +enabled  +Canonical Livepatch service
+            """
+        When I run `ua status --all` as non-root
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -368,7 +368,11 @@ class UAConfig:
                 released_resources.append(resource)
                 continue
 
-            if not ent_cls.is_beta:
+            enabled_status = status.UserFacingStatus.ACTIVE.value
+            if (
+                not ent_cls.is_beta
+                or resource.get("status", "") == enabled_status
+            ):
                 released_resources.append(resource)
 
         if released_resources:


### PR DESCRIPTION
## Proposed Commit Message
Show beta services in status if they are enabled

Currently, we are always hiding beta services from ua status, even if a beta service is enabled. However, we should always show
the user which services are enabled in the machine by default, being beta services or not.

Fixes: #1410

## Test Steps
Run the modified integration tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
