### PR TITLE
Make lint and style stage run sequentially

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,35 +37,28 @@ pipeline {
                 '''
             }
         }
-        stage ('Lint and Style') {
-            parallel {
-                stage("flake8") {
-                    steps {
-                        sh '''
-                        set +x
-                        . $TMPDIR/bin/activate
-                        tox --parallel--safe-build -e flake8
-                        '''
-                    }
-                }
-                stage("style") {
-                    steps {
-                        sh '''
-                        set +x
-                        . $TMPDIR/bin/activate
-                        tox --parallel--safe-build -e black
-                        '''
-                    }
-                }
-                stage("mypy") {
-                    steps {
-                        sh '''
-                        set +x
-                        . $TMPDIR/bin/activate
-                        tox --parallel--safe-build -e mypy
-                        '''
-                    }
-                }
+        stage("flake8") {
+            steps {
+                sh '''
+                set +x
+                tox -e flake8
+                '''
+            }
+        }
+        stage("style") {
+            steps {
+                sh '''
+                set +x
+                tox -e black
+                '''
+            }
+        }
+        stage("mypy") {
+            steps {
+                sh '''
+                set +x
+                tox -e mypy
+                '''
             }
         }
         stage ('Unit Tests') {


### PR DESCRIPTION
## Proposed Commit Message
Make lint and style stage run sequentially

We are experiencing some issues running mypy tests. We believe that reason is because we are running tox inside
a virtualenv. To fix that, we removing the virtualenv creation from this stage and also making the jobs in that stage run sequentially

## Test Steps
We can spot the behavior on the CI

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
