### PR TITLE
Fix bootstrap links in tox-lxd-runner script

### DIFF
--- a/tools/tox-lxd-runner
+++ b/tools/tox-lxd-runner
@@ -57,9 +57,9 @@ python_minor=$(lxc exec "$container" -- python3 -c 'import sys; print(sys.versio
 if ((python_minor > 5)); then
     get_pip_url="https://bootstrap.pypa.io/get-pip.py"
 elif ((python_minor == 5)); then
-    get_pip_url="https://bootstrap.pypa.io/3.5/get-pip.py"
+    get_pip_url="https://bootstrap.pypa.io/pip/3.5/get-pip.py"
 elif ((python_minor == 4)); then
-    get_pip_url="https://bootstrap.pypa.io/3.4/get-pip.py"
+    get_pip_url="https://bootstrap.pypa.io/pip/3.4/get-pip.py"
 else
     echo "Unsupported Python version (3.$python_minor)"
     exit 1


### PR DESCRIPTION
## Proposed Commit Message
Fix bootstrap links in tox-lxd-runner script

Update the broken bootstrap links we use to download pip in the tox-lxd-runner script.

To better understand this fix, our flake8 jenkins jobs are outputting the following text before exiting:
```
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/3.5/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!
```

## Test Steps
None

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
