### PR TITLE
logs: emit error response on API errors and redact sensitive logs

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1051,7 +1051,9 @@ def main(sys_argv=None):
     log_level = cfg.log_level
     console_level = logging.DEBUG if args.debug else logging.INFO
     setup_logging(console_level, log_level, cfg.log_file)
-    logging.debug("Executed with sys.argv: %r", sys_argv)
+    logging.debug(
+        util.redact_sensitive_logs("Executed with sys.argv: %r" % sys_argv)
+    )
     return args.action(args, cfg)
 
 


### PR DESCRIPTION
## Proposed Commit Message

Add regex log redacting for uaclient/cli.py and
uaclient.util.readurl call and response logging.

This is a step toward eventually making ubuntu-advantage.log
world-readable.

Fixes: #1424

## Test Steps
checkout this branch on a xenial container
```bash
make deps
dpkg-buildpackag -us -uc
dpkg -i ../*deb
ua --debug attach <yourTOKEN>
egrep '<yourToken>|REDACT' /var/log/ubuntu-advantage.log
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
