### PR TITLE
cli: drop subcommand repeated help output, fix enable & refresh

### DIFF
--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -138,7 +138,7 @@ subscription.
 """
 MESSAGE_SECURITY_UPDATE_INSTALLED = "The update is already installed."
 MESSAGE_SECURITY_USE_PRO_TMPL = (
-    "For easiest security on {title}, use Ubuntu PRO."
+    "For easiest security on {title}, use Ubuntu Pro."
     " https://ubuntu.com/{cloud}/pro."
 )
 MESSAGE_SECURITY_ISSUE_RESOLVED = OKGREEN_CHECK + " {issue} is resolved."

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -1,4 +1,5 @@
 import mock
+import textwrap
 
 import pytest
 
@@ -7,6 +8,7 @@ from uaclient.cli import (
     auto_attach_parser,
     get_parser,
     _get_contract_token_from_cloud_identity,
+    main,
 )
 from uaclient.contract import ContractAPIError
 from uaclient.exceptions import (
@@ -22,6 +24,17 @@ from uaclient import util
 
 M_PATH = "uaclient.cli."
 M_ID_PATH = "uaclient.clouds.identity."
+
+HELP_OUTPUT = textwrap.dedent(
+    """\
+usage: ua auto-attach [flags]
+
+Automatically attach an Ubuntu Advantage token on Ubuntu Pro images.
+
+Flags:
+  -h, --help  show this help message and exit
+"""
+)
 
 
 @mock.patch(M_PATH + "os.getuid")
@@ -267,6 +280,15 @@ class TestGetContractTokenFromCloudIdentity:
 # For all of these tests we want to appear as root, so mock on the class
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionAutoAttach:
+    def test_auto_attach_help(self, _getuid, capsys):
+        with pytest.raises(SystemExit):
+            with mock.patch(
+                "sys.argv", ["/usr/bin/ua", "auto-attach", "--help"]
+            ):
+                main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+
     @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_already_attached_on_non_ubuntu_pro(
         self, m_cloud_instance_factory, _m_getuid, FakeConfig

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -2,10 +2,11 @@ import mock
 import pytest
 import textwrap
 
-from uaclient.cli import action_disable
+from uaclient.cli import action_disable, main
 from uaclient import entitlements
 from uaclient import exceptions
 from uaclient import status
+
 
 ALL_SERVICE_MSG = "\n".join(
     textwrap.wrap(
@@ -15,9 +16,32 @@ ALL_SERVICE_MSG = "\n".join(
     )
 )
 
+HELP_OUTPUT = textwrap.dedent(
+    """\
+usage: ua disable <service> [<service>] [flags]
+
+Disable an Ubuntu Advantage service.
+
+Arguments:
+  service       the name(s) of the Ubuntu Advantage services to disable One
+                of: esm-infra, fips, fips-updates, livepatch
+
+Flags:
+  -h, --help    show this help message and exit
+  --assume-yes  do not prompt for confirmation before performing the disable
+"""
+)
+
 
 @mock.patch("uaclient.cli.os.getuid", return_value=0)
 class TestDisable:
+    def test_disable_help(self, _getuid, capsys):
+        with pytest.raises(SystemExit):
+            with mock.patch("sys.argv", ["/usr/bin/ua", "disable", "--help"]):
+                main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+
     @pytest.mark.parametrize("service", [["testitlement"], ["ent1", "ent2"]])
     @pytest.mark.parametrize("assume_yes", (True, False))
     @pytest.mark.parametrize(

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -5,15 +5,39 @@ import textwrap
 
 import pytest
 
-from uaclient.cli import _perform_enable, action_enable
+from uaclient.cli import _perform_enable, action_enable, main
 from uaclient import entitlements
 from uaclient import exceptions
 from uaclient import status
+
+HELP_OUTPUT = textwrap.dedent(
+    """\
+usage: ua enable <service> [<service>] [flags]
+
+Enable an Ubuntu Advantage service.
+
+Arguments:
+  service       the name(s) of the Ubuntu Advantage services to enable. One
+                of: esm-infra, fips, fips-updates, livepatch
+
+Flags:
+  -h, --help    show this help message and exit
+  --assume-yes  do not prompt for confirmation before performing the enable
+  --beta        allow beta service to be enabled
+"""
+)
 
 
 @mock.patch("uaclient.cli.os.getuid")
 @mock.patch("uaclient.contract.request_updated_contract")
 class TestActionEnable:
+    def test_enable_help(self, _getuid, _request_updated_contract, capsys):
+        with pytest.raises(SystemExit):
+            with mock.patch("sys.argv", ["/usr/bin/ua", "enable", "--help"]):
+                main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+
     def test_non_root_users_are_rejected(
         self, _request_updated_contract, getuid, FakeConfig
     ):

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -1,15 +1,39 @@
 import mock
+import textwrap
 
 import pytest
 
 from uaclient import exceptions
 
-from uaclient.cli import action_fix
+from uaclient.cli import action_fix, main
 
 M_PATH = "uaclient.cli."
 
+HELP_OUTPUT = textwrap.dedent(
+    """\
+usage: ua fix <CVE-yyyy-nnnn+>|<USN-nnnn-d+> [flags]
+
+Inspect and resolve CVEs and USNs (Ubuntu Security Notices) on this machine.
+
+positional arguments:
+  security_issue  Security vulnerability ID to inspect and resolve on this
+                  system. Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-
+                  dd
+
+Flags:
+  -h, --help      show this help message and exit
+"""
+)
+
 
 class TestActionFix:
+    def test_fix_help(self, capsys):
+        with pytest.raises(SystemExit):
+            with mock.patch("sys.argv", ["/usr/bin/ua", "fix", "--help"]):
+                main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+
     @pytest.mark.parametrize(
         "issue,is_valid",
         (

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -1,4 +1,5 @@
 import mock
+import textwrap
 
 import pytest
 
@@ -11,13 +12,31 @@ except ImportError:
     pass
 
 from uaclient import status
-from uaclient.cli import action_refresh
+from uaclient.cli import action_refresh, main
 
 M_PATH = "uaclient.cli."
+
+HELP_OUTPUT = textwrap.dedent(
+    """\
+usage: ua refresh [flags]
+
+Refresh existing Ubuntu Advantage contract and update services.
+
+Flags:
+  -h, --help  show this help message and exit
+"""
+)
 
 
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionRefresh:
+    def test_refresh_help(self, _getuid, capsys):
+        with pytest.raises(SystemExit):
+            with mock.patch("sys.argv", ["/usr/bin/ua", "refresh", "--help"]):
+                main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+
     def test_non_root_users_are_rejected(self, getuid, FakeConfig):
         """Check that a UID != 0 will receive a message and exit non-zero"""
         getuid.return_value = 1


### PR DESCRIPTION
## Proposed Commit Message
Add unit test coverage for all help output, fix discovered bugs:
- Fix ua subcommand --help which repeated its printed output twice
- Fix traceback on ua enable due to a stay end of line comma
- Fix ua refresh --help adding a refresh_parser to align help
  formatting with all other subcommands
- Add subcommand descriptions to give context on the intent for the
  subcommand

Fixes: #1440
## Test Steps
```bash
PYTHONPATH=. python3 -m uaclient.cli  enable --help
PYTHONPATH=. python3 -m uaclient.cli  refresh--help
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
