### PR TITLE
test deps: bump pycloudlib for 60 second banner timeout

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@da9b7c6b0d6e9c07f2a11a2c0b6a02f717723904
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@21ff1bd5d442eb946a9c910176c3d2f18c5bdf54
 
 
 # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
## Proposed Commit Message
test deps: bump pycloudlib for 60 second banner timeout

Fixes: #1428

## Test Steps
CI tests should cover this hoping to avoid intermitetent Banner timeout errors.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
n/a
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
