### PR TITLE
fix: provide related CVE URLs instead of USNs

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -152,8 +152,8 @@ Feature: Command behaviour when unattached
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
-            https://ubuntu.com/security/notices/USN-4539-1
-            Related CVEs: CVE-2020-11728.
+            Found CVEs: CVE-2020-11728
+            https://ubuntu.com/security/CVE-2020-11728
             1 affected package is installed: awl
             \(1/1\) awl:
             A fix is available in Ubuntu standard updates.
@@ -185,8 +185,8 @@ Feature: Command behaviour when unattached
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
-            https://ubuntu.com/security/notices/USN-4539-1
-            Related CVEs: CVE-2020-11728.
+            Found CVEs: CVE-2020-11728
+            https://ubuntu.com/security/CVE-2020-11728
             1 affected package is installed: awl
             \(1/1\) awl:
             Ubuntu security engineers are investigating this issue.
@@ -204,21 +204,7 @@ Feature: Command behaviour when unattached
             .*✔.* CVE-2020-28196 is resolved.
             """
         When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza` with sudo
-        And I run `ua fix CVE-2017-9233` with sudo
-        Then stdout matches regexp:
-            """
-            CVE-2017-9233: Expat vulnerability
-            https://ubuntu.com/security/CVE-2017-9233
-            3 affected packages are installed: expat, matanza, swish-e
-            \(1/3, 2/3\) matanza, swish-e:
-            Ubuntu security engineers are investigating this issue.
-            \(3/3\) expat:
-            A fix is available in Ubuntu standard updates.
-            The update is not yet installed.
-            .*\{ apt update && apt install --only-upgrade -y expat \}.*
-            .*✘.* CVE-2017-9233 is not resolved.
-            """
-        When I run `ua fix CVE-2017-9233` with sudo
+        And I verify that running `ua fix CVE-2017-9233` `as non-root` exits `1`
         Then stdout matches regexp:
             """
             CVE-2017-9233: Expat vulnerability
@@ -247,8 +233,8 @@ Feature: Command behaviour when unattached
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
-            https://ubuntu.com/security/notices/USN-4539-1
-            Related CVEs: CVE-2020-11728.
+            Found CVEs: CVE-2020-11728
+            https://ubuntu.com/security/CVE-2020-11728
             No affected packages are installed.
             .*✔.* USN-4539-1 does not affect your system.
             """
@@ -307,8 +293,8 @@ Feature: Command behaviour when unattached
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
-            https://ubuntu.com/security/notices/USN-4539-1
-            Related CVEs: CVE-2020-11728.
+            Found CVEs: CVE-2020-11728
+            https://ubuntu.com/security/CVE-2020-11728
             1 affected package is installed: awl
             \(1/1\) awl:
             Ubuntu security engineers are investigating this issue.

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -273,9 +273,11 @@ class CVE:
             # Only look at the most recent USN title
             title = notice.title
             break
-        return status.MESSAGE_SECURITY_URL.format(
-            issue=self.id, title=title, url_path="{}".format(self.id)
-        )
+        lines = [
+            "{issue}: {title}".format(issue=self.id, title=title),
+            "https://ubuntu.com/security/{}".format(self.id),
+        ]
+        return "\n".join(lines)
 
     @property
     def notice_ids(self):
@@ -335,11 +337,15 @@ class USN:
 
     def get_url_header(self):
         """Return a string representing the URL for this notice."""
-        return status.MESSAGE_SECURITY_URL.format(
-            issue=self.id,
-            title=self.title,
-            url_path="notices/{}".format(self.id),
-        )
+        lines = [
+            "{issue}: {title}".format(issue=self.id, title=self.title),
+            "Found CVEs: {}".format(
+                ", ".join(sorted(self.cve_ids, reverse=True))
+            ),
+        ]
+        for cve in self.cve_ids:
+            lines.append("https://ubuntu.com/security/{}".format(cve))
+        return "\n".join(lines)
 
     @property
     def release_packages(self) -> "Dict[str, Dict[str, Dict[str, str]]]":
@@ -501,7 +507,6 @@ def fix_security_issue_id(cfg: UAConfig, issue_id: str) -> None:
                 "{} metadata defines no related CVEs.".format(issue_id),
                 issue_id=issue_id,
             )
-        print("Related CVEs: {}.".format(", ".join(usn.cve_ids)))
         if not usn.response["release_packages"]:
             # Since usn.release_packages filters to our current release only
             # check overall metadata and error if empty.

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -111,7 +111,7 @@ SAMPLE_CVE_RESPONSE = {
 }
 
 SAMPLE_USN_RESPONSE = {
-    "cves": ["CVE-2020-1472"],
+    "cves": ["CVE-2020-1473", "CVE-2020-1472"],
     "id": "USN-4510-2",
     "instructions": "In general, a standard system update will make all ...\n",
     "references": [],
@@ -411,21 +411,26 @@ class TestUSN:
         request_url.side_effect = fake_request_url
 
         cves = usn.get_cves_metadata()
-        assert ["CVE-2020-1472"] == [cve.id for cve in cves]
+        assert ["CVE-2020-1473", "CVE-2020-1472"] == [cve.id for cve in cves]
         assert [
-            mock.call("cves/CVE-2020-1472.json")
+            mock.call("cves/CVE-2020-1473.json"),
+            mock.call("cves/CVE-2020-1472.json"),
         ] == request_url.call_args_list
         # no extra calls being made
         usn.get_cves_metadata()
-        assert 1 == request_url.call_count
+        assert 2 == request_url.call_count
 
     def test_get_url_header(self, FakeConfig):
         """USN.get_url_header returns a string based on the USN response."""
         client = UASecurityClient(FakeConfig())
-        usn = CVE(client, SAMPLE_USN_RESPONSE)
+        usn = USN(client, SAMPLE_USN_RESPONSE)
         assert (
             textwrap.dedent(
-                """USN-4510-2: None\nhttps://ubuntu.com/security/USN-4510-2"""
+                """\
+                USN-4510-2: Samba vulnerability
+                Found CVEs: CVE-2020-1473, CVE-2020-1472
+                https://ubuntu.com/security/CVE-2020-1473
+                https://ubuntu.com/security/CVE-2020-1472"""
             )
             == usn.get_url_header()
         )


### PR DESCRIPTION
## Proposed Commit Message
fix: provide related CVE URLs instead of USNs

During a `ua fix USN-XXX` provide related CVE URLs for context
instead of USN URLs.

Fixes: #1456
## Test Steps
```bash
# single related CVE found
PYTHONPATH=. python3 -m uaclient.cli  fix USN-4575-1

# Multiple related CVEs
PYTHONPATH=. python3 -m uaclient.cli  fix USN-4754-1
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
