### PR TITLE
Prompt to enable service during ua fix

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -161,6 +161,16 @@ def when_i_fix_a_issue_by_attaching(context, issue, token_type):
     )
 
 
+@when("I fix `{issue}` by enabling required service")
+def when_i_fix_a_issue_by_enabling_service(context, issue):
+    when_i_run_command(
+        context=context,
+        command="ua fix {}".format(issue),
+        user_spec="with sudo",
+        stdin="e\n",
+    )
+
+
 @when("I attach `{token_type}` {user_spec}")
 def when_i_attach_staging_token(context, token_type, user_spec):
     token = getattr(context.config, token_type)

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -276,6 +276,31 @@ Feature: Command behaviour when unattached
             .*\{ apt update && apt install --only-upgrade -y screen \}.*
             .*✔.* USN-4747-2 is resolved.
             """
+        When I run `apt-get install -y screen=4.1.0~20120320gitdb59704-9 --force-yes` with sudo
+        And I run `ua disable esm-infra` with sudo
+        And I fix `USN-4747-2` by enabling required service
+        Then stdout matches regexp:
+            """
+            USN-4747-2: GNU Screen vulnerability
+            Found CVEs: CVE-2021-26937
+            https://ubuntu.com/security/CVE-2021-26937
+            1 affected package is installed: screen
+            \(1/1\) screen:
+            A fix is available in UA Infra.
+            The update is not installed because this system does not have
+            esm-infra enabled.
+
+            Choose: \[E\]nable esm-infra \[C\]ancel
+            > .*\{ ua enable esm-infra \}.*
+            One moment, checking your subscription first
+            Updating package lists
+            ESM Infra enabled
+            """
+        And stdout matches regexp:
+            """
+            .*\{ apt update && apt install --only-upgrade -y screen \}.*
+            .*✔.* USN-4747-2 is resolved.
+            """
 
         Examples: ubuntu release
            | release |

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -137,6 +137,10 @@ MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION = """\
 The update is not installed because this system is not attached to a
 subscription.
 """
+MESSAGE_SECURITY_SERVICE_DISABLED = """\
+The update is not installed because this system does not have
+{service} enabled.
+"""
 MESSAGE_SECURITY_UPDATE_INSTALLED = "The update is already installed."
 MESSAGE_SECURITY_USE_PRO_TMPL = (
     "For easiest security on {title}, use Ubuntu Pro."
@@ -156,7 +160,10 @@ MESSAGE_SECURITY_URL = (
     "{issue}: {title}\nhttps://ubuntu.com/security/{url_path}"
 )
 MESSAGE_SECURITY_UA_SERVICE_NOT_ENABLED = """\
-Error: The current ua subscription is not entitled to {service}
+Error: UA service: {service} is not enabled.
+Without it, we cannot fix the system."""
+MESSAGE_SECURITY_UA_SERVICE_NOT_ENTITLED = """\
+Error: The current UA subscription is not entitled to: {service}.
 Without it, we cannot fix the system."""
 MESSAGE_APT_INSTALL_FAILED = "APT install failed."
 MESSAGE_APT_UPDATE_FAILED = "APT update failed."


### PR DESCRIPTION
## Proposed Commit Message
Prompt to enable service during ua fix

Currently, when we are running ua fix and a necessary ua service is not enabled, we abort the operation and report that the CVE/USN was not solved. However, if the user is entitled to that service through uaclient, we can prompt the user to enable that service during the fix operation. We are now adding this functionality to the ua fix command.

Fixes: #1455

## Test Steps
Run the modified integration test in this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
