### PR TITLE
fix: prefer USN.release_packages binary pkg versions to CVE src ver

### DIFF
--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -90,3 +90,10 @@ class UnattachedError(UserFacingError):
 
     def __init__(self, msg: str = status.MESSAGE_UNATTACHED) -> None:
         super().__init__(msg)
+
+
+class SecurityAPIMetadataError(UserFacingError):
+    """An exception raised with Security API metadata returns invalid data."""
+
+    def __init__(self, msg: str) -> None:
+        super().__init__("Error: " + msg)


### PR DESCRIPTION
## Proposed Commit Message

Since binary packages derived from a source package can have
different versioning schemes, check binary package versions
reported by USN.release_packages if present.

CVE package statuses only report the source package version, so
only fallback to use CVE package statuses versions if USN does not
report either the specific binary package version or the related
source package version.

Fixes: #1436

## Test Steps
```bash
lxc launch ubuntu-daily:trusty dev-t
lxc exec dev-t add-apt-repository ppa:canonical-server/ua-client-daily
lxc exec dev-t apt-get update
lxc exec dev-t apt-get install ubuntu-advantage-tools
lxc file push uaclient/security.py dev-t/usr/lib/python3/dist-packages/uaclient/security.py
lxc exec dev-t ua fix -- ua --debug fix USN-4754-4
lxc exec dev-t ua fix -- ua --debug fix USN-4754-1
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
