### PR TITLE
Fix/prompt for token

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -205,8 +205,7 @@ Feature: Command behaviour when unattached
         \(1/1\) xterm:
         A fix is available in Ubuntu standard updates.
         The update is not yet installed.
-        apt-get update
-        apt-get install --only-upgrade -y xterm
+        .*\{ apt update && apt install --only-upgrade -y xterm \}.*
         """
         When I run `ua fix CVE-2021-27135` with sudo
         Then stdout matches regexp:

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -129,10 +129,7 @@ def _parse_apt_update_for_invalid_apt_config(apt_error: str) -> str:
 
 
 def run_apt_command(
-    cmd: "List[str]",
-    error_msg: str,
-    env: "Optional[Dict[str, str]]" = {},
-    print_cmd: bool = False,
+    cmd: "List[str]", error_msg: str, env: "Optional[Dict[str, str]]" = {}
 ) -> str:
     """Run an apt command, retrying upon failure APT_RETRIES times.
 
@@ -140,15 +137,11 @@ def run_apt_command(
     :param error_msg: The string to raise as UserFacingError when all retries
        are exhausted in failure.
     :param env: Optional dictionary of environment variables to pass to subp.
-    :param print_cmd: If true, print the apt command that will be run
 
     :return: stdout from successful run of the apt command.
     :raise UserFacingError: on issues running apt-cache policy.
     """
     try:
-        if print_cmd:
-            print(" ".join(cmd))
-
         out, _err = util.subp(
             cmd, capture=True, retry_sleeps=APT_RETRIES, env=env
         )

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -21,6 +21,16 @@ CLOUDINIT_INSTANCE_ID_FILE = "/var/lib/cloud/data/instance-id"
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
 DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws", "gce": "gcp"}
 
+CLOUD_TYPE_TO_TITLE = {
+    "aws": "AWS",
+    "aws-china": "AWS China",
+    "aws-gov": "AWS Gov",
+    "azure": "Azure",
+    "gcp": "GCP",
+}
+
+PRO_CLOUDS = ["aws", "azure"]
+
 
 def get_instance_id(
     _iid_file: str = CLOUDINIT_INSTANCE_ID_FILE

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -134,9 +134,13 @@ MESSAGE_SECURITY_FIX_RELEASE_STREAM = "A fix is available in {fix_stream}."
 MESSAGE_SECURITY_UPDATE_NOT_INSTALLED = "The update is not yet installed."
 MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION = """\
 The update is not installed because this system is not attached to a
-subscription that covers these packages.
+subscription.
 """
 MESSAGE_SECURITY_UPDATE_INSTALLED = "The update is already installed."
+MESSAGE_SECURITY_USE_PRO_TMPL = (
+    "For easiest security on {title}, use Ubuntu PRO."
+    " https://ubuntu.com/{cloud}/pro."
+)
 MESSAGE_SECURITY_ISSUE_RESOLVED = OKGREEN_CHECK + " {issue} is resolved."
 MESSAGE_SECURITY_ISSUE_UNAFFECTED = (
     OKGREEN_CHECK + " {issue} does not affect your system."
@@ -239,6 +243,11 @@ This will disable access to certified FIPS packages.
     + PROMPT_YES_NO
 )
 
+PROMPT_ENTER_TOKEN = """\
+Enter your token (from https://ubuntu.com/advantage) to attach this system:"""
+PROMPT_UA_SUBSCRIPTION_URL = """\
+Open a browser to: https://ubuntu.com/advantage/subscribe"""
+
 STATUS_UNATTACHED_TMPL = "{name: <14}{available: <11}{description}"
 
 STATUS_HEADER = "SERVICE       ENTITLED  STATUS    DESCRIPTION"
@@ -316,6 +325,17 @@ To install them, run this command as root (try using sudo)
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""
     return STATUS_COLOR.get(string, string) if sys.stdout.isatty() else string
+
+
+def colorize_commands(commands: "List[List[str]]") -> str:
+    content = ""
+    for cmd in commands:
+        if content:
+            content += " && "
+        content += " ".join(cmd)
+    return "{color}{{ {content} }}{end}".format(
+        color=TxtColor.DISABLEGREY, content=content, end=TxtColor.ENDC
+    )
 
 
 def get_section_column_content(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1,8 +1,6 @@
 """Tests related to uaclient.apt module."""
 
-import contextlib
 import glob
-import io
 import mock
 import os
 import stat
@@ -913,21 +911,3 @@ class TestRunAptCommand:
 
         expected_message = "\n".join(output_list)
         assert expected_message == excinfo.value.msg
-
-    @pytest.mark.parametrize("print_cmd", ((True), (False)))
-    @mock.patch("uaclient.apt.util.subp")
-    def test_run_apt_command_can_print_cmd_to_output(self, m_subp, print_cmd):
-        m_subp.side_effect = util.ProcessExecutionError(cmd="apt update")
-        fake_stdout = io.StringIO()
-        with contextlib.redirect_stdout(fake_stdout):
-            with pytest.raises(exceptions.UserFacingError):
-                run_apt_command(
-                    cmd=["apt", "update"],
-                    error_msg=status.MESSAGE_APT_UPDATE_FAILED,
-                    print_cmd=print_cmd,
-                )
-
-        if print_cmd:
-            assert "apt update" in fake_stdout.getvalue()
-        else:
-            assert "apt update" not in fake_stdout.getvalue()

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -609,20 +609,23 @@ class TestQueryInstalledPkgSources:
             ),
         ),
     )
+    @pytest.mark.parametrize("series", ("trusty", "bionic"))
     @mock.patch("uaclient.security.util.subp")
+    @mock.patch("uaclient.util.get_platform_info")
     def test_result_keyed_by_source_package_name(
-        self, subp, dpkg_out, results
+        self, get_platform_info, subp, series, dpkg_out, results
     ):
+        get_platform_info.return_value = {"series": series}
         subp.return_value = dpkg_out, ""
         assert results == query_installed_source_pkg_versions()
-        assert [
-            mock.call(
-                [
-                    "dpkg-query",
-                    "-f=${Package},${Source},${Version},${db:Status-Status}\n",
-                    "-W",
-                ]
+        if series == "trusty":
+            _format = "-f=${Package},${Source},${Version},${Status}\n"
+        else:
+            _format = (
+                "-f=${Package},${Source},${Version},${db:Status-Status}\n"
             )
+        assert [
+            mock.call(["dpkg-query", _format, "-W"])
         ] == subp.call_args_list
 
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -1,5 +1,4 @@
 from errno import ENOENT
-import sys
 import datetime
 import json
 import logging

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -1,4 +1,5 @@
 from errno import ENOENT
+import sys
 import datetime
 import json
 import logging
@@ -410,10 +411,15 @@ def prompt_choices(msg: str = "", valid_choices: "List[str]" = []) -> str:
     :return: Valid response character chosen.
     """
     value = ""
-    if msg[-1] != " ":
-        msg += " "
-    while value not in valid_choices:
-        value = input(msg).lower().strip()
+    error_msg = "{} is not one of: {}".format(
+        value, ", ".join([choice.upper() for choice in valid_choices])
+    )
+    while True:
+        print(msg)
+        value = input("> ").lower()
+        if value in valid_choices:
+            break
+        print(error_msg)
     return value
 
 


### PR DESCRIPTION
Prompt updates for inline error messages, wire token prompt to _attach_with_token
and fix trusty installed package via dpkg-query format ${Status} option.

This PR does not handle integration testing due to #1327


## Proposed Commit Message
Rebase from existing commits

*  fix: prompt to emit pro suggestion on pro_clouds if unattached
    
    When unattached, emit ubuntu pro suggestion before prompting to
    attach.
    
    Also prompt for token if chosen and wire the response to
    _attach_with_token.
    
    Fixes: #1386

*   util: add error prompts on invalid selection
    
    Add inline error messages during reprompts which will color
    that error text red on invalid input.

*   trusty: query_installed_source_pkg_versions support
    
    dpkg-query doesn't support ${db:Status-Status}.
    Use ${Status} instead otherwise trusty will not
    list any installed packages.

## Test Steps
```bash
# test valid prompt and retries
PYTHONPATH=. python3 -c 'from uaclient.util import prompt_choices; prompt_choices("\nChoose: [S]ubscribe at ubuntu.com [A]ttach or [C]ancel", valid_choices=["s", "a", "c"])'

# to test prompts and attach and fix 
lxc launch ubuntu-daily:trusty  dev-t
lxc exec dev-t -- apt install libkrad0=1.12+dfsg-2ubuntu5.4;
lxc exec dev-t -- apt install krb5-locales=1.12+dfsg-2ubuntu5.4;   # optional 2nd binary needing upgrades
# try both on attached an detached machine
lxc exec dev-t  ua fix CVE-2020-28196 
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
