### PR TITLE
{WIP] config: create settings_overrides on config

### DIFF
--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -6,6 +6,7 @@ from uaclient import exceptions
 from uaclient import clouds
 from uaclient import status
 from uaclient import util
+from uaclient.config import apply_config_settings_override
 
 try:
     from typing import Dict, Optional, Type  # noqa: F401
@@ -57,6 +58,7 @@ def get_cloud_type_from_result_file(
     return DATASOURCE_TO_CLOUD_ID.get(dsname, dsname)
 
 
+@apply_config_settings_override("cloud_type")
 def get_cloud_type() -> "Optional[str]":
     if util.which("cloud-id"):
         # Present in cloud-init on >= Xenial

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -97,6 +97,37 @@ class TestGetCloudType:
     ):
         assert get_cloud_type() is None
 
+    @pytest.mark.parametrize(
+        "settings_overrides",
+        (
+            (
+                """
+                settings_overrides:
+                  cloud_type: "azure"
+                """
+            ),
+            (
+                """
+                settings_overrides:
+                  other_setting: "blah"
+                """
+            ),
+        ),
+    )
+    @mock.patch("uaclient.util.load_file")
+    @mock.patch(M_PATH + "util.which", return_value="/usr/bin/cloud-id")
+    @mock.patch(M_PATH + "util.subp", return_value=("test", ""))
+    def test_cloud_type_when_using_settings_override(
+        self, m_subp, m_which, m_load_file, settings_overrides
+    ):
+        if "azure" in settings_overrides:
+            expected_value = "azure"
+        else:
+            expected_value = "test"
+
+        m_load_file.return_value = settings_overrides
+        assert get_cloud_type() == expected_value
+
 
 @mock.patch(M_PATH + "get_cloud_type")
 class TestCloudInstanceFactory:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import datetime
+from functools import wraps
 import json
 import logging
 import os
@@ -47,6 +48,7 @@ MERGE_ID_KEY_MAP = {
     "availableResources": "name",
     "resourceEntitlements": "type",
 }
+UNSET_SETTINGS_OVERRIDE_KEY = "_unset"
 
 
 # A data path is a filename, and an attribute ("private") indicating whether it
@@ -658,6 +660,37 @@ def parse_config(config_path=None):
                 "Invalid url in config. {}: {}".format(key, cfg[key])
             )
     return cfg
+
+
+def apply_config_settings_override(override_key: str):
+    """Decorator used to override function return by config settings.
+
+    To identify if we should override the function return, we check
+    if the config object has the expected override key, we use it
+    has, we will use the key value as the function return. Otherwise
+    we will call the function normally.
+
+    @param override_key: key to be looked for in the settings_override
+     entry in the config dict. If that key is present, we will return
+     its value as the function return.
+    """
+
+    def wrapper(f):
+        @wraps(f)
+        def new_f():
+            cfg = parse_config()
+            value_override = cfg.get("settings_overrides", {}).get(
+                override_key, UNSET_SETTINGS_OVERRIDE_KEY
+            )
+
+            if value_override != UNSET_SETTINGS_OVERRIDE_KEY:
+                return value_override
+
+            return f()
+
+        return new_f
+
+    return wrapper
 
 
 def depth_first_merge_overlay_dict(base_dict, overlay_dict):


### PR DESCRIPTION
## Proposed Commit Message
config: create settings_overrides on config

Currently, we need cloud-init to identify if FIPS can be correctly installed in an instance. This behavior is making
it harder to use uaclient in other scenarios, for example, when building an image using chroot. To better handle that, we are
creating a settings_overrides dict in ua config. Users will be able to override specific settings by just updating the uaclient.conf
file.  For example, to override the cloud type users will need to add this to `uaclient.conf`:

```yaml
settings_overrides:
  cloud_type: "gce"
```

To use these overrides, we have created a decorator that can modify a function return based on the override defined in the config. As of today, this is only being used in the get_cloud_type function.

Fixes: #1507

## Test Steps
This is a WIP branch

We have a new unittest for this feature, but more tests can be included

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
