### PR TITLE
fix: prompt for new token when expired one is used

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -7,7 +7,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
         When I verify that running `ua attach INVALID_TOKEN` `with sudo` exits `1`
         Then stderr matches regexp:
             """
-            Invalid token. See https://ubuntu.com/advantage.
+            Invalid token. See https://ubuntu.com/advantage
             """
         When I verify that running `ua attach INVALID_TOKEN` `as non-root` exits `1`
         Then I will see the following on stderr:

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -36,7 +36,7 @@ Feature: Command behaviour when attached to an UA subscription
         And I will see the following on stdout:
             """
             Livepatch is not currently enabled
-            See: sudo ua status.
+            See: sudo ua status
             """
 
         Examples: ubuntu release
@@ -231,7 +231,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
             Updating package lists
             Livepatch is not currently enabled
-            See: sudo ua status.
+            See: sudo ua status
             """
         And stderr matches regexp:
             """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -67,7 +67,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             One moment, checking your subscription first
             ESM Infra is already enabled.
-            See: sudo ua status.
+            See: sudo ua status
             """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
@@ -101,7 +101,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             One moment, checking your subscription first
             ESM Infra is already enabled.
-            See: sudo ua status.
+            See: sudo ua status
             """
         When I run `apt install -y <pkg-version>` with sudo, retrying exit [100]
         And I run `apt update` with sudo

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -12,7 +12,7 @@ Feature: Command behaviour when unattached
         Then stderr matches regexp:
             """
             Auto-attach image support is not available on <data>
-            See: https://ubuntu.com/advantage.
+            See: https://ubuntu.com/advantage
             """
 
         Examples: ubuntu release
@@ -34,7 +34,7 @@ Feature: Command behaviour when unattached
         Then stderr matches regexp:
             """
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """
 
         Examples: ua commands
@@ -61,7 +61,7 @@ Feature: Command behaviour when unattached
             """
             To use '<service>' you need an Ubuntu Advantage subscription
             Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """
 
         Examples: ua commands

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -13,7 +13,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """
         When I run `ua status --all` as non-root
         Then stdout matches regexp:
@@ -28,7 +28,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """
         When I run `ua status` with sudo
         Then stdout matches regexp:
@@ -40,7 +40,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """
         When I run `ua status --all` with sudo
         Then stdout matches regexp:
@@ -55,7 +55,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """ 
         When I append the following on uaclient config:
             """
@@ -75,7 +75,7 @@ Feature: Unattached status
             livepatch     yes        Canonical Livepatch service
 
             This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage.
+            See https://ubuntu.com/advantage
             """ 
 
         Examples: ubuntu release

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -924,14 +924,16 @@ def print_version(_args=None, _cfg=None):
 @assert_root
 @assert_attached()
 @assert_lock_file("ua refresh")
-def action_refresh(args, cfg):
+def action_refresh(args, cfg, verbose=True):
     try:
         contract.request_updated_contract(cfg)
     except util.UrlError as exc:
         with util.disable_log_to_console():
             logging.exception(exc)
         raise exceptions.UserFacingError(ua_status.MESSAGE_REFRESH_FAILURE)
-    print(ua_status.MESSAGE_REFRESH_SUCCESS)
+
+    if verbose:
+        print(ua_status.MESSAGE_REFRESH_SUCCESS)
     return 0
 
 

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -11,6 +11,7 @@ DEFAULT_HELP_FILE = UAC_ETC_PATH + "help_data.yaml"
 DEFAULT_UPGRADE_CONTRACT_FLAG_FILE = UAC_ETC_PATH + "request-update-contract"
 BASE_CONTRACT_URL = "https://contracts.canonical.com"
 BASE_SECURITY_URL = "https://ubuntu.com/security"
+BASE_UA_URL = "https://ubuntu.com/advantage"
 
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -121,7 +121,7 @@ class TestUaEntitlement:
 
         expected_stdout = (
             "Test Concrete Entitlement is not currently enabled\n"
-            "See: sudo ua status.\n"
+            "See: sudo ua status\n"
         )
         stdout, _ = capsys.readouterr()
         assert expected_stdout == stdout
@@ -203,7 +203,7 @@ class TestUaEntitlement:
 
         expected_stdout = (
             "Test Concrete Entitlement is already enabled.\n"
-            "See: sudo ua status.\n"
+            "See: sudo ua status\n"
         )
         if silent:
             expected_stdout = ""

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -18,6 +18,7 @@ from uaclient import status
 from uaclient import serviceclient
 from uaclient import util
 from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
+from uaclient.defaults import BASE_UA_URL
 
 try:
     from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
@@ -937,9 +938,10 @@ def _prompt_for_new_token(cfg: UAConfig) -> bool:
 
     _inform_ubuntu_pro_existence_if_applicable()
     print(status.MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_EXPIRED)
-    token_url = "https://ubuntu.com/advantage"
     choice = util.prompt_choices(
-        "Choose: [R]enew your subscription (at {}) [C]ancel".format(token_url),
+        "Choose: [R]enew your subscription (at {}) [C]ancel".format(
+            BASE_UA_URL
+        ),
         valid_choices=["r", "c"],
     )
     if choice == "r":

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -187,7 +187,7 @@ LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (
 )
 MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)."
 MESSAGE_ALREADY_DISABLED_TMPL = """\
-{title} is not currently enabled\nSee: sudo ua status."""
+{title} is not currently enabled\nSee: sudo ua status"""
 MESSAGE_ENABLED_FAILED_TMPL = "Could not enable {title}."
 MESSAGE_DISABLE_FAILED_TMPL = "Could not disable {title}."
 MESSAGE_ENABLED_TMPL = "{title} enabled"
@@ -195,7 +195,7 @@ MESSAGE_ALREADY_ATTACHED = """\
 This machine is already attached to '{account_name}'
 To use a different subscription first run: sudo ua detach."""
 MESSAGE_ALREADY_ENABLED_TMPL = """\
-{title} is already enabled.\nSee: sudo ua status."""
+{title} is already enabled.\nSee: sudo ua status"""
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\
 {title} is not available for platform {arch}.
 Supported platforms are: {supported_arches}."""
@@ -226,21 +226,18 @@ MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE = (
 Auto-attach image support is not available on {cloud_type}
 See: """
     + BASE_UA_URL
-    + "."
 )
 MESSAGE_UNSUPPORTED_AUTO_ATTACH = (
     """\
 Auto-attach image support is not available on this image
 See: """
     + BASE_UA_URL
-    + "."
 )
 MESSAGE_UNATTACHED = (
     """\
 This machine is not attached to a UA subscription.
 See """
     + BASE_UA_URL
-    + "."
 )
 MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
@@ -310,7 +307,6 @@ MESSAGE_ATTACH_INVALID_TOKEN = (
     """\
 Invalid token. See """
     + BASE_UA_URL
-    + "."
 )
 MESSAGE_ATTACH_REQUIRES_TOKEN = (
     """\
@@ -323,7 +319,6 @@ MESSAGE_ATTACH_FAILURE = (
     """\
 Failed to attach machine. See """
     + BASE_UA_URL
-    + "."
 )
 MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES = """\
 Failed to enable default services, check: sudo ua status"""
@@ -344,7 +339,6 @@ To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
 See """
     + BASE_UA_URL
-    + "."
 )
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
 MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL = """\

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -137,6 +137,10 @@ MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION = """\
 The update is not installed because this system is not attached to a
 subscription.
 """
+MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_EXPIRED = """\
+The update is not installed because this system is attached to an
+expired subscription.
+"""
 MESSAGE_SECURITY_SERVICE_DISABLED = """\
 The update is not installed because this system does not have
 {service} enabled.
@@ -257,6 +261,8 @@ This will disable access to certified FIPS packages.
 
 PROMPT_ENTER_TOKEN = """\
 Enter your token (from https://ubuntu.com/advantage) to attach this system:"""
+PROMPT_EXPIRED_ENTER_TOKEN = """\
+Enter your new token to renew UA subscription on this system:"""
 PROMPT_UA_SUBSCRIPTION_URL = """\
 Open a browser to: https://ubuntu.com/advantage/subscribe"""
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,6 +1,8 @@
 import enum
 import sys
 
+from uaclient.defaults import BASE_UA_URL
+
 try:
     from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 except ImportError:
@@ -205,21 +207,41 @@ Supported flavors are: {supported_kernels}."""
 MESSAGE_INAPPLICABLE_KERNEL_VER_TMPL = """\
 {title} is not available for kernel {kernel}.
 Minimum kernel version required: {min_kernel}."""
-MESSAGE_UNENTITLED_TMPL = """\
+MESSAGE_UNENTITLED_TMPL = (
+    """\
 This subscription is not entitled to {title}
-For more information see: https://ubuntu.com/advantage."""
-MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE = """\
+For more information see: """
+    + BASE_UA_URL
+    + "."
+)
+MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE = (
+    """\
 Unable to determine auto-attach platform support
-For more information see: https://ubuntu.com/advantage."""
-MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE = """\
+For more information see: """
+    + BASE_UA_URL
+    + "."
+)
+MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE = (
+    """\
 Auto-attach image support is not available on {cloud_type}
-See: https://ubuntu.com/advantage."""
-MESSAGE_UNSUPPORTED_AUTO_ATTACH = """\
+See: """
+    + BASE_UA_URL
+    + "."
+)
+MESSAGE_UNSUPPORTED_AUTO_ATTACH = (
+    """\
 Auto-attach image support is not available on this image
-See: https://ubuntu.com/advantage."""
-MESSAGE_UNATTACHED = """\
+See: """
+    + BASE_UA_URL
+    + "."
+)
+MESSAGE_UNATTACHED = (
+    """\
 This machine is not attached to a UA subscription.
-See https://ubuntu.com/advantage."""
+See """
+    + BASE_UA_URL
+    + "."
+)
 MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 MESSAGE_NO_ACTIVE_OPERATIONS = """No Ubuntu Advantage operations are running"""
@@ -260,11 +282,15 @@ This will disable access to certified FIPS packages.
 )
 
 PROMPT_ENTER_TOKEN = """\
-Enter your token (from https://ubuntu.com/advantage) to attach this system:"""
+Enter your token (from {}) to attach this system:""".format(
+    BASE_UA_URL
+)
 PROMPT_EXPIRED_ENTER_TOKEN = """\
 Enter your new token to renew UA subscription on this system:"""
 PROMPT_UA_SUBSCRIPTION_URL = """\
-Open a browser to: https://ubuntu.com/advantage/subscribe"""
+Open a browser to: {}/subscribe""".format(
+    BASE_UA_URL
+)
 
 STATUS_UNATTACHED_TMPL = "{name: <14}{available: <11}{description}"
 
@@ -275,16 +301,30 @@ STATUS_HEADER = "SERVICE       ENTITLED  STATUS    DESCRIPTION"
 # that factor into formats len() calculations
 STATUS_TMPL = "{name: <14}{entitled: <19}{status: <19}{description}"
 
-MESSAGE_ATTACH_EXPIRED_TOKEN = """\
-Expired token or contract. To obtain a new token visit: \
-https://ubuntu.com/advantage"""
-MESSAGE_ATTACH_INVALID_TOKEN = """\
-Invalid token. See https://ubuntu.com/advantage."""
-MESSAGE_ATTACH_REQUIRES_TOKEN = """\
+MESSAGE_ATTACH_EXPIRED_TOKEN = (
+    """\
+Expired token or contract. To obtain a new token visit: """
+    + BASE_UA_URL
+)
+MESSAGE_ATTACH_INVALID_TOKEN = (
+    """\
+Invalid token. See """
+    + BASE_UA_URL
+    + "."
+)
+MESSAGE_ATTACH_REQUIRES_TOKEN = (
+    """\
 Attach requires a token: sudo ua attach <TOKEN>
-To obtain a token please visit: https://ubuntu.com/advantage"""
-MESSAGE_ATTACH_FAILURE = """\
-Failed to attach machine. See https://ubuntu.com/advantage"""
+To obtain a token please visit: """
+    + BASE_UA_URL
+    + "."
+)
+MESSAGE_ATTACH_FAILURE = (
+    """\
+Failed to attach machine. See """
+    + BASE_UA_URL
+    + "."
+)
 MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES = """\
 Failed to enable default services, check: sudo ua status"""
 MESSAGE_ATTACH_SUCCESS_TMPL = """\
@@ -298,10 +338,14 @@ MESSAGE_UNEXPECTED_ERROR = """\
 Unexpected error(s) occurred.
 For more details, see the log: /var/log/ubuntu-advantage.log
 To file a bug run: ubuntu-bug ubuntu-advantage-tools"""
-MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
+MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = (
+    """\
 To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
-See https://ubuntu.com/advantage."""
+See """
+    + BASE_UA_URL
+    + "."
+)
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
 MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL = """\
 A reboot is required to complete {operation}."""
@@ -323,9 +367,13 @@ MESSAGE_INCOMPATIBLE_SERVICE_STOPS_ENABLE = """\
 Cannot enable {service_being_enabled} when {incompatible_service} is enabled.
 """
 
-MESSAGE_FIPS_BLOCK_ON_CLOUD = """\
+MESSAGE_FIPS_BLOCK_ON_CLOUD = (
+    """\
 Ubuntu {series} does not provide {cloud} optimized FIPS kernel
-For help see: https://ubuntu.com/advantage."""
+For help see: """
+    + BASE_UA_URL
+    + "."
+)
 ERROR_INVALID_CONFIG_VALUE = """\
 Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \
 Expected {expected_value}, found {value}."""

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -22,7 +22,7 @@ SERVICE       AVAILABLE  DESCRIPTION
 livepatch     yes        Canonical Livepatch service
 
 This machine is not attached to a UA subscription.
-See https://ubuntu.com/advantage.
+See https://ubuntu.com/advantage
 """
 
 ATTACHED_STATUS = """\


### PR DESCRIPTION
## Proposed Commit Message
fix: prompt for new token when expired one is used

When running ua fix we may need to install packages that depend on a UA service. Even if the user is already attached
to a UA subscription, this may not be enough, since the token used may be expired. If we encounter that situation, we would
need to ask the user to get a new token before proceeding with the package fixes. We are now adding the necessary code to allow us to handle that scenario.

Fixes: #1475

## Test Steps
Run the new unittests for this feature

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
