### PR TITLE
gcp: update public gcp images for integration testing

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -515,7 +515,9 @@ def after_step(context, step):
 
 
 def after_all(context):
-    if context.config.image_clean:
+    if context.config.ppa == "":
+        print(" No custom images to delete. UACLIENT_BEHAVE_PPA is unset.")
+    elif context.config.image_clean:
         for key, image in context.series_image_name.items():
             if key == context.series_reuse_image:
                 print(
@@ -630,6 +632,17 @@ def create_uat_image(context: Context, series: str) -> None:
             context.reuse_container[series],
         )
         return
+    ppa = context.config.ppa
+    if ppa == "":
+        image_name = context.config.cloud_manager.locate_image_name(series)
+        print(
+            "--- Unset UACLIENT_BEHAVE_PPA. Using ubuntu-advantage-tools from image: {}".format(
+                image_name
+            )
+        )
+        context.series_image_name[series] = image_name
+        return
+
     time_suffix = datetime.datetime.now().strftime("%s%f")
     deb_paths = []
     if context.config.build_pr:

--- a/features/gcp-ids.yaml
+++ b/features/gcp-ids.yaml
@@ -1,3 +1,3 @@
-xenial: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-1604-xenial-v20210205"
-bionic: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-1804-bionic-v20210205"
-focal: "projects/ubuntu-os-cloud-image-proposed/global/images/testing-ubuntu-pro-2004-focal-v20210205"
+xenial: "projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1604-xenial-v20210329"
+bionic: "projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1804-bionic-v20210329"
+focal: "projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-2004-focal-v20210329"


### PR DESCRIPTION
## Proposed Commit Message

CPC team just published official GCP images.

Add a secondary commit to allow specifying UACLIENT_BEHAVE_PPA="" to avoid altering PRO images under test

Update our gcp test image ids to reference the public images.
## Test Steps
```bash
UACLIENT_BEHAVE_PPA="" UACLIENT_BEHAVE_GCP_PROJECT=ubuntu-rickh UACLIENT_BEHAVE_GOOGLE_APPLICATION_CREDENTIALS=/root/gcp-cred.json tox -e behave-18.04-gcp  # on a machine with gcloud credentials installed
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
