### PR TITLE
refactor: remove duplicated lines in setup_logging

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -965,22 +965,21 @@ def setup_logging(console_level, log_level, log_file=None):
     log_formatter = logging.Formatter(DEFAULT_LOG_FORMAT)
     root = logging.getLogger()
     root.setLevel(log_level)
+
     # Setup console logging
-    stderr_found = False
+    stderr_handler = None
     for handler in root.handlers:
         if hasattr(handler, "stream") and hasattr(handler.stream, "name"):
             if handler.stream.name == "<stderr>":
-                handler.setLevel(console_level)
-                handler.setFormatter(console_formatter)
-                handler.set_name("console")  # Used to disable console logging
-                stderr_found = True
+                stderr_handler = handler
                 break
-    if not stderr_found:
-        console = logging.StreamHandler(sys.stderr)
-        console.setFormatter(console_formatter)
-        console.setLevel(console_level)
-        console.set_name("console")  # Used to disable console logging
-        root.addHandler(console)
+    if not stderr_handler:
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        root.addHandler(stderr_handler)
+    stderr_handler.setFormatter(console_formatter)
+    stderr_handler.setLevel(console_level)
+    stderr_handler.set_name("console")  # Used to disable console logging
+
     if os.getuid() == 0:
         # Setup readable-by-root-only debug file logging if running as root
         log_file_path = pathlib.Path(log_file)


### PR DESCRIPTION
## Proposed Commit Message
refactor: remove duplicated lines in setup_logging

Remove a small amount of duplicated lines in `cli.setup_logging`.

Fixes: #553

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
