### PR TITLE
fix: update how the expired token logic works

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -18,7 +18,7 @@ from hamcrest import (
 from features.environment import create_uat_image
 from features.util import SLOW_CMDS, emit_spinner_on_travis, nullcontext
 
-from uaclient.defaults import DEFAULT_CONFIG_FILE
+from uaclient.defaults import DEFAULT_CONFIG_FILE, DEFAULT_MACHINE_TOKEN_PATH
 
 
 CONTAINER_PREFIX = "ubuntu-behave-test-"
@@ -168,6 +168,33 @@ def when_i_fix_a_issue_by_enabling_service(context, issue):
         command="ua fix {}".format(issue),
         user_spec="with sudo",
         stdin="e\n",
+    )
+
+
+@when("I fix `{issue}` by updating expired token")
+def when_i_fix_a_issue_by_updating_expired_token(context, issue):
+    token = getattr(context.config, "contract_token")
+    when_i_run_command(
+        context=context,
+        command="ua fix {}".format(issue),
+        user_spec="with sudo",
+        stdin="r\n{}\n".format(token),
+    )
+
+
+@when("I update contract to use `{contract_field}` as `{new_value}`")
+def when_i_update_contract_field_to_new_value(
+    context, contract_field, new_value
+):
+    when_i_run_command(
+        context,
+        'sed -i \'s/"{}": "[^"]*"/"{}": "{}"/g\' {}'.format(
+            contract_field,
+            contract_field,
+            new_value,
+            DEFAULT_MACHINE_TOKEN_PATH,
+        ),
+        user_spec="with sudo",
     )
 
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -346,6 +346,36 @@ Feature: Command behaviour when unattached
             .*\{ apt update && apt install --only-upgrade -y screen \}.*
             .*✔.* USN-4747-2 is resolved.
             """
+        When I run `apt-get install -y screen=4.1.0~20120320gitdb59704-9 --force-yes` with sudo
+        And I update contract to use `effectiveTo` as `1999-12-01T00:00:00Z`
+        And I fix `USN-4747-2` by updating expired token
+        Then stdout matches regexp:
+            """
+            USN-4747-2: GNU Screen vulnerability
+            Found CVEs:
+            https://ubuntu.com/security/CVE-2021-26937
+            1 affected package is installed: screen
+            \(1/1\) screen:
+            A fix is available in UA Infra.
+            The update is not installed because this system is attached to an
+            expired subscription.
+
+            Choose: \[R\]enew your subscription \(at https://ubuntu.com/advantage\) \[C\]ancel
+            > Enter your new token to renew UA subscription on this system:
+            > .*\{ ua detach \}.*
+            Detach will disable the following service:
+                esm-infra
+            Updating package lists
+            This machine is now detached.
+            .*\{ ua attach .* \}.*
+            Updating package lists
+            ESM Infra enabled
+            """
+        And stdout matches regexp:
+            """
+            .*\{ apt update && apt install --only-upgrade -y screen \}.*
+            .*✔.* USN-4747-2 is resolved.
+            """
 
         Examples: ubuntu release
            | release |

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -924,7 +924,7 @@ def print_version(_args=None, _cfg=None):
 @assert_root
 @assert_attached()
 @assert_lock_file("ua refresh")
-def action_refresh(args, cfg, verbose=True):
+def action_refresh(args, cfg):
     try:
         contract.request_updated_contract(cfg)
     except util.UrlError as exc:
@@ -932,8 +932,7 @@ def action_refresh(args, cfg, verbose=True):
             logging.exception(exc)
         raise exceptions.UserFacingError(ua_status.MESSAGE_REFRESH_FAILURE)
 
-    if verbose:
-        print(ua_status.MESSAGE_REFRESH_SUCCESS)
+    print(ua_status.MESSAGE_REFRESH_SUCCESS)
     return 0
 
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -69,6 +69,7 @@ class UAConfig:
 
     _entitlements = None  # caching to avoid repetitive file reads
     _machine_token = None  # caching to avoid repetitive file reading
+    _contract_expiry_datetime = None
 
     def __init__(
         self, cfg: "Dict[str, Any]" = None, series: str = None
@@ -211,6 +212,18 @@ class UAConfig:
             util.apply_series_overrides(entitlement_cfg, self.series)
             self._entitlements[entitlement_name] = entitlement_cfg
         return self._entitlements
+
+    @property
+    def contract_expiry_datetime(self) -> "datetime":
+        if not self._contract_expiry_datetime:
+            contractInfo = self.machine_token["machineTokenInfo"][
+                "contractInfo"
+            ]
+            self._contract_expiry_datetime = datetime.strptime(
+                contractInfo["effectiveTo"], "%Y-%m-%dT%H:%M:%SZ"
+            )
+
+        return self._contract_expiry_datetime
 
     @property
     def is_attached(self):

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -6,6 +6,8 @@ any of our dependencies installed.
 """
 
 UAC_ETC_PATH = "/etc/ubuntu-advantage/"
+DEFAULT_DATA_DIR = "/var/lib/ubuntu-advantage"
+DEFAULT_MACHINE_TOKEN_PATH = DEFAULT_DATA_DIR + "/private/machine-token.json"
 DEFAULT_CONFIG_FILE = UAC_ETC_PATH + "uaclient.conf"
 DEFAULT_HELP_FILE = UAC_ETC_PATH + "help_data.yaml"
 DEFAULT_UPGRADE_CONTRACT_FLAG_FILE = UAC_ETC_PATH + "request-update-contract"
@@ -17,7 +19,7 @@ PRINT_WRAP_WIDTH = 80
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,
     "security_url": BASE_SECURITY_URL,
-    "data_dir": "/var/lib/ubuntu-advantage",
+    "data_dir": DEFAULT_DATA_DIR,
     "log_level": "INFO",
     "log_file": "/var/log/ubuntu-advantage.log",
 }

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -5,6 +5,7 @@ import socket
 import textwrap
 
 from collections import defaultdict
+from datetime import datetime
 
 from uaclient import apt
 from uaclient.config import UAConfig
@@ -1039,15 +1040,10 @@ def _check_subscription_is_expired(cfg: UAConfig) -> bool:
 
     :returns: True if subscription is expired and not renewed.
     """
-    from uaclient import cli
-
-    try:
-        cli.action_refresh(args=None, cfg=cfg, verbose=False)
-    except exceptions.UserFacingError as e:
-        if status.MESSAGE_ATTACH_EXPIRED_TOKEN in str(e):
-            return not _prompt_for_new_token(cfg)
-        else:
-            raise e
+    contract_expiry_datetime = cfg.contract_expiry_datetime
+    tzinfo = contract_expiry_datetime.tzinfo
+    if contract_expiry_datetime < datetime.now(tzinfo):
+        return not _prompt_for_new_token(cfg)
 
     return False
 

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -33,7 +33,6 @@ from uaclient.status import (
     MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION as MSG_SUBSCRIPTION,
     MESSAGE_SECURITY_SERVICE_DISABLED,
     MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_EXPIRED,
-    MESSAGE_ATTACH_EXPIRED_TOKEN,
     MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL,
     PROMPT_ENTER_TOKEN,
     PROMPT_EXPIRED_ENTER_TOKEN,
@@ -1816,7 +1815,6 @@ A fix is available in Ubuntu standard updates.\n"""
     @mock.patch("uaclient.cli.action_attach")
     @mock.patch("builtins.input", return_value="token")
     @mock.patch("uaclient.cli.action_detach")
-    @mock.patch("uaclient.cli.action_refresh")
     @mock.patch("uaclient.security._check_subscription_for_required_service")
     @mock.patch("os.getuid", return_value=0)
     @mock.patch("uaclient.security.get_cloud_type")
@@ -1827,7 +1825,6 @@ A fix is available in Ubuntu standard updates.\n"""
         m_get_cloud_type,
         _m_os_getuid,
         m_check_subscription_for_service,
-        m_cli_refresh,
         _m_cli_detach,
         _m_input,
         m_cli_attach,
@@ -1842,13 +1839,16 @@ A fix is available in Ubuntu standard updates.\n"""
     ):
         m_get_cloud_type.return_value = "cloud"
         m_check_subscription_for_service.return_value = True
-        m_cli_refresh.side_effect = exceptions.UserFacingError(
-            MESSAGE_ATTACH_EXPIRED_TOKEN
-        )
         m_cli_attach.return_value = 0
 
         cfg = FakeConfig()
-        cfg.for_attached_machine()
+        cfg.for_attached_machine(
+            machine_token={
+                "machineTokenInfo": {
+                    "contractInfo": {"effectiveTo": "1999-12-01T00:00:00Z"}
+                }
+            }
+        )
         prompt_for_affected_packages(
             cfg=cfg,
             issue_id="USN-###",
@@ -1882,7 +1882,6 @@ A fix is available in Ubuntu standard updates.\n"""
         ),
     )
     @mock.patch("uaclient.util.should_reboot", return_value=False)
-    @mock.patch("uaclient.cli.action_refresh")
     @mock.patch("os.getuid", return_value=0)
     @mock.patch("uaclient.security.get_cloud_type")
     @mock.patch("uaclient.security.util.prompt_choices", return_value="c")
@@ -1891,7 +1890,6 @@ A fix is available in Ubuntu standard updates.\n"""
         m_prompt_choices,
         m_get_cloud_type,
         _m_os_getuid,
-        m_cli_refresh,
         _m_should_reboot,
         affected_pkg_status,
         installed_packages,
@@ -1901,12 +1899,15 @@ A fix is available in Ubuntu standard updates.\n"""
         capsys,
     ):
         m_get_cloud_type.return_value = "cloud"
-        m_cli_refresh.side_effect = exceptions.UserFacingError(
-            MESSAGE_ATTACH_EXPIRED_TOKEN
-        )
 
         cfg = FakeConfig()
-        cfg.for_attached_machine()
+        cfg.for_attached_machine(
+            machine_token={
+                "machineTokenInfo": {
+                    "contractInfo": {"effectiveTo": "1999-12-01T00:00:00Z"}
+                }
+            }
+        )
         prompt_for_affected_packages(
             cfg=cfg,
             issue_id="USN-###",


### PR DESCRIPTION
## Proposed Commit Message
fix: update how the expired token logic works

We are now updating the logic to verify if an UA subscription has expired. Instead of requesting an ua refresh and verifying if the
contract backend has raised any errors, we are now going directly to the machine-token.json file and verifing until which date the contract is valid through the effectiveTo field.

## Test Steps
Run the modified unit tests and run the modified trusty integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
