### PR TITLE
fix: show packages that were not fixed

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -189,6 +189,8 @@ Feature: Command behaviour when unattached
             1 affected package is installed: awl
             \(1/1\) awl:
             Ubuntu security engineers are investigating this issue.
+            1 package is still affected: awl
+            .*✘.* USN-4539-1 is not resolved.
             """
         When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
@@ -214,6 +216,7 @@ Feature: Command behaviour when unattached
         And stderr matches regexp:
             """
             Error: CVE-2017-9233 metadata defines no fixed version for expat.
+            3 packages are still affected: expat, matanza, swish-e
             .*✘.* CVE-2017-9233 is not resolved.
             """
 
@@ -252,6 +255,8 @@ Feature: Command behaviour when unattached
             A fix is available in UA Infra.
             Package fixes cannot be installed.
             To install them, run this command as root \(try using sudo\)
+            1 package is still affected: krb5
+            .*✘.* CVE-2020-28196 is not resolved.
             """
         When I fix `USN-4747-2` by attaching to a subscription with `contract_token`
         Then stdout matches regexp:
@@ -341,6 +346,7 @@ Feature: Command behaviour when unattached
             1 affected package is installed: awl
             \(1/1\) awl:
             Ubuntu security engineers are investigating this issue.
+            1 package is still affected: awl
             .*✘.* USN-4539-1 is not resolved.
             """
         When I run `ua fix CVE-2020-28196` as non-root
@@ -365,6 +371,8 @@ Feature: Command behaviour when unattached
         A fix is available in Ubuntu standard updates.
         Package fixes cannot be installed.
         To install them, run this command as root \(try using sudo\)
+        1 package is still affected: xterm
+        .*✘.* CVE-2021-27135 is not resolved.
         """
         When I run `ua fix CVE-2021-27135` with sudo
         Then stdout matches regexp:
@@ -375,6 +383,7 @@ Feature: Command behaviour when unattached
         \(1/1\) xterm:
         A fix is available in Ubuntu standard updates.
         .*\{ apt update && apt install --only-upgrade -y xterm \}.*
+        .*✔.* CVE-2021-27135 is resolved.
         """
         When I run `ua fix CVE-2021-27135` with sudo
         Then stdout matches regexp:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -378,8 +378,7 @@ Found error: {error} when reading json file: {file_path}"""
 
 MESSAGE_SECURITY_APT_NON_ROOT = """\
 Package fixes cannot be installed.
-To install them, run this command as root (try using sudo)
-"""
+To install them, run this command as root (try using sudo)"""
 
 
 def colorize(string: str) -> str:

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -884,6 +884,7 @@ class TestPromptForAffectedPackages:
             )
         assert (
             "Error: USN-### metadata defines no fixed version for sl.\n"
+            "1 package is still affected: slsrc\n"
             "{msg}".format(
                 msg=MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(issue="USN-###")
             )
@@ -1064,38 +1065,48 @@ class TestPromptForAffectedPackages:
                     "pkg13": CVEPackageStatus(
                         CVE_PKG_STATUS_RELEASED_ESM_INFRA
                     ),
+                    "pkg14": CVEPackageStatus(
+                        CVE_PKG_STATUS_RELEASED_ESM_APPS
+                    ),
+                    "pkg15": CVEPackageStatus(
+                        CVE_PKG_STATUS_RELEASED_ESM_APPS
+                    ),
                 },
                 {
                     "pkg10": {"pkg10": "2.0"},
                     "pkg11": {"pkg11": "2.0"},
                     "pkg12": {"pkg12": "2.0"},
                     "pkg13": {"pkg13": "2.0"},
+                    "pkg14": {"pkg14": "2.0"},
+                    "pkg15": {"pkg15": "2.0"},
                 },
                 {
                     "pkg10": {"pkg10": {"version": "2.1"}},
                     "pkg11": {"pkg11": {"version": "2.1"}},
                     "pkg12": {"pkg12": {"version": "2.1"}},
                     "pkg13": {"pkg13": {"version": "2.1"}},
+                    "pkg14": {"pkg14": {"version": "2.1"}},
+                    "pkg15": {"pkg15": {"version": "2.1"}},
                 },
                 "gcp",
                 textwrap.dedent(
                     """\
-                    13 affected packages are installed: {}
-                    (1/13, 2/13, 3/13) pkg1, pkg2, pkg9:
+                    15 affected packages are installed: {}
+                    (1/15, 2/15, 3/15) pkg1, pkg2, pkg9:
                     Sorry, no fix is available.
-                    (4/13, 5/13) pkg7, pkg8:
+                    (4/15, 5/15) pkg7, pkg8:
                     Sorry, no fix is available yet.
-                    (6/13, 7/13) pkg5, pkg6:
+                    (6/15, 7/15) pkg5, pkg6:
                     Ubuntu security engineers are investigating this issue.
-                    (8/13, 9/13) pkg3, pkg4:
+                    (8/15, 9/15) pkg3, pkg4:
                     A fix is coming soon. Try again tomorrow.
-                    (10/13, 11/13) pkg10, pkg11:
+                    (10/15, 11/15) pkg10, pkg11:
                     A fix is available in Ubuntu standard updates.
                     """
                 ).format(
                     (
-                        "pkg1, pkg10, pkg11, pkg12, pkg13, pkg2, pkg3, pkg4,"
-                        " pkg5, pkg6, pkg7, pkg8, pkg9"
+                        "pkg1, pkg10, pkg11, pkg12, pkg13, pkg14, pkg15, "
+                        "pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9"
                     )
                 )
                 + colorize_commands(
@@ -1109,11 +1120,18 @@ class TestPromptForAffectedPackages:
                 + "\n"
                 + textwrap.dedent(
                     """\
-                    (12/13, 13/13) pkg12, pkg13:
-                    A fix is available in UA Infra.
+                    (12/15, 13/15) pkg14, pkg15:
+                    A fix is available in UA Apps.
                     """
                 )
-                + MSG_SUBSCRIPTION,
+                + MSG_SUBSCRIPTION
+                + "\n"
+                + "13 packages are still affected: {}".format(
+                    (
+                        "pkg1, pkg12, pkg13, pkg14, pkg15, pkg2, pkg3,"
+                        " pkg4, pkg5, pkg6, pkg7, pkg8, pkg9"
+                    )
+                ),
             ),
             (  # No released version
                 {
@@ -1145,6 +1163,10 @@ class TestPromptForAffectedPackages:
                 ).format(
                     "pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9"
                 )
+                + "9 packages are still affected: {}".format(
+                    "pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7, pkg8, pkg9"
+                )
+                + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
             ),
         ),
@@ -1316,6 +1338,8 @@ class TestPromptForAffectedPackages:
                     A fix is available in Ubuntu standard updates.
                     """
                 )
+                + "3 packages are still affected: pkg1, pkg2, pkg3"
+                + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
             ),
         ),
@@ -1383,6 +1407,8 @@ class TestPromptForAffectedPackages:
                 + MESSAGE_SECURITY_UA_SERVICE_NOT_ENTITLED.format(
                     service="esm-apps"
                 )
+                + "\n"
+                + "2 packages are still affected: pkg1, pkg2"
                 + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
             ),
@@ -1546,6 +1572,8 @@ class TestPromptForAffectedPackages:
                     service="esm-apps"
                 )
                 + "\n"
+                + "1 package is still affected: pkg1"
+                + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
             ),
         ),
@@ -1692,6 +1720,8 @@ class TestPromptForAffectedPackages:
                     """
                 )
                 + MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_EXPIRED
+                + "\n"
+                + "1 package is still affected: pkg1"
                 + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
             ),


### PR DESCRIPTION
## Proposed Commit Message
fix: show packages that were not fixed

When running ua fix when may end up in a state where we cannot fix all the packages. If we get into that situation, we will not display to the user what were the packages that were not fixed and are still affected by the CVE/USN that the command tried to fix.

Fixed: #1448

## Test Steps
Run the modified integration tests in this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
