### PR TITLE
Update message for invalid issue in ua fix

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -137,6 +137,18 @@ Feature: Command behaviour when unattached
             """
             Error: USN-12345-12 not found.
             """
+        When I verify that running `ua fix CVE-12345678-12` `as non-root` exits `1`
+        Then I will see the following on stderr:
+            """
+            Error: issue "CVE-12345678-12" is not recognized.
+            Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
+            """
+        When I verify that running `ua fix USN-12345678-12` `as non-root` exits `1`
+        Then I will see the following on stderr:
+            """
+            Error: issue "USN-12345678-12" is not recognized.
+            Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
+            """
         When I run `apt install -y libawl-php` with sudo
         And I run `ua fix USN-4539-1` as non-root
         Then stdout matches regexp:

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -257,9 +257,12 @@ def refresh_parser(parser):
 
 def action_fix(args, cfg, **kwargs):
     if not re.match(security.CVE_OR_USN_REGEX, args.security_issue):
-        raise exceptions.UserFacingError(
-            "Invalid issue format: {}".format(args.security_issue)
-        )
+        msg = (
+            'Error: issue "{}" is not recognized.\n'
+            'Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"'
+        ).format(args.security_issue)
+        raise exceptions.UserFacingError(msg)
+
     security.fix_security_issue_id(cfg, args.security_issue)
     return 0
 

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -68,7 +68,11 @@ class TestActionFix:
         else:
             with pytest.raises(exceptions.UserFacingError) as excinfo:
                 action_fix(args, cfg)
-            assert "Invalid issue format: {}".format(issue) == str(
-                excinfo.value
-            )
+
+            expected_msg = (
+                'Error: issue "{}" is not recognized.\n'
+                'Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"'
+            ).format(issue)
+
+            assert expected_msg == str(excinfo.value)
             assert 0 == m_fix_security_issue_id.call_count


### PR DESCRIPTION
## Proposed Commit Message
Update message for invalid issue in ua fix

We are now updating the error message we output when an invalid CVE/USN is given to the ua fix command.

Fixes: #1433

## Test Steps
Run the modified unit test and integration tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
