### PR TITLE
tests: run status wait before detach in PRO tests

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -743,6 +743,7 @@ def _install_uat_in_container(
                 conf_path
             )
         )
+        cmds.append("sudo ua status --wait")
         cmds.append("sudo ua detach --assume-yes")
 
     cmds.append(["ua", "version"])


### PR DESCRIPTION
## Proposed Commit Message
tests: run status wait before detach in PRO tests

When we are creating a PRO instance, we install the latest uaclient package on the machine and then snapshot it to be used as a base image for all other tests. This base image should be a clean image, meaning that it should not be attached to uaclient. To ensure that, we run a detach operation on the base image and config it to block auto-attach. However, when we run detach, the auto-attach operation may still be running. We are now running ua status --wait before detach to avoid that.

## Test Steps
Run any of the GCP PRO integration tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
