### PR TITLE
fix: notify users if reboot is required

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -526,6 +526,16 @@ class UAConfig:
 
         Write the status-cache when called by root.
         """
+
+        # Try to remove fix reboot notices if not applicable
+        if not util.should_reboot():
+            self.remove_notice(
+                "",
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="fix operation"
+                ),
+            )
+
         if os.getuid() != 0:
             response = cast("Dict[str, Any]", self.read_cache("status-cache"))
             if not response:

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -870,11 +870,11 @@ def prompt_for_affected_packages(
         print(_format_unfixed_packages_msg(unfixed_pkgs))
 
     if util.should_reboot():
-        print(
-            status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                operation="fix operation"
-            )
+        reboot_msg = status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+            operation="fix operation"
         )
+        print(reboot_msg)
+        cfg.add_notice("", reboot_msg)
         print(
             status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(issue=issue_id)
         )

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -869,6 +869,17 @@ def prompt_for_affected_packages(
     if unfixed_pkgs:
         print(_format_unfixed_packages_msg(unfixed_pkgs))
 
+    if util.should_reboot():
+        print(
+            status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                operation="fix operation"
+            )
+        )
+        print(
+            status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(issue=issue_id)
+        )
+        return
+
     if fix_status:
         print(fix_message)
     else:

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -122,12 +122,16 @@ class TestActionAttach:
             ),
         ),
     )
+    @mock.patch("uaclient.util.should_reboot", return_value=False)
+    @mock.patch("uaclient.config.UAConfig.remove_notice")
     @mock.patch("uaclient.contract.get_available_resources")
     @mock.patch(M_PATH + "contract.request_updated_contract")
     def test_status_updated_when_auto_enable_fails(
         self,
         request_updated_contract,
         _m_get_available_resources,
+        _m_should_reboot,
+        _m_remove_notice,
         _m_get_uid,
         error_class,
         error_str,
@@ -158,12 +162,20 @@ class TestActionAttach:
         logs = caplog_text()
         assert expected_log in logs
 
+    @mock.patch("uaclient.util.should_reboot", return_value=False)
+    @mock.patch("uaclient.config.UAConfig.remove_notice")
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_contract_machine_attach"
     )
     @mock.patch(M_PATH + "action_status")
     def test_happy_path_with_token_arg(
-        self, action_status, contract_machine_attach, _m_getuid, FakeConfig
+        self,
+        action_status,
+        contract_machine_attach,
+        _m_should_reboot,
+        _m_remove_notice,
+        _m_getuid,
+        FakeConfig,
     ):
         """A mock-heavy test for the happy path with the contract token arg"""
         # TODO: Improve this test with less general mocking and more
@@ -186,9 +198,17 @@ class TestActionAttach:
         assert expected_calls == contract_machine_attach.call_args_list
 
     @pytest.mark.parametrize("auto_enable", (True, False))
+    @mock.patch("uaclient.util.should_reboot", return_value=False)
+    @mock.patch("uaclient.config.UAConfig.remove_notice")
     @mock.patch("uaclient.contract.get_available_resources")
     def test_auto_enable_passed_through_to_request_updated_contract(
-        self, _m_getuid, _m_get_available_resources, auto_enable, FakeConfig
+        self,
+        _m_get_available_resources,
+        _m_should_reboot,
+        _m_remove_notice,
+        _m_get_uid,
+        auto_enable,
+        FakeConfig,
     ):
         args = mock.MagicMock(auto_enable=auto_enable)
 

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -314,12 +314,16 @@ class TestActionAutoAttach:
             "Operation in progress: ua disable (pid:123)"
         ) == err.value.msg
 
+    @mock.patch("uaclient.util.should_reboot", return_value=False)
+    @mock.patch("uaclient.config.UAConfig.remove_notice")
     @mock.patch(M_PATH + "contract.request_updated_contract")
     @mock.patch(M_PATH + "_get_contract_token_from_cloud_identity")
     def test_happy_path_on_aws_non_auto_attach(
         self,
         get_contract_token_from_cloud_identity,
         request_updated_contract,
+        _m_should_reboot,
+        _m_remove_notice,
         _m_getuid,
         FakeConfig,
     ):

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -166,13 +166,22 @@ Flags:
 )
 
 
+@mock.patch("uaclient.util.should_reboot", return_value=False)
+@mock.patch("uaclient.config.UAConfig.remove_notice")
 @mock.patch(
     M_PATH + "contract.get_available_resources",
     return_value=RESPONSE_LIVEPATCH_AVAILABLE,
 )
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionStatus:
-    def test_status_help(self, _getuid, _get_available_resources, capsys):
+    def test_status_help(
+        self,
+        _getuid,
+        _get_available_resources,
+        _m_should_reboot,
+        _m_remove_notice,
+        capsys,
+    ):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "status", "--help"]):
                 main()
@@ -194,6 +203,8 @@ class TestActionStatus:
         self,
         m_getuid,
         m_get_avail_resources,
+        _m_should_reboot,
+        _m_remove_notice,
         notices,
         notice_status,
         use_all,
@@ -224,7 +235,13 @@ class TestActionStatus:
         )
 
     def test_unattached(
-        self, m_getuid, m_get_avail_resources, capsys, FakeConfig
+        self,
+        m_getuid,
+        m_get_avail_resources,
+        _m_should_reboot,
+        _m_remove_notice,
+        capsys,
+        FakeConfig,
     ):
         """Check that unattached status is emitted to console"""
         cfg = FakeConfig()
@@ -240,6 +257,8 @@ class TestActionStatus:
         m_subp,
         m_getuid,
         m_get_avail_resources,
+        _m_should_reboot,
+        _m_remove_notice,
         capsys,
         FakeConfig,
     ):
@@ -259,12 +278,12 @@ class TestActionStatus:
         assert "...\n" + UNATTACHED_STATUS == capsys.readouterr()[0]
 
     @pytest.mark.parametrize("use_all", (True, False))
-    @mock.patch(M_PATH + "util.should_reboot", return_value=False)
     def test_unattached_json(
         self,
         m_getuid,
         m_get_avail_resources,
-        m_should_reboot,
+        _m_should_reboot,
+        _m_remove_notice,
         use_all,
         capsys,
         FakeConfig,
@@ -298,12 +317,12 @@ class TestActionStatus:
         assert expected == json.loads(capsys.readouterr()[0])
 
     @pytest.mark.parametrize("use_all", (True, False))
-    @mock.patch(M_PATH + "util.should_reboot", return_value=False)
     def test_attached_json(
         self,
         m_getuid,
         m_get_avail_resources,
-        m_should_reboot,
+        _m_should_reboot,
+        _m_remove_notice,
         use_all,
         capsys,
         FakeConfig,
@@ -343,7 +362,13 @@ class TestActionStatus:
         assert expected == json.loads(capsys.readouterr()[0])
 
     def test_error_on_connectivity_errors(
-        self, m_getuid, m_get_avail_resources, capsys, FakeConfig
+        self,
+        m_getuid,
+        m_get_avail_resources,
+        _m_should_reboot,
+        _m_remove_notice,
+        capsys,
+        FakeConfig,
     ):
         """Raise UrlError on connectivity issues"""
         m_get_avail_resources.side_effect = util.UrlError(
@@ -363,6 +388,8 @@ class TestActionStatus:
         self,
         _m_getuid,
         _m_get_avail_resources,
+        _m_should_reboot,
+        _m_remove_notice,
         encoding,
         expected_dash,
         FakeConfig,

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -34,6 +34,7 @@ from uaclient.status import (
     MESSAGE_SECURITY_SERVICE_DISABLED,
     MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_EXPIRED,
     MESSAGE_ATTACH_EXPIRED_TOKEN,
+    MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL,
     PROMPT_ENTER_TOKEN,
     PROMPT_EXPIRED_ENTER_TOKEN,
     UserFacingStatus,
@@ -1940,6 +1941,7 @@ A fix is available in Ubuntu standard updates.\n"""
             ),
         ),
     )
+    @mock.patch("uaclient.config.UAConfig.add_notice")
     @mock.patch("uaclient.util.should_reboot", return_value=True)
     @mock.patch("uaclient.apt.run_apt_command", return_value="")
     @mock.patch("os.getuid", return_value=0)
@@ -1950,6 +1952,7 @@ A fix is available in Ubuntu standard updates.\n"""
         _m_os_getuid,
         _m_run_apt_command,
         _m_should_reboot,
+        m_add_notice,
         affected_pkg_status,
         installed_packages,
         usn_released_pkgs,
@@ -1969,6 +1972,15 @@ A fix is available in Ubuntu standard updates.\n"""
         )
         out, err = capsys.readouterr()
         assert expected in out
+
+        assert [
+            mock.call(
+                "",
+                MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation="fix operation"
+                ),
+            )
+        ] == m_add_notice.call_args_list
 
 
 class TestUpgradePackagesAndAttach:


### PR DESCRIPTION
## Proposed Commit Message
fix: notify users if reboot is required

When upgrading packages during ua fix we may install a package that requires a system reboot to fully fix the issue at hand. We are now alerting the user if a reboot is required when running ua fix.

Fixes: #1476

PS: The approach used here some shortcomings:

* If the user has installed a package that requires reboot and then run ua fix, we will not known if the reboot is need because of ua fix or the package installed by the user.
* If we detect that a reboot is required, should we say that the CVE/USN was not fixed ? I am using that approach, but I am not sure if that is the intended behavior.

## Test Steps
Run the new unittest added

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
