### PR TITLE
fix: parse full API responses for related CVEs and USNs

### DIFF
--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -162,7 +162,7 @@ class UASecurityClient(serviceclient.UAServiceClient):
             [
                 USN(client=self, response=usn_md)
                 for usn_md in usns_response.get("notices", [])
-                if details is None or details in usn_md.get("cves", [])
+                if details is None or details in usn_md.get("cves_ids", [])
             ],
             key=lambda x: x.id,
         )
@@ -533,7 +533,7 @@ def fix_security_issue_id(cfg: UAConfig, issue_id: str) -> None:
         try:
             usn = client.get_notice(notice_id=issue_id)
             for cve in usn.cves:
-                for related_usn_id in cve.usn_ids:
+                for related_usn_id in cve.notices_ids:
                     if related_usn_id not in related_usns:
                         related_usns[related_usn_id] = client.get_notice(
                             notice_id=related_usn_id

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -681,8 +681,8 @@ class TestUASecurityClient:
             request_url.return_value = (
                 {
                     "notices": [
-                        {"id": "2", "cves": ["cve"]},
-                        {"id": "1", "cves": ["cve"]},
+                        {"id": "2", "cves_ids": ["cve"]},
+                        {"id": "1", "cves_ids": ["cve"]},
                     ]
                 },
                 "headers",
@@ -706,8 +706,8 @@ class TestUASecurityClient:
         request_url.return_value = (
             {
                 "notices": [
-                    {"id": "2", "cves": ["cve1"]},
-                    {"id": "1", "cves": ["cve12"]},
+                    {"id": "2", "cves_ids": ["cve1"]},
+                    {"id": "1", "cves_ids": ["cve12"]},
                 ]
             },
             "headers",
@@ -1885,6 +1885,14 @@ class TestFixSecurityIssueId:
                 UASecurityClient, "get_notices"
             ) as m_notices:
                 usn_mock = mock.MagicMock()
+                cve_mock = mock.MagicMock()
+
+                type(cve_mock).notices_ids = mock.PropertyMock(
+                    return_value=["USN-123"]
+                )
+                type(usn_mock).cves = mock.PropertyMock(
+                    return_value=[cve_mock]
+                )
                 type(usn_mock).response = mock.PropertyMock(
                     return_value={"release_packages": {}}
                 )


### PR DESCRIPTION
## Proposed Commit Message

Reduce the number of API calls needed to query related CVEs and USNs
by processing the keys USN["cves"] and CVE["notices"] which now
contain detailed metadata response for the CVE and USN objects.

- Drop unneeded USN.get_cves_metadata and CVE.get_notices_metadata
- add CVE.notices to cache a list of USNs based on new "notices"
  key which contains full USN metadata from API response
- adapt CVE.notices_ids to rely on new "notices_ids" key from API
- add USN.cves to cache a list of CVEs based on the new "cves"
  full metadata from API response
- adapt USN.cves_ids to rely on new "cves_ids" key from API
- add equality checks for USN and CVE instances

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
