### PR TITLE
tests: address ua fix for krb5

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -172,8 +172,12 @@ Feature: Command behaviour when unattached
             """
             CVE-2020-28196: Kerberos vulnerability
             https://ubuntu.com/security/CVE-2020-28196
-            No affected packages are installed.
-            .*✔.* CVE-2020-28196 does not affect your system.
+            1 affected package is installed: krb5
+            \(1/1\) krb5:
+            A fix is available in UA Infra.
+            The update is not yet installed.
+            Package fixes cannot be installed.
+            To install them, run this command as root \(try using sudo\)
             """
 
         Examples: ubuntu release


### PR DESCRIPTION
## Proposed Commit Message
tests: correct ua fix integration test for krb5

trusty now properly detects installed packages
and reports krb5 upgrades required.
Correct integration test to prompt about installing

## Test Steps
```bash
tox -e behave-lxd-14.04 features/unattached_commands.feature:185
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
