### PR TITLE
subp: separate % format strings when logging

### DIFF
--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -250,9 +250,8 @@ def retry(exception, retry_sleeps):
                 except exception as e:
                     if not sleeps:
                         raise e
-                    logging.debug(
-                        str(e) + " Retrying %d more times.", len(sleeps)
-                    )
+                    retry_msg = " Retrying %d more times." % len(sleeps)
+                    logging.debug(str(e) + retry_msg)
                     time.sleep(sleeps.pop(0))
 
         return decorator
@@ -582,9 +581,8 @@ def subp(
                 logging.debug(str(e))
             if not retry_sleeps:
                 raise
-            logging.debug(
-                str(e) + " Retrying %d more times.", len(retry_sleeps)
-            )
+            retry_msg = " Retrying %d more times." % len(retry_sleeps)
+            logging.debug(str(e) + retry_msg)
             time.sleep(retry_sleeps.pop(0))
     return out, err
 


### PR DESCRIPTION
## Proposed Commit Message

Some apt errors contain % in the failure messages.
When concatenating this str(e) with a python %-formatting there
will be collisions when trying to report the number of retries
remaining.

Avoid this formmatting collision by first rendering any %-formatted
retry message and concatenating it to str(e) seperately.

Fixes: #1520


## Test Steps
New Unit test will exercise this, otherwise one could do something like the following:
```bash
lxc launch ubuntu-daily:xenial dev-x 
lxc exec dev-x -- sudo add-apt-repository ppa:ua-client/daily
lxc exec dev-x -- sudo apt-get update
lxc exec dev-x -- sudo apt-get install ubuntu-advantage-tools
edit /usr/lib/python3/dist-packages/uaclient/util.is_container to return False
sudo ua attach <your_token>
sudo ua enable fips
See traceback
lxc file push uaclient/util.py dev-x/usr/lib/python3/dist-packages/uaclient/
Try again with success and proper retry logs.
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
