### PR TITLE
fix: add links to ubuntu.com/gcp/aws in messaging when on non-PRO

### DIFF
--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -29,7 +29,7 @@ CLOUD_TYPE_TO_TITLE = {
     "gcp": "GCP",
 }
 
-PRO_CLOUDS = ["aws", "azure"]
+PRO_CLOUDS = ["aws", "azure", "gcp"]
 
 
 def get_instance_id(

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -1067,7 +1067,14 @@ class TestPromptForAffectedPackages:
                     A fix is available in UA Apps.
                     """
                 )
-                + MSG_SUBSCRIPTION,
+                + "\n".join(
+                    [
+                        MESSAGE_SECURITY_USE_PRO_TMPL.format(
+                            title="GCP", cloud="gcp"
+                        ),
+                        MSG_SUBSCRIPTION,
+                    ]
+                ),
             ),
             (  # version is < released affected both esm-apps and standard
                 {
@@ -1147,7 +1154,14 @@ class TestPromptForAffectedPackages:
                     A fix is available in UA Apps.
                     """
                 )
-                + MSG_SUBSCRIPTION
+                + "\n".join(
+                    [
+                        MESSAGE_SECURITY_USE_PRO_TMPL.format(
+                            title="GCP", cloud="gcp"
+                        ),
+                        MSG_SUBSCRIPTION,
+                    ]
+                )
                 + "\n"
                 + "13 packages are still affected: {}".format(
                     (


### PR DESCRIPTION
## Proposed Commit Message
fix: add links to ubuntu.com/gcp/aws in messaging when on non-PRO

## Test Steps

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
