### PR TITLE
Update output for released packages in ua fix

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -118,7 +118,9 @@ def when_i_retry_run_command(context, command, user_spec, exit_codes):
 
 
 @when("I run `{command}` {user_spec}")
-def when_i_run_command(context, command, user_spec, verify_return=True):
+def when_i_run_command(
+    context, command, user_spec, verify_return=True, stdin=None
+):
     prefix = get_command_prefix_for_user_spec(user_spec)
     slow_cmd_spinner = nullcontext
     for slow_cmd in SLOW_CMDS:
@@ -128,7 +130,7 @@ def when_i_run_command(context, command, user_spec, verify_return=True):
 
     full_cmd = prefix + shlex.split(command)
     with slow_cmd_spinner():
-        result = context.instance.execute(full_cmd)
+        result = context.instance.execute(full_cmd, stdin=stdin)
 
     process = subprocess.CompletedProcess(
         args=full_cmd,
@@ -146,6 +148,17 @@ def when_i_run_command(context, command, user_spec, verify_return=True):
         assert_that(process.returncode, equal_to(0))
 
     context.process = process
+
+
+@when("I fix `{issue}` by attaching to a subscription with `{token_type}`")
+def when_i_fix_a_issue_by_attaching(context, issue, token_type):
+    token = getattr(context.config, token_type)
+    when_i_run_command(
+        context=context,
+        command="ua fix {}".format(issue),
+        user_spec="with sudo",
+        stdin="a\n{}\n".format(token),
+    )
 
 
 @when("I attach `{token_type}` {user_spec}")

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -157,7 +157,6 @@ Feature: Command behaviour when unattached
             1 affected package is installed: awl
             \(1/1\) awl:
             A fix is available in Ubuntu standard updates.
-            The update is not yet installed.
             .*\{ apt update && apt install --only-upgrade -y libawl-php \}.*
             .*✔.* USN-4539-1 is resolved.
             """
@@ -190,7 +189,6 @@ Feature: Command behaviour when unattached
             1 affected package is installed: awl
             \(1/1\) awl:
             Ubuntu security engineers are investigating this issue.
-            .*✘.* USN-4539-1 is not resolved.
             """
         When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
@@ -204,7 +202,7 @@ Feature: Command behaviour when unattached
             .*✔.* CVE-2020-28196 is resolved.
             """
         When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza` with sudo
-        And I verify that running `ua fix CVE-2017-9233` `as non-root` exits `1`
+        And I verify that running `ua fix CVE-2017-9233` `with sudo` exits `1`
         Then stdout matches regexp:
             """
             CVE-2017-9233: Expat vulnerability
@@ -212,10 +210,8 @@ Feature: Command behaviour when unattached
             3 affected packages are installed: expat, matanza, swish-e
             \(1/3, 2/3\) matanza, swish-e:
             Ubuntu security engineers are investigating this issue.
-            \(3/3\) expat:
-            A fix is available in Ubuntu standard updates.
             """
-        Then stderr matches regexp:
+        And stderr matches regexp:
             """
             Error: CVE-2017-9233 metadata defines no fixed version for expat.
             .*✘.* CVE-2017-9233 is not resolved.
@@ -225,7 +221,7 @@ Feature: Command behaviour when unattached
            | release |
            | xenial  |
 
-
+    @uses.config.contract_token
     @series.trusty
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -254,9 +250,31 @@ Feature: Command behaviour when unattached
             1 affected package is installed: krb5
             \(1/1\) krb5:
             A fix is available in UA Infra.
-            The update is not yet installed.
             Package fixes cannot be installed.
             To install them, run this command as root \(try using sudo\)
+            """
+        When I fix `USN-4747-2` by attaching to a subscription with `contract_token`
+        Then stdout matches regexp:
+            """
+            USN-4747-2: GNU Screen vulnerability
+            Found CVEs: CVE-2021-26937
+            https://ubuntu.com/security/CVE-2021-26937
+            1 affected package is installed: screen
+            \(1/1\) screen:
+            A fix is available in UA Infra.
+            The update is not installed because this system is not attached to a
+            subscription.
+
+            Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
+            > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
+            > .*\{ ua attach .*\}.*
+            Updating package lists
+            ESM Infra enabled
+            """
+        And stdout matches regexp:
+            """
+            .*\{ apt update && apt install --only-upgrade -y screen \}.*
+            .*✔.* USN-4747-2 is resolved.
             """
 
         Examples: ubuntu release
@@ -320,7 +338,6 @@ Feature: Command behaviour when unattached
         1 affected package is installed: xterm
         \(1/1\) xterm:
         A fix is available in Ubuntu standard updates.
-        The update is not yet installed.
         Package fixes cannot be installed.
         To install them, run this command as root \(try using sudo\)
         """
@@ -332,7 +349,6 @@ Feature: Command behaviour when unattached
         1 affected package is installed: xterm
         \(1/1\) xterm:
         A fix is available in Ubuntu standard updates.
-        The update is not yet installed.
         .*\{ apt update && apt install --only-upgrade -y xterm \}.*
         """
         When I run `ua fix CVE-2021-27135` with sudo

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -155,6 +155,9 @@ MESSAGE_CVE_FIXED = "{issue} is resolved."
 MESSAGE_SECURITY_URL = (
     "{issue}: {title}\nhttps://ubuntu.com/security/{url_path}"
 )
+MESSAGE_SECURITY_UA_SERVICE_NOT_ENABLED = """\
+Error: The current ua subscription is not entitled to {service}
+Without it, we cannot fix the system."""
 MESSAGE_APT_INSTALL_FAILED = "APT install failed."
 MESSAGE_APT_UPDATE_FAILED = "APT update failed."
 MESSAGE_APT_UPDATE_INVALID_URL_CONFIG = (

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -27,9 +27,11 @@ from uaclient.status import (
     OKGREEN_CHECK,
     FAIL_X,
     MESSAGE_SECURITY_APT_NON_ROOT,
+    MESSAGE_SECURITY_UA_SERVICE_NOT_ENABLED,
     MESSAGE_SECURITY_ISSUE_NOT_RESOLVED,
     MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION as MSG_SUBSCRIPTION,
     PROMPT_ENTER_TOKEN,
+    UserFacingStatus,
     colorize_commands,
 )
 from uaclient import exceptions
@@ -1103,8 +1105,8 @@ class TestPromptForAffectedPackages:
         (
             (
                 {
-                    "pkg1": CVEPackageStatus(CVE_PKG_STATUS_RELEASED),
-                    "pkg2": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_APPS),
+                    "pkg1": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_APPS),
+                    "pkg2": CVEPackageStatus(CVE_PKG_STATUS_RELEASED),
                     "pkg3": CVEPackageStatus(
                         CVE_PKG_STATUS_RELEASED_ESM_INFRA
                     ),
@@ -1122,18 +1124,18 @@ class TestPromptForAffectedPackages:
                 textwrap.dedent(
                     """\
                     3 affected packages are installed: pkg1, pkg2, pkg3
-                    (1/3) pkg1:
+                    (1/3) pkg2:
                     A fix is available in Ubuntu standard updates.
                     """
                 )
                 + colorize_commands(
-                    [["apt update && apt install --only-upgrade" " -y pkg1"]]
+                    [["apt update && apt install --only-upgrade" " -y pkg2"]]
                 )
                 + "\n"
                 + textwrap.dedent(
                     """\
-                    (2/3) pkg3:
-                    A fix is available in UA Infra.
+                    (2/3) pkg1:
+                    A fix is available in UA Apps.
                     """
                 )
                 + MSG_SUBSCRIPTION
@@ -1143,23 +1145,24 @@ class TestPromptForAffectedPackages:
                 + colorize_commands([["ua attach token"]])
                 + "\n"
                 + colorize_commands(
-                    [["apt update && apt install --only-upgrade" " -y pkg3"]]
+                    [["apt update && apt install --only-upgrade" " -y pkg1"]]
                 )
                 + "\n"
                 + textwrap.dedent(
                     """\
-                    (3/3) pkg2:
-                    A fix is available in UA Apps.
+                    (3/3) pkg3:
+                    A fix is available in UA Infra.
                     """
                 )
                 + colorize_commands(
-                    [["apt update && apt install --only-upgrade" " -y pkg2"]]
+                    [["apt update && apt install --only-upgrade" " -y pkg3"]]
                 )
                 + "\n"
                 + "{check} USN-### is resolved.\n".format(check=OKGREEN_CHECK),
             ),
         ),
     )
+    @mock.patch("uaclient.security._check_subscription_for_required_service")
     @mock.patch("uaclient.cli.action_attach")
     @mock.patch("builtins.input", return_value="token")
     @mock.patch("os.getuid", return_value=0)
@@ -1174,6 +1177,7 @@ class TestPromptForAffectedPackages:
         _m_os_getuid,
         _m_input,
         m_action_attach,
+        m_check_subscription,
         affected_pkg_status,
         installed_packages,
         usn_released_pkgs,
@@ -1182,6 +1186,7 @@ class TestPromptForAffectedPackages:
         capsys,
     ):
         m_get_cloud_type.return_value = "cloud"
+        m_check_subscription.return_value = True
 
         def fake_attach(args, cfg):
             cfg.for_attached_machine()
@@ -1254,6 +1259,105 @@ class TestPromptForAffectedPackages:
             usn_released_pkgs=usn_released_pkgs,
         )
         out, err = capsys.readouterr()
+        assert expected in out
+
+    @pytest.mark.parametrize(
+        "service_status",
+        (
+            (UserFacingStatus.INACTIVE),
+            (UserFacingStatus.INAPPLICABLE),
+            (UserFacingStatus.UNAVAILABLE),
+        ),
+    )
+    @pytest.mark.parametrize(
+        "affected_pkg_status,installed_packages,usn_released_pkgs,expected",
+        (
+            (
+                {
+                    "pkg1": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_APPS),
+                    "pkg2": CVEPackageStatus(
+                        CVE_PKG_STATUS_RELEASED_ESM_INFRA
+                    ),
+                },
+                {"pkg1": {"pkg1": "1.8"}, "pkg2": {"pkg2": "1.8"}},
+                {
+                    "pkg1": {"pkg1": {"version": "2.0"}},
+                    "pkg2": {"pkg2": {"version": "2.0"}},
+                },
+                textwrap.dedent(
+                    """\
+                    2 affected packages are installed: pkg1, pkg2
+                    (1/2) pkg1:
+                    A fix is available in UA Apps.
+                    """
+                )
+                + MSG_SUBSCRIPTION
+                + "\n"
+                + PROMPT_ENTER_TOKEN
+                + "\n"
+                + colorize_commands([["ua attach token"]])
+                + "\n"
+                + MESSAGE_SECURITY_UA_SERVICE_NOT_ENABLED.format(
+                    service="esm-apps"
+                )
+                + "\n"
+                + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
+            ),
+        ),
+    )
+    @mock.patch("uaclient.cli.action_attach")
+    @mock.patch("builtins.input", return_value="token")
+    @mock.patch("os.getuid", return_value=0)
+    @mock.patch("uaclient.security.get_cloud_type")
+    @mock.patch("uaclient.security.util.prompt_choices", return_value="a")
+    def test_messages_for_affected_packages_when_required_service_not_enabled(
+        self,
+        m_prompt_choices,
+        m_get_cloud_type,
+        _m_os_getuid,
+        _m_input,
+        m_action_attach,
+        affected_pkg_status,
+        installed_packages,
+        usn_released_pkgs,
+        expected,
+        service_status,
+        FakeConfig,
+        capsys,
+    ):
+        import uaclient.security as sec
+
+        m_get_cloud_type.return_value = "cloud"
+
+        def fake_attach(args, cfg):
+            cfg.for_attached_machine()
+            return 0
+
+        m_action_attach.side_effect = fake_attach
+        m_entitlement_cls = mock.MagicMock()
+        m_entitlement_obj = m_entitlement_cls.return_value
+        m_entitlement_obj.user_facing_status.return_value = (
+            service_status,
+            "",
+        )
+        type(m_entitlement_obj).name = mock.PropertyMock(
+            return_value="esm-apps"
+        )
+
+        cfg = FakeConfig()
+        with mock.patch.object(
+            sec, "ENTITLEMENT_CLASS_BY_NAME", {"esm-apps": m_entitlement_cls}
+        ):
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
+        out, err = capsys.readouterr()
+        print(out)
+        print(expected)
         assert expected in out
 
 


### PR DESCRIPTION
## Proposed Commit Message
Update output for released packages in ua fix

Currently, we list every released package in the output of ua fix and only after that we start installing them. This is not optimal since depending on the source of the package we need to perform different actions to install those packages. Therefore, we are now grouping the released packages by pocket origin and acting on them as soon as we can.

Fixes: #1438

## Test Steps
This branch is not yet complete. I still need to add more unit tests and integration tests to it.
However, it is possible to verify the current expected behavior by running the modified unit tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
