### PR TITLE
fix: get_cve_affected_source_packages_status won't list not-affected

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -201,7 +201,7 @@ Feature: Command behaviour when unattached
             The update is already installed.
             .*✔.* CVE-2020-28196 is resolved.
             """
-        When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza` with sudo
+        When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza ghostscript` with sudo
         And I verify that running `ua fix CVE-2017-9233` `with sudo` exits `1`
         Then stdout matches regexp:
             """

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -216,6 +216,8 @@ class CVEPackageStatus:
             return "Sorry, no fix is available."
         elif self.status == "DNE":
             return "Source package does not exist on this release."
+        elif self.status == "not-affected":
+            return "Source package is not affected on this release."
         elif self.status == "released":
             return status.MESSAGE_SECURITY_FIX_RELEASE_STREAM.format(
                 fix_stream=self.pocket_source
@@ -563,6 +565,8 @@ def get_cve_affected_source_packages_status(
     """
     affected_pkg_versions = {}
     for source_pkg, package_status in cve.packages_status.items():
+        if package_status.status == "not-affected":
+            continue
         if source_pkg in installed_packages:
             affected_pkg_versions[source_pkg] = package_status
     return affected_pkg_versions

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -165,8 +165,8 @@ class TestGetCVEAffectedPackageStatus:
             ("bionic", {"samba": "1000"}, SAMBA_CVE_STATUS_BIONIC),
             # active series has a bearing on status filtering
             ("upstream", {"samba": "1000"}, SAMBA_CVE_STATUS_UPSTREAM),
-            # package status status has no bearing on status filtering
-            ("focal", {"samba": "1000"}, SAMBA_CVE_STATUS_FOCAL),
+            # package status not-affected gets filtered from affected_pkgs
+            ("focal", {"samba": "1000"}, {}),
         ),
     )
     @mock.patch("uaclient.security.util.get_platform_info")
@@ -490,6 +490,11 @@ class TestCVEPackageStatus:
     @pytest.mark.parametrize(
         "status,pocket,expected",
         (
+            (
+                "not-affected",
+                "",
+                "Source package is not affected on this release.",
+            ),
             ("DNE", "", "Source package does not exist on this release."),
             (
                 "needs-triage",


### PR DESCRIPTION
CVEPackageStatus of not-affected should be honored for a given
release. Do not group and report these packages during a fix
because there will be no released fixes for "not-affected" packages.

Add human-readable messaging for CVEs with not-affected status:
 Source package is not affected on this release.

Fixes: #1467

## Proposed Commit Message
CVEPackageStatus of not-affected should be honored for a given
release. Do not group and report these packages during a fix
because there will be no released fixes for "not-affected" packages.

Add human-readable messaging for CVEs with not-affected status:
 Source package is not affected on this release.

Fixes: #1467

## Test Stepsfeatures/unattached_commands.feature
```bash
tox -e behave-lxd-16.04 features/unattached_commands.feature:226
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
