### PR TITLE
cli: pass assume_yes param to services on detach

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -635,7 +635,7 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     """
     to_disable = []
     for ent_cls in entitlements.ENTITLEMENT_CLASSES:
-        ent = ent_cls(cfg)
+        ent = ent_cls(cfg=cfg, assume_yes=assume_yes)
         if ent.can_disable(silent=True):
             to_disable.append(ent)
     if to_disable:

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -99,6 +99,10 @@ class TestActionDetach:
                 mock.call(silent=True)
             ] == ent_cls.return_value.can_disable.call_args_list
 
+            assert [
+                mock.call(cfg=cfg, assume_yes=assume_yes)
+            ] == ent_cls.call_args_list
+
         # Check that disable is only called when can_disable is true
         for undisabled_cls in [
             m_entitlements.ENTITLEMENT_CLASSES[0],


### PR DESCRIPTION
## Proposed Commit Message
cli: pass assume_yes param to services on detach

Currently, we are not passing the assume_yes parameter to each service that we will disable during a detach operation. We are now updating detach to pass assume_yes for all services that it will disable during the operation.

Fixes: #1530

## Test Steps
Run the modified unit test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
