### PR TITLE
Update container check for chroot environments

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: bash-completion,
                debhelper (>=9),
+               debianutils,
                dh-python,
                dh-systemd,
                gettext,


### PR DESCRIPTION
## Proposed Commit Message
util: improve is_container check for chroot
    
When on a chroot, we don't want to say that the system is a container type. To avoid that, we are first calling the ischroot command. If it returns 0, we assume that we are on a chroot and inform that we are not in a container.

## Test Steps
Run the modified unit tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
