### PR TITLE
Handle other package status when running ua fix

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -122,7 +122,6 @@ Feature: Command behaviour when unattached
            | trusty  |
            | xenial  |
 
-    @series.xenial
     @series.bionic
     @series.focal
     Scenario Outline: Fix command on an unattached machine
@@ -164,6 +163,64 @@ Feature: Command behaviour when unattached
            | xenial  | Ubuntu security engineers are investigating this issue. |
            | bionic  | Ubuntu security engineers are investigating this issue. |
            | focal   | A fix is available in Ubuntu standard updates.\nThe update is already installed.\n.*✔.* USN-4539-1 is resolved. |
+
+    @series.xenial
+    Scenario Outline: Fix command on an unattached machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt install -y libawl-php` with sudo
+        And I run `ua fix USN-4539-1` as non-root
+        Then stdout matches regexp:
+            """
+            USN-4539-1: AWL vulnerability
+            https://ubuntu.com/security/notices/USN-4539-1
+            1 affected package is installed: awl
+            \(1/1\) awl:
+            <usn_resolution>
+            .*✘.* USN-4539-1 is not resolved.
+            """
+        When I run `ua fix CVE-2020-28196` as non-root
+        Then stdout matches regexp:
+            """
+            CVE-2020-28196: Kerberos vulnerability
+            https://ubuntu.com/security/CVE-2020-28196
+            1 affected package is installed: krb5
+            \(1/1\) krb5:
+            A fix is available in Ubuntu standard updates.
+            The update is already installed.
+            .*✔.* CVE-2020-28196 is resolved.
+            """
+        When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza` with sudo
+        And I run `ua fix CVE-2017-9233` with sudo
+        Then stdout matches regexp:
+            """
+            CVE-2017-9233: Expat vulnerability
+            https://ubuntu.com/security/CVE-2017-9233
+            3 affected packages are installed: expat, matanza, swish-e
+            \(1/3, 2/3\) matanza, swish-e:
+            Ubuntu security engineers are investigating this issue.
+            \(3/3\) expat:
+            A fix is available in Ubuntu standard updates.
+            The update is not yet installed.
+            .*\{ apt update && apt install --only-upgrade -y expat \}.*
+            .*✘.* CVE-2017-9233 is not resolved.
+            """
+        When I run `ua fix CVE-2017-9233` with sudo
+        Then stdout matches regexp:
+            """
+            CVE-2017-9233: Expat vulnerability
+            https://ubuntu.com/security/CVE-2017-9233
+            3 affected packages are installed: expat, matanza, swish-e
+            \(1/3, 2/3\) matanza, swish-e:
+            Ubuntu security engineers are investigating this issue.
+            \(3/3\) expat:
+            A fix is available in Ubuntu standard updates.
+            The update is already installed.
+            .*✘.* CVE-2017-9233 is not resolved.
+            """
+
+        Examples: ubuntu release details
+           | release | usn_resolution |
+           | xenial  | Ubuntu security engineers are investigating this issue. |
 
 
     @series.trusty

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -143,6 +143,7 @@ MESSAGE_SECURITY_USE_PRO_TMPL = (
     " https://ubuntu.com/{cloud}/pro."
 )
 MESSAGE_SECURITY_ISSUE_RESOLVED = OKGREEN_CHECK + " {issue} is resolved."
+MESSAGE_SECURITY_ISSUE_NOT_RESOLVED = FAIL_X + " {issue} is not resolved."
 MESSAGE_SECURITY_ISSUE_UNAFFECTED = (
     OKGREEN_CHECK + " {issue} does not affect your system."
 )


### PR DESCRIPTION
## Proposed Commit Message
Handle other package status when running ua fix

Currently, when we are fixing a USN or CVE, we are just handling the case where a package has a released status. However, a package can have different status. If we have an affected package which status is not released, that CVE/USN cannot be completely fixed. We are now updating the ua fix logic to handle those status and correctly report to the user that a CVE/USN was not fixed when we found one of the other status.

PS: The original idea on this work was to group the packages based on the status and present a summarized view of those packages for each status. Although we can do this in the code, my rationale for not doing it is just that it could potentially modified
the output a lot. For example, for each affected package in the system, we print that package and what action we will perform:

```
(1/3) matanza:
Ubuntu security engineers are investigating this issue.
```

Those numbers indicate the current package that we are evaluating in contrast with all of the affected packages in the system.
Now, imagine that we would have a summarized version of the information, like this:

```
The following packages are on a pending state: pkg1. pkg2
Ubuntu security engineers are investigating this issue.
(3/3) pkg3:
The updated is already installed.
```

In my opinion, this output can be a little bit confusing, since we are joining two distinct concepts here.

However, maybe there is a better way to format this output that I am not seeing. if that is the case, I am open to ideas on how to best present this to the user.

## Test Steps
Run the new unit and integration test provided in this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
