### PR TITLE
Add retry for apt-helper command

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -58,6 +58,7 @@ def assert_valid_apt_credentials(repo_url, username, password):
                     os.path.join(tmpd, "apt-helper-output"),
                 ],
                 timeout=APT_HELPER_TIMEOUT,
+                retry_sleeps=APT_RETRIES,
             )
     except util.ProcessExecutionError as e:
         if e.exit_code == 100:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 import pytest
 
 from uaclient.apt import (
+    APT_RETRIES,
     APT_KEYS_DIR,
     APT_AUTH_COMMENT,
     KEYRINGS_DIR,
@@ -149,6 +150,7 @@ class TestValidAptCredentials:
                 expected_path,
             ],
             timeout=60,
+            retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
 
@@ -220,6 +222,7 @@ class TestValidAptCredentials:
                 expected_path,
             ],
             timeout=60,
+            retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
 
@@ -262,6 +265,7 @@ class TestValidAptCredentials:
                 expected_path,
             ],
             timeout=apt.APT_HELPER_TIMEOUT,
+            retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
 


### PR DESCRIPTION
## Proposed Commit Message
Add retry for apt-helper command

We have experience some flaky issues regarding the apt-helper download-file command. Because of that, we are now retrying on that command to try to avoid those flaky issues.

Fixes: #1431

## Test Steps
Run the modified unit tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
