### PR TITLE
lib: fix notice handling on reboot script

### DIFF
--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -120,15 +120,19 @@ def process_reboot_operations(args, cfg):
     if os.path.exists(reboot_cmd_marker_file):
         logging.debug("Running process contract deltas on reboot ...")
 
-        fix_pro_pkg_holds(cfg)
-        refresh_contract(cfg)
-        process_remaining_deltas(cfg)
+        try:
+            fix_pro_pkg_holds(cfg)
+            refresh_contract(cfg)
+            process_remaining_deltas(cfg)
 
-        cfg.delete_cache_key("marker-reboot-cmds")
-
-        logging.debug(
-            "Completed running process contract deltas on reboot ..."
-        )
+            cfg.delete_cache_key("marker-reboot-cmds")
+            cfg.remove_notice("", status.MESSAGE_REBOOT_SCRIPT_FAILED)
+            logging.debug("Successfully ran all commands on reboot.")
+        except Exception as e:
+            msg = "Failed running commands on reboot."
+            msg += str(e)
+            logging.error(msg)
+            cfg.add_notice("", status.MESSAGE_REBOOT_SCRIPT_FAILED)
 
 
 def main(cfg):

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -245,6 +245,9 @@ Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 MESSAGE_NO_ACTIVE_OPERATIONS = """No Ubuntu Advantage operations are running"""
 MESSAGE_LOCK_HELD = """Operation in progress: {lock_holder} (pid:{pid})"""
 PROMPT_YES_NO = """Are you sure? (y/N) """
+MESSAGE_REBOOT_SCRIPT_FAILED = (
+    "Failed running reboot_cmds script. See: /var/log/ubuntu-advantage.log"
+)
 MESSAGE_LIVEPATCH_LTS_REBOOT_REQUIRED = (
     "Livepatch support requires a system reboot across LTS upgrade."
 )


### PR DESCRIPTION
## Proposed Commit Message
lib: fix notice handling on reboot script

When the reboot script fails, we keep the notice that show that it is running. This happens because the assert_lock_file decorator cannot complete and remove the notice. We are now fixing that by catching the exceptions in the reboot script. Furthermore, we also issue a notice if the reboot script fails for some reason.

Fixes: #1518

## Test Steps
Run the new unit test on this PR

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
