### PR TITLE
fix: parse all related USNS to a given CVE when fixing

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -154,6 +154,7 @@ Feature: Command behaviour when unattached
             """
             USN-4539-1: AWL vulnerability
             https://ubuntu.com/security/notices/USN-4539-1
+            Related CVEs: CVE-2020-11728.
             1 affected package is installed: awl
             \(1/1\) awl:
             <usn_resolution>
@@ -185,10 +186,9 @@ Feature: Command behaviour when unattached
             """
             USN-4539-1: AWL vulnerability
             https://ubuntu.com/security/notices/USN-4539-1
-            1 affected package is installed: awl
-            \(1/1\) awl:
-            <usn_resolution>
-            .*✘.* USN-4539-1 is not resolved.
+            Related CVEs: CVE-2020-11728.
+            No affected packages are installed.
+            .*✔.* USN-4539-1 does not affect your system.
             """
         When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
@@ -231,8 +231,8 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ubuntu release details
-           | release | usn_resolution |
-           | xenial  | Ubuntu security engineers are investigating this issue. |
+           | release |
+           | xenial  |
 
 
     @series.trusty
@@ -243,6 +243,7 @@ Feature: Command behaviour when unattached
             """
             USN-4539-1: AWL vulnerability
             https://ubuntu.com/security/notices/USN-4539-1
+            Related CVEs: CVE-2020-11728.
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -95,5 +95,10 @@ class UnattachedError(UserFacingError):
 class SecurityAPIMetadataError(UserFacingError):
     """An exception raised with Security API metadata returns invalid data."""
 
-    def __init__(self, msg: str) -> None:
-        super().__init__("Error: " + msg)
+    def __init__(self, msg: str, issue_id: str) -> None:
+        super().__init__(
+            "Error: "
+            + msg
+            + "\n"
+            + status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(issue=issue_id)
+        )

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -950,6 +950,33 @@ class TestPromptForAffectedPackages:
                 + MSG_SUBSCRIPTION
                 + "\n",
             ),
+            (  # version is < released affected package overrides USN pocket
+                {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_INFRA)},
+                {"slsrc": {"sl": "2.0"}},
+                {
+                    "slsrc": {
+                        "source": {"name": "slsrc", "version": "1.2"},
+                        "sl": {"pocket": "esm-apps", "version": "2.1"},
+                    }
+                },
+                "azure",
+                textwrap.dedent(
+                    """\
+                    1 affected package is installed: slsrc
+                    (1/1) slsrc:
+                    A fix is available in UA Apps.
+                    The update is not yet installed.
+                    """
+                )
+                + "\n".join(
+                    [
+                        MESSAGE_SECURITY_USE_PRO_TMPL.format(
+                            title="Azure", cloud="azure"
+                        ),
+                        MSG_SUBSCRIPTION,
+                    ]
+                ),
+            ),
             (  # version is < released affected both esm-apps and standard
                 {
                     "pkg1": CVEPackageStatus(CVE_PKG_STATUS_IGNORED),


### PR DESCRIPTION
Two fixes here,
  - Aggregate all related USNs #1451 
  - fix: use pocket values from USNs  #1439


## Proposed Commit Message
fix: parse all related USNS to a given CVE when fixing

ua fixing a USN instead of CVE will pool all related USNs based on
calls to client.get_notices(details=cve_id) for each usn.cve_ids.

Change Security API calls to use notices.json?details=<CVE-ID> when
fixing CVEs instead of cves/<CVE-ID>.json to get a single response
containing all related USNs.

merge_usn_released_binary_package_versions now takes a list of USNs
instead of a single CVE and merges the set of all usn.released_packages
to provide binary package API responses.

Now print "Related CVEs: X, Y, Z" message when fixing a USN.

Also reorder logic to prompt for subscription URL and fall through
to prompt for token when the user hits [Enter].

Extend SecurityAPIMetadataError to require an issue_id which is used
to append the MESSAGE_SECURITY_ISSUE_NOT_RESOLVED message on exit(1).

Fixes: #1451


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
