### PR TITLE
Fix/md sparse source link

### DIFF
--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -384,6 +384,25 @@ class USN:
                 # is_source == False or None, then this is a binary package.
                 # If processed before a source item, the top-level key will
                 # not exist yet.
+                # TODO(GH: 1465: determine if this is expected on kern pkgs)
+                if not pkg.get("source_link"):
+                    raise exceptions.SecurityAPIMetadataError(
+                        "{issue} metadata does not define release_packages"
+                        " source_link for {bin_pkg}.".format(
+                            issue=self.id, bin_pkg=pkg["name"]
+                        ),
+                        issue_id=self.id,
+                    )
+                elif "/" not in pkg["source_link"]:
+                    raise exceptions.SecurityAPIMetadataError(
+                        "{issue} metadata has unexpected release_packages"
+                        " source_link value for {bin_pkg}: {link}".format(
+                            issue=self.id,
+                            bin_pkg=pkg["name"],
+                            link=pkg["source_link"],
+                        ),
+                        issue_id=self.id,
+                    )
                 source_pkg_name = pkg["source_link"].split("/")[-1]
                 if source_pkg_name not in self._release_packages:
                     self._release_packages[source_pkg_name] = {}

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -13,14 +13,15 @@ from uaclient.security import (
     CVEPackageStatus,
     UASecurityClient,
     USN,
+    SecurityAPIError,
+    fix_security_issue_id,
     get_cve_affected_source_packages_status,
+    merge_usn_released_binary_package_versions,
+    override_usn_release_package_status,
     prompt_for_affected_packages,
     query_installed_source_pkg_versions,
-    version_cmp_le,
     upgrade_packages_and_attach,
-    fix_security_issue_id,
-    SecurityAPIError,
-    merge_usn_released_binary_package_versions,
+    version_cmp_le,
 )
 from uaclient.status import (
     MESSAGE_SECURITY_USE_PRO_TMPL,
@@ -1268,3 +1269,57 @@ class TestMergeUSNReleasedBinaryPackageVersions:
 
         usn_pkgs_dict = merge_usn_released_binary_package_versions(usns)
         assert expected_pkgs_dict == usn_pkgs_dict
+
+
+class TestOverrideUSNReleasePackageStatus:
+    @pytest.mark.parametrize(
+        "pkg_status",
+        (
+            CVE_PKG_STATUS_IGNORED,
+            CVE_PKG_STATUS_PENDING,
+            CVE_PKG_STATUS_NEEDS_TRIAGE,
+            CVE_PKG_STATUS_NEEDED,
+            CVE_PKG_STATUS_DEFERRED,
+            CVE_PKG_STATUS_RELEASED,
+            CVE_PKG_STATUS_RELEASED_ESM_INFRA,
+        ),
+    )
+    @pytest.mark.parametrize(
+        "usn_src_released_pkgs,expected",
+        (
+            ({}, None),
+            (  # No "source" key, so ignore all binaries
+                {"somebinary": {"pocket": "my-pocket", "version": "usn-ver"}},
+                None,
+            ),
+            (
+                {
+                    "source": {
+                        "name": "srcpkg",
+                        "version": "usn-source-pkg-ver",
+                    },
+                    "somebinary": {
+                        "pocket": "my-pocket",
+                        "version": "usn-bin-ver",
+                    },
+                },
+                {
+                    "pocket": "my-pocket",
+                    "description": "usn-source-pkg-ver",
+                    "status": "released",
+                },
+            ),
+        ),
+    )
+    def test_override_cve_src_info_with_pocket_and_ver_from_usn(
+        self, usn_src_released_pkgs, expected, pkg_status
+    ):
+        """Override CVEPackageStatus with released/pocket from USN."""
+        orig_cve = CVEPackageStatus(pkg_status)
+        override = override_usn_release_package_status(
+            orig_cve, usn_src_released_pkgs
+        )
+        if expected is None:  # Expect CVEPackageStatus unaltered
+            assert override.response == orig_cve.response
+        else:
+            assert expected == override.response

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -396,6 +396,43 @@ class TestUSN:
         usn._release_packages = {"sl": "1.0"}
         assert {"sl": "1.0"} == usn.release_packages
 
+    @pytest.mark.parametrize(
+        "source_link,error_msg",
+        (
+            (
+                None,
+                "USN-4510-2 metadata does not define release_packages"
+                " source_link for samba2.",
+            ),
+            (
+                "unknown format",
+                "USN-4510-2 metadata has unexpected release_packages"
+                " source_link value for samba2: unknown format",
+            ),
+        ),
+    )
+    @mock.patch("uaclient.util.get_platform_info")
+    def test_release_packages_errors_on_sparse_source_url(
+        self, get_platform_info, source_link, error_msg, FakeConfig
+    ):
+        """Raise errors when USN metadata contains no valid source_link."""
+        get_platform_info.return_value = {"series": "trusty"}
+        client = UASecurityClient(FakeConfig())
+        sparse_md = copy.deepcopy(SAMPLE_USN_RESPONSE)
+        sparse_md["release_packages"]["trusty"].append(
+            {
+                "is_source": False,
+                "name": "samba2",
+                "source_link": source_link,
+                "version": "2~14.04.1+esm9",
+                "version_link": "https://....11+dfsg-0ubuntu0.14.04.20+esm9",
+            }
+        )
+        usn = USN(client, sparse_md)
+        with pytest.raises(exceptions.SecurityAPIMetadataError) as exc:
+            usn.release_packages
+        assert error_msg == str(exc.value)
+
     @mock.patch("uaclient.security.UASecurityClient.request_url")
     def test_get_cves_metadata(self, request_url, FakeConfig):
         """USN.get_cves_metadata is cached to avoid API round-trips."""


### PR DESCRIPTION
Avoid tracebacks caused by unexpected source_link metadata in USN.release_packages. Raise a sensible error message.
If Security confirms whether this is expected behavior, we may look at alternatives to handle consuming this metadata appropriately in uaclient.

## Proposed Commit Message
Rebase and merge two commits:

1. tests: add unittest coverage for override_usn_release_package_status

2. fix: raise errors when source_link is null or unexpected format
    
    Avoid tracebacks when source_link is None or unexpected format.
    
    Addresses part of GH: #1465.
    
    When security defines whether this is expected metadata for certain
    classes of USN.releasE_packages the client can define better handling
    for those cases

## Test Steps

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
