### PR TITLE
fix: filter usns by cve details

### DIFF
--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -162,6 +162,7 @@ class UASecurityClient(serviceclient.UAServiceClient):
             [
                 USN(client=self, response=usn_md)
                 for usn_md in usns_response.get("notices", [])
+                if details is None or details in usn_md.get("cves", [])
             ],
             key=lambda x: x.id,
         )


### PR DESCRIPTION
## Proposed Commit Message
fix: filter usns by cve details

When we are querying for related USNs to fix, we use find all related USNs to a given CVE. However, the query that we are using to get the related USNs is using applying the CVE match as a substring instead of an exact match. This means that we will be return USNs that are not related to our query CVE, but have are fixing a CVE which id is a substring of our original CVE. We are filtering the returned USNs to only those that actually contain the exact CVE id in them.

Fixes: #1470

## Test Steps
Run the new unittest added

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
