### PR TITLE
Add stop "." punctuation to messages

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -7,12 +7,12 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
         When I verify that running `ua attach INVALID_TOKEN` `with sudo` exits `1`
         Then stderr matches regexp:
             """
-            Invalid token. See https://ubuntu.com/advantage
+            Invalid token. See https://ubuntu.com/advantage.
             """
         When I verify that running `ua attach INVALID_TOKEN` `as non-root` exits `1`
         Then I will see the following on stderr:
              """
-             This command must be run as root (try using sudo)
+             This command must be run as root (try using sudo).
              """
         Examples: ubuntu release
            | release |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -8,12 +8,12 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua refresh` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         When I run `ua refresh` with sudo
         Then I will see the following on stdout:
             """
-            Successfully refreshed your subscription
+            Successfully refreshed your subscription.
             """
 
         Examples: ubuntu release
@@ -30,13 +30,13 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua disable livepatch` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         And I verify that running `ua disable livepatch` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             Livepatch is not currently enabled
-            See: sudo ua status
+            See: sudo ua status.
             """
 
         Examples: ubuntu release
@@ -53,18 +53,18 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua disable foobar` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         And I verify that running `ua disable foobar` `with sudo` exits `1`
         And stderr matches regexp:
             """
             Cannot disable unknown service 'foobar'.
-            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch
+            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch.
             """
         And I verify that running `ua disable esm-infra` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         When I run `ua disable esm-infra` with sudo
         Then I will see the following on stdout:
@@ -91,7 +91,7 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua detach` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         When I run `ua detach --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -99,7 +99,7 @@ Feature: Command behaviour when attached to an UA subscription
             Detach will disable the following service:
                 esm-infra
             Updating package lists
-            This machine is now detached
+            This machine is now detached.
             """
        When I run `ua status --all` as non-root
        Then stdout matches regexp:
@@ -133,7 +133,7 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua auto-attach` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         When I run `ua auto-attach` with sudo
         Then stderr matches regexp:
@@ -231,12 +231,12 @@ Feature: Command behaviour when attached to an UA subscription
             """
             Updating package lists
             Livepatch is not currently enabled
-            See: sudo ua status
+            See: sudo ua status.
             """
         And stderr matches regexp:
             """
             Cannot disable unknown service 'foobar'.
-            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch
+            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch.
             """
         When I run `ua status` with sudo
         Then stdout matches regexp:
@@ -258,13 +258,13 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua disable foobar` `as non-root` exits `1`
         And stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         And I verify that running `ua disable foobar` `with sudo` exits `1`
         And stderr matches regexp:
             """
             Cannot disable unknown service 'foobar'.
-            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch
+            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch.
             """
         And I verify that running `ua disable esm-infra` `as non-root` exits `1`
         And stderr matches regexp:

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -8,7 +8,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
         And I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
         And I verify that running `ua enable cc-eal --beta` `with sudo` exits `1`
         And I will see the following on stdout
@@ -24,7 +24,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'cc-eal'.
-            Try esm-infra, fips, fips-updates, livepatch
+            Try esm-infra, fips, fips-updates, livepatch.
             """
 
         Examples: ubuntu release
@@ -34,40 +34,13 @@ Feature: Enable command behaviour when attached to an UA subscription
            | trusty  | CC EAL2 is not available for Ubuntu 14.04 LTS (Trusty Tahr).   |
 
     @series.all
-    Scenario Outline: Attached enable a disabled beta service and unknown service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua enable cc-eal foobar` `as non-root` exits `1`
-        And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo)
-            """
-        And I verify that running `ua enable cc-eal foobar` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar, cc-eal'.
-            Try esm-infra, fips, fips-updates, livepatch
-            """
-
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | trusty  |
-           | xenial  |
-
-    @series.all
-    Scenario Outline: Attached enable of an unknown service in a ubuntu machine
+    Scenario Outline: Attached enable of a service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `ua enable foobar` `as non-root` exits `1`
         And I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
         And I verify that running `ua enable foobar` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -77,31 +50,24 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try esm-infra, fips, fips-updates, livepatch
+            Try esm-infra, fips, fips-updates, livepatch.
             """
-
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | trusty  |
-           | xenial  |
-
-    @series.all
-    Scenario Outline: Attached enable of a known service already enabled (UA Infra) in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua enable esm-infra` `as non-root` exits `1`
-        And I will see the following on stderr:
+        And I verify that running `ua enable cc-eal foobar` `with sudo` exits `1`
+        And I will see the following on stdout:
             """
-            This command must be run as root (try using sudo)
+            One moment, checking your subscription first
+            """
+        And stderr matches regexp:
+            """
+            Cannot enable unknown service 'foobar, cc-eal'.
+            Try esm-infra, fips, fips-updates, livepatch.
             """
         And I verify that running `ua enable esm-infra` `with sudo` exits `1`
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
             ESM Infra is already enabled.
-            See: sudo ua status
+            See: sudo ua status.
             """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
@@ -135,7 +101,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             One moment, checking your subscription first
             ESM Infra is already enabled.
-            See: sudo ua status
+            See: sudo ua status.
             """
         When I run `apt install -y <pkg-version>` with sudo, retrying exit [100]
         And I run `apt update` with sudo
@@ -161,32 +127,36 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `ua enable <service> <flag>` `as non-root` exits `1`
+        Then I verify that running `ua enable livepatch` `as non-root` exits `1`
         And I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
-        And I verify that running `ua enable <service> <flag>` `with sudo` exits `1`
+        And I verify that running `ua enable livepatch` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
-            Cannot install <title> on a container
+            Cannot install Livepatch on a container.
+            """
+        And I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
+        And I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install FIPS on a container.
+            """
+        And I verify that running `ua enable fips-updates --assume-yes` `with sudo` exits `1`
+        And I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Cannot install FIPS Updates on a container.
             """
 
         Examples: Un-supported services in containers
-           | release | service      | title        | flag         |
-           | bionic  | livepatch    | Livepatch    |              |
-           | bionic  | fips         | FIPS         | --assume-yes |
-           | bionic  | fips-updates | FIPS Updates | --assume-yes |
-           | focal   | livepatch    | Livepatch    |              |
-           | focal   | fips         | FIPS         | --assume-yes |
-           | focal   | fips-updates | FIPS Updates | --assume-yes |
-           | trusty  | livepatch    | Livepatch    |              |
-           | trusty  | fips         | FIPS         | --assume-yes |
-           | trusty  | fips-updates | FIPS Updates | --assume-yes |
-           | xenial  | livepatch    | Livepatch    |              |
-           | xenial  | fips         | FIPS         | --assume-yes |
-           | xenial  | fips-updates | FIPS Updates | --assume-yes |
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
 
     @series.all
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
@@ -195,26 +165,29 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I verify that running `ua enable <service>` `as non-root` exits `1`
         And I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
-        And I verify that running `ua enable <service> --beta` `with sudo` exits `1`
+        And I verify that running `ua enable cis --beta` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
-            This subscription is not entitled to <title>.
-            For more information see: https://ubuntu.com/advantage
+            This subscription is not entitled to CIS Audit
+            For more information see: https://ubuntu.com/advantage.
+            """
+        And I verify that running `ua enable esm-apps --beta` `with sudo` exits `1`
+        And I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            This subscription is not entitled to ESM Apps
+            For more information see: https://ubuntu.com/advantage.
             """
 
         Examples: not entitled services
-           | release | service      | title        |
-           | bionic  | cis          | CIS Audit    |
-           | bionic  | esm-apps     | ESM Apps     |
-           | focal   | cis          | CIS Audit    |
-           | focal   | esm-apps     | ESM Apps     |
-           | trusty  | cis          | CIS Audit    |
-           | trusty  | esm-apps     | ESM Apps     |
-           | xenial  | cis          | CIS Audit    |
-           | xenial  | esm-apps     | ESM Apps     |
+           | release |
+           | bionic  |
+           | focal   |
+           | trusty  |
+           | xenial  |
 
     @series.focal
     @uses.config.machine_type.lxd.vm
@@ -321,7 +294,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             Updating package lists
             Installing FIPS packages
             FIPS enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I append the following on uaclient config:
             """
@@ -332,7 +305,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And I will see the following on stdout
             """
             One moment, checking your subscription first
-            Cannot enable Livepatch when FIPS is enabled
+            Cannot enable Livepatch when FIPS is enabled.
             """
 
     @series.bionic
@@ -359,7 +332,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
         And I will see the following on stderr
             """
-            Cannot enable FIPS when Livepatch is enabled
+            Cannot enable FIPS when Livepatch is enabled.
             """
 
     @series.xenial
@@ -385,7 +358,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             Updating package lists
             Installing FIPS packages
             FIPS enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `ua status` with sudo
         Then stdout matches regexp:
@@ -425,13 +398,13 @@ Feature: Enable command behaviour when attached to an UA subscription
             Updating package lists
             Installing FIPS Updates packages
             FIPS Updates enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
         Then I will see the following on stdout
             """
             One moment, checking your subscription first
-            Cannot enable FIPS when FIPS Updates is enabled
+            Cannot enable FIPS when FIPS Updates is enabled.
             """
 
         Examples: ubuntu release

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -8,13 +8,13 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
         And I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
         When I run `ua enable cc-eal --beta` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found
+            GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found.
             """ 
     @series.xenial
     @series.bionic

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -6,13 +6,13 @@ Feature: Command behaviour when unattached
         When I verify that running `ua auto-attach` `as non-root` exits `1`
         Then stderr matches regexp:
             """
-            This command must be run as root \(try using sudo\)
+            This command must be run as root \(try using sudo\).
             """
         When I run `ua auto-attach` with sudo
         Then stderr matches regexp:
             """
             Auto-attach image support is not available on <data>
-            See: https://ubuntu.com/advantage
+            See: https://ubuntu.com/advantage.
             """
 
         Examples: ubuntu release
@@ -28,13 +28,13 @@ Feature: Command behaviour when unattached
         When I verify that running `ua <command>` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
         When I verify that running `ua <command>` `with sudo` exits `1`
         Then stderr matches regexp:
             """
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """
 
         Examples: ua commands
@@ -54,14 +54,14 @@ Feature: Command behaviour when unattached
         When I verify that running `ua <command> <service>` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
-            This command must be run as root (try using sudo)
+            This command must be run as root (try using sudo).
             """
         When I verify that running `ua <command> <service>` `with sudo` exits `1`
         Then stderr matches regexp:
             """
             To use '<service>' you need an Ubuntu Advantage subscription
             Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """
 
         Examples: ua commands

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -13,7 +13,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """
         When I run `ua status --all` as non-root
         Then stdout matches regexp:
@@ -28,7 +28,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """
         When I run `ua status` with sudo
         Then stdout matches regexp:
@@ -40,7 +40,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """
         When I run `ua status --all` with sudo
         Then stdout matches regexp:
@@ -55,7 +55,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """ 
         When I append the following on uaclient config:
             """
@@ -75,7 +75,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            See https://ubuntu.com/advantage.
             """ 
 
         Examples: ubuntu release

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -469,7 +469,7 @@ def action_disable(args, cfg, **kwargs):
         ret &= _perform_disable(entitlement, cfg, assume_yes=args.assume_yes)
 
     if entitlements_not_found:
-        valid_names = "Try " + entitlements.ALL_ENTITLEMENTS_STR
+        valid_names = "Try " + entitlements.ALL_ENTITLEMENTS_STR + "."
         service_msg = "\n".join(
             textwrap.wrap(valid_names, width=80, break_long_words=False)
         )
@@ -570,7 +570,7 @@ def action_enable(args, cfg, **kwargs):
             valid_names = entitlements.RELEASED_ENTITLEMENTS_STR
         service_msg = "\n".join(
             textwrap.wrap(
-                "Try " + valid_names, width=80, break_long_words=False
+                "Try " + valid_names + ".", width=80, break_long_words=False
             )
         )
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -118,7 +118,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         )
         return (
             (
-                "Cannot install {} on a container".format(self.title),
+                "Cannot install {} on a container.".format(self.title),
                 lambda: util.is_container(),
                 False,
             ),

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -49,17 +49,17 @@ class LivepatchEntitlement(base.UAEntitlement):
 
         return (
             (
-                "Cannot install Livepatch on a container",
+                "Cannot install Livepatch on a container.",
                 lambda: util.is_container(),
                 False,
             ),
             (
-                "Cannot enable Livepatch when FIPS is enabled",
+                "Cannot enable Livepatch when FIPS is enabled.",
                 lambda: is_fips_enabled,
                 False,
             ),
             (
-                "Cannot enable Livepatch when FIPS Updates is enabled",
+                "Cannot enable Livepatch when FIPS Updates is enabled.",
                 lambda: is_fips_updates_enabled,
                 False,
             ),

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -121,7 +121,7 @@ class TestUaEntitlement:
 
         expected_stdout = (
             "Test Concrete Entitlement is not currently enabled\n"
-            "See: sudo ua status\n"
+            "See: sudo ua status.\n"
         )
         stdout, _ = capsys.readouterr()
         assert expected_stdout == stdout
@@ -154,8 +154,8 @@ class TestUaEntitlement:
         assert not entitlement.can_enable(**kwargs)
 
         expected_stdout = (
-            "This subscription is not entitled to Test Concrete Entitlement.\n"
-            "For more information see: https://ubuntu.com/advantage\n"
+            "This subscription is not entitled to Test Concrete Entitlement\n"
+            "For more information see: https://ubuntu.com/advantage.\n"
         )
         if silent:
             expected_stdout = ""
@@ -203,7 +203,7 @@ class TestUaEntitlement:
 
         expected_stdout = (
             "Test Concrete Entitlement is already enabled.\n"
-            "See: sudo ua status\n"
+            "See: sudo ua status.\n"
         )
         if silent:
             expected_stdout = ""

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -52,7 +52,7 @@ class TestCommonCriteriaEntitlementUserFacingStatus:
                 "xenial",
                 "16.04 LTS (Xenial Xerus)",
                 "CC EAL2 is not available for platform arm64.\n"
-                "Supported platforms are: x86_64, ppc64le, s390x",
+                "Supported platforms are: x86_64, ppc64le, s390x.",
             ),
             (
                 "s390x",

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -218,7 +218,7 @@ class TestLivepatchEntitlementCanEnable:
             assert not entitlement.can_enable()
         msg = (
             "Livepatch is not available for kernel 4.2.9-00-generic.\n"
-            "Minimum kernel version required: 4.4\n"
+            "Minimum kernel version required: 4.4.\n"
         )
         assert (msg, "") == capsys.readouterr()
 
@@ -234,7 +234,7 @@ class TestLivepatchEntitlementCanEnable:
             assert not entitlement.can_enable()
         msg = (
             "Livepatch is not available for kernel 4.4.0-140-notgeneric.\n"
-            "Supported flavors are: generic, lowlatency\n"
+            "Supported flavors are: generic, lowlatency.\n"
         )
         assert (msg, "") == capsys.readouterr()
 
@@ -272,7 +272,9 @@ class TestLivepatchEntitlementCanEnable:
         else:
             msg = (
                 "Livepatch is not available for kernel {}.\n"
-                "Minimum kernel version required: 4.4\n".format(kernel_version)
+                "Minimum kernel version required: 4.4.\n".format(
+                    kernel_version
+                )
             )
         assert (msg, "") == capsys.readouterr()
 
@@ -287,7 +289,7 @@ class TestLivepatchEntitlementCanEnable:
             assert not entitlement.can_enable()
         msg = (
             "Livepatch is not available for platform ppc64le.\n"
-            "Supported platforms are: x86_64\n"
+            "Supported platforms are: x86_64.\n"
         )
         assert (msg, "") == capsys.readouterr()
 
@@ -302,7 +304,7 @@ class TestLivepatchEntitlementCanEnable:
             m_is_container.return_value = True
             entitlement = LivepatchEntitlement(entitlement.cfg)
             assert not entitlement.can_enable()
-        msg = "Cannot install Livepatch on a container\n"
+        msg = "Cannot install Livepatch on a container.\n"
         assert (msg, "") == capsys.readouterr()
 
 
@@ -679,7 +681,7 @@ class TestLivepatchEntitlementEnable:
                 with contextlib.redirect_stdout(fake_stdout):
                     entitlement.enable()
 
-        expected_msg = "Cannot enable Livepatch when {} is enabled".format(
+        expected_msg = "Cannot enable Livepatch when {} is enabled.".format(
             cls_title
         )
         assert expected_msg.strip() == fake_stdout.getvalue().strip()

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -537,7 +537,7 @@ class TestRepoEnable:
             )
         ]
 
-        reboot_msg = "A reboot is required to complete install"
+        reboot_msg = "A reboot is required to complete install."
         expected_output = (
             "\n".join(
                 ["Updating package lists", "Repo Test Class enabled"]

--- a/uaclient/gpg.py
+++ b/uaclient/gpg.py
@@ -18,7 +18,7 @@ def export_gpg_key(source_keyfile: str, destination_keyfile: str) -> None:
     logging.debug("Exporting GPG key %s", source_keyfile)
     if not os.path.exists(source_keyfile):
         raise exceptions.UserFacingError(
-            "GPG key '{}' not found".format(source_keyfile)
+            "GPG key '{}' not found.".format(source_keyfile)
         )
     shutil.copy(source_keyfile, destination_keyfile)
     os.chmod(destination_keyfile, 0o644)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -152,54 +152,54 @@ MESSAGE_SECURITY_URL = (
 MESSAGE_APT_INSTALL_FAILED = "APT install failed."
 MESSAGE_APT_UPDATE_FAILED = "APT update failed."
 MESSAGE_APT_UPDATE_INVALID_URL_CONFIG = (
-    "APT update failed to read APT config for the following URL{}:\n{}"
+    "APT update failed to read APT config for the following URL{}:\n{}."
 )
 MESSAGE_APT_POLICY_FAILED = "Failure checking APT policy."
 MESSAGE_APT_UPDATING_LISTS = "Updating package lists"
 MESSAGE_CONNECTIVITY_ERROR = """\
 Failed to connect to authentication server
-Check your Internet connection and try again"""
-LOG_CONNECTIVITY_ERROR_TMPL = MESSAGE_CONNECTIVITY_ERROR + ". {error}"
+Check your Internet connection and try again."""
+LOG_CONNECTIVITY_ERROR_TMPL = MESSAGE_CONNECTIVITY_ERROR + " {error}"
 LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (
-    MESSAGE_CONNECTIVITY_ERROR + ". Failed to access URL: {url}. {error}"
+    MESSAGE_CONNECTIVITY_ERROR + " Failed to access URL: {url}. {error}"
 )
-MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)"
+MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)."
 MESSAGE_ALREADY_DISABLED_TMPL = """\
-{title} is not currently enabled\nSee: sudo ua status"""
+{title} is not currently enabled\nSee: sudo ua status."""
 MESSAGE_ENABLED_FAILED_TMPL = "Could not enable {title}."
 MESSAGE_DISABLE_FAILED_TMPL = "Could not disable {title}."
 MESSAGE_ENABLED_TMPL = "{title} enabled"
 MESSAGE_ALREADY_ATTACHED = """\
 This machine is already attached to '{account_name}'
-To use a different subscription first run: sudo ua detach"""
+To use a different subscription first run: sudo ua detach."""
 MESSAGE_ALREADY_ENABLED_TMPL = """\
-{title} is already enabled.\nSee: sudo ua status"""
+{title} is already enabled.\nSee: sudo ua status."""
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\
 {title} is not available for platform {arch}.
-Supported platforms are: {supported_arches}"""
+Supported platforms are: {supported_arches}."""
 MESSAGE_INAPPLICABLE_SERIES_TMPL = """\
 {title} is not available for Ubuntu {series}."""
 MESSAGE_INAPPLICABLE_KERNEL_TMPL = """\
 {title} is not available for kernel {kernel}.
-Supported flavors are: {supported_kernels}"""
+Supported flavors are: {supported_kernels}."""
 MESSAGE_INAPPLICABLE_KERNEL_VER_TMPL = """\
 {title} is not available for kernel {kernel}.
-Minimum kernel version required: {min_kernel}"""
+Minimum kernel version required: {min_kernel}."""
 MESSAGE_UNENTITLED_TMPL = """\
-This subscription is not entitled to {title}.
-For more information see: https://ubuntu.com/advantage"""
+This subscription is not entitled to {title}
+For more information see: https://ubuntu.com/advantage."""
 MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE = """\
 Unable to determine auto-attach platform support
-For more information see: https://ubuntu.com/advantage"""
+For more information see: https://ubuntu.com/advantage."""
 MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE = """\
 Auto-attach image support is not available on {cloud_type}
-See: https://ubuntu.com/advantage"""
+See: https://ubuntu.com/advantage."""
 MESSAGE_UNSUPPORTED_AUTO_ATTACH = """\
 Auto-attach image support is not available on this image
-See: https://ubuntu.com/advantage"""
+See: https://ubuntu.com/advantage."""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
-See https://ubuntu.com/advantage"""
+See https://ubuntu.com/advantage."""
 MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 MESSAGE_NO_ACTIVE_OPERATIONS = """No Ubuntu Advantage operations are running"""
@@ -252,7 +252,7 @@ MESSAGE_ATTACH_EXPIRED_TOKEN = """\
 Expired token or contract. To obtain a new token visit: \
 https://ubuntu.com/advantage"""
 MESSAGE_ATTACH_INVALID_TOKEN = """\
-Invalid token. See https://ubuntu.com/advantage"""
+Invalid token. See https://ubuntu.com/advantage."""
 MESSAGE_ATTACH_REQUIRES_TOKEN = """\
 Attach requires a token: sudo ua attach <TOKEN>
 To obtain a token please visit: https://ubuntu.com/advantage"""
@@ -274,17 +274,17 @@ To file a bug run: ubuntu-bug ubuntu-advantage-tools"""
 MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
 To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
-See https://ubuntu.com/advantage"""
+See https://ubuntu.com/advantage."""
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
 MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL = """\
-A reboot is required to complete {operation}"""
+A reboot is required to complete {operation}."""
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
 Service {name} is recommended by default. Run: sudo ua enable {name}"""
-MESSAGE_DETACH_SUCCESS = "This machine is now detached"
+MESSAGE_DETACH_SUCCESS = "This machine is now detached."
 MESSAGE_DETACH_AUTOMATION_FAILURE = "Unable to automatically detach machine"
 
 MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"
-MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"
+MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription."
 MESSAGE_REFRESH_FAILURE = "Unable to refresh your subscription"
 
 MESSAGE_INCOMPATIBLE_SERVICE = """\
@@ -298,7 +298,7 @@ Cannot enable {service_being_enabled} when {incompatible_service} is enabled
 
 MESSAGE_FIPS_BLOCK_ON_CLOUD = """\
 Ubuntu {series} does not provide {cloud} optimized FIPS kernel
-For help see: https://ubuntu.com/advantage"""
+For help see: https://ubuntu.com/advantage."""
 ERROR_INVALID_CONFIG_VALUE = """\
 Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \
 Expected {expected_value}, found {value}."""

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -911,7 +911,7 @@ class TestRunAptCommand:
                 error_msg=status.MESSAGE_APT_UPDATE_FAILED,
             )
 
-        expected_message = "\n".join(output_list)
+        expected_message = "\n".join(output_list) + "."
         assert expected_message == excinfo.value.msg
 
     @pytest.mark.parametrize("print_cmd", ((True), (False)))

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -580,6 +580,8 @@ class TestMain:
         assert "{}\n".format(status.MESSAGE_CONNECTIVITY_ERROR) == err
         error_log = caplog_text()
 
+        print(expected_log)
+        print(error_log)
         assert expected_log in error_log
         assert "Traceback (most recent call last):" in error_log
 

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -9,7 +9,7 @@ from uaclient import status
 
 ALL_SERVICE_MSG = "\n".join(
     textwrap.wrap(
-        "Try " + entitlements.ALL_ENTITLEMENTS_STR,
+        "Try " + entitlements.ALL_ENTITLEMENTS_STR + ".",
         width=80,
         break_long_words=False,
     )
@@ -112,7 +112,7 @@ class TestDisable:
 
         assert (
             expected_error_tmpl.format(
-                operation="disable", name="ent1", service_msg="Try ent2, ent3"
+                operation="disable", name="ent1", service_msg="Try ent2, ent3."
             )
             == err.value.msg
         )

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -92,7 +92,7 @@ class TestActionEnable:
             action_enable(args, cfg)
         service_msg = "\n".join(
             textwrap.wrap(
-                "Try " + entitlements.ALL_ENTITLEMENTS_STR,
+                "Try " + entitlements.ALL_ENTITLEMENTS_STR + ".",
                 width=80,
                 break_long_words=False,
             )
@@ -201,7 +201,7 @@ class TestActionEnable:
             expected_error_tmpl.format(
                 operation="enable",
                 name="ent1",
-                service_msg="Try " + m_entitlements.ALL_ENTITLEMENTS_STR,
+                service_msg="Try " + m_entitlements.ALL_ENTITLEMENTS_STR + ".",
             )
             == err.value.msg
         )
@@ -275,9 +275,9 @@ class TestActionEnable:
 
         if not beta_flag:
             not_found_name += ", ent2"
-            ent_str = "Try " + m_entitlements.RELEASED_ENTITLEMENTS_STR
+            ent_str = "Try " + m_entitlements.RELEASED_ENTITLEMENTS_STR + "."
         else:
-            ent_str = "Try " + m_entitlements.ALL_ENTITLEMENTS_STR
+            ent_str = "Try " + m_entitlements.ALL_ENTITLEMENTS_STR + "."
             mock_ent_list.append(m_ent2_cls)
             mock_obj_list.append(m_ent3_obj)
         service_msg = "\n".join(
@@ -334,9 +334,9 @@ class TestActionEnable:
 
         assert expected_msg == fake_stdout.getvalue()
         if beta:
-            ent_str = "Try " + entitlements.ALL_ENTITLEMENTS_STR
+            ent_str = "Try " + entitlements.ALL_ENTITLEMENTS_STR + "."
         else:
-            ent_str = "Try " + entitlements.RELEASED_ENTITLEMENTS_STR
+            ent_str = "Try " + entitlements.RELEASED_ENTITLEMENTS_STR + "."
         service_msg = "\n".join(
             textwrap.wrap(ent_str, width=80, break_long_words=False)
         )

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -21,7 +21,7 @@ SERVICE       AVAILABLE  DESCRIPTION
 livepatch     yes        Canonical Livepatch service
 
 This machine is not attached to a UA subscription.
-See https://ubuntu.com/advantage
+See https://ubuntu.com/advantage.
 """
 
 ATTACHED_STATUS = """\


### PR DESCRIPTION
## Proposed Commit Message
Add stop "." punctuation to messages

Add missing "." punctuation to some uaclient messages.

Fixes: #1320

## Test Steps
Run the modified integration tests in this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
