### PR TITLE
apt-hook: print static messages on apt upgrade/dist-upgrade

### DIFF
--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -1,5 +1,5 @@
 APT::Update::Post-Invoke-Stats {
-	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook";
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook post-invoke-stats";
 };
 
 APT::Install::Post-Invoke-Success {

--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -3,9 +3,9 @@ APT::Update::Post-Invoke-Stats {
 };
 
 APT::Install::Post-Invoke-Success {
-	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook";
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook post-invoke-success";
 }; 
 
 APT::Install::Pre-Invoke {
-	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook apt-install-pre-invoke";
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook pre-invoke";
 }

--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -1,3 +1,11 @@
+APT::Update::Post-Invoke-Stats {
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook post-invoke-stats";
+};
+
+APT::Install::Post-Invoke-Success {
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook post-invoke-success";
+}; 
+
 APT::Install::Pre-Invoke {
 	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook pre-invoke";
 }

--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -1,11 +1,3 @@
-APT::Update::Post-Invoke-Stats {
-	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook post-invoke-stats";
-};
-
-APT::Install::Post-Invoke-Success {
-	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook post-invoke-success";
-}; 
-
 APT::Install::Pre-Invoke {
 	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook pre-invoke";
 }

--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -5,3 +5,7 @@ APT::Update::Post-Invoke-Stats {
 APT::Install::Post-Invoke-Success {
 	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook";
 }; 
+
+APT::Install::Pre-Invoke {
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook apt-install-pre-invoke";
+}

--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -6,7 +6,7 @@ ubuntu-advantage.pot: hook.cc
 	xgettext hook.cc -o ubuntu-advantage.pot
 
 hook: hook.cc
-	$(CXX) -Wall -Wextra -pedantic $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
+	$(CXX) -Wall -Wextra -pedantic -std=c++11 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
 
 install: hook
 	install -D -m 644 20apt-esm-hook.conf $(DESTDIR)/etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -245,11 +245,11 @@ static void process_all_templates(
    std::string esm_i_pkgs_count,
    std::string esm_i_pkgs
 ) {
-   std::array<std::string, 5> template_file_names = {
+   std::array<std::string, 2> template_file_names = {
       CONTRACT_EXPIRY_STATUS_MESSAGE_TEMPLATE_PATH,
       CONTRACT_EXPIRY_STATUS_APT_MESSAGE_TEMPLATE_PATH
    };
-   std::array<std::string, 5> static_file_names = {
+   std::array<std::string, 2> static_file_names = {
       CONTRACT_EXPIRY_STATUS_MESSAGE_STATIC_PATH,
       CONTRACT_EXPIRY_STATUS_APT_MESSAGE_STATIC_PATH
    };

--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -36,10 +36,6 @@
 
 #define CONTRACT_EXPIRY_STATUS_MESSAGE_TEMPLATE_PATH              "/var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl"
 #define CONTRACT_EXPIRY_STATUS_MESSAGE_STATIC_PATH                "/var/lib/ubuntu-advantage/messages/contract-expiry-status"
-#define CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_TEMPLATE_PATH        "/var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl"
-#define CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_STATIC_PATH          "/var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade"
-#define CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_TEMPLATE_PATH   "/var/lib/ubuntu-advantage/messages/contract-expired-apt-dist-upgrade.tmpl"
-#define CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_STATIC_PATH     "/var/lib/ubuntu-advantage/messages/contract-expired-apt-dist-upgrade"
 #define ESM_APPS_NOT_ENABLED_MESSAGE_TEMPLATE_PATH                "/var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl"
 #define ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH                  "/var/lib/ubuntu-advantage/messages/esm-apps-not-enabled"
 #define ESM_INFRA_NOT_ENABLED_MESSAGE_TEMPLATE_PATH               "/var/lib/ubuntu-advantage/messages/esm-infra-not-enabled.tmpl"
@@ -253,15 +249,11 @@ static void process_all_templates(
 ) {
    std::array<std::string, 5> template_file_names = {
       CONTRACT_EXPIRY_STATUS_MESSAGE_TEMPLATE_PATH,
-      CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_TEMPLATE_PATH,
-      CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_TEMPLATE_PATH,
       ESM_APPS_NOT_ENABLED_MESSAGE_TEMPLATE_PATH,
       ESM_INFRA_NOT_ENABLED_MESSAGE_TEMPLATE_PATH
    };
    std::array<std::string, 5> static_file_names = {
       CONTRACT_EXPIRY_STATUS_MESSAGE_STATIC_PATH,
-      CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_STATIC_PATH,
-      CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_STATIC_PATH,
       ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH,
       ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH
    };
@@ -387,13 +379,6 @@ int main(int argc, char *argv[])
          // Try not enabled messages
          output_file_if_present(ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH);
          output_file_if_present(ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH);
-
-         // Try command specific messages
-         if (command_used == "upgrade") {
-            output_file_if_present(CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_STATIC_PATH);
-         } else if (command_used == "dist-upgrade") {
-            output_file_if_present(CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_STATIC_PATH);
-         }
       }
    }
 

--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -302,8 +302,6 @@ int main(int argc, char *argv[])
    }
 
    // Iterate over apt cache looking for esm packages
-   // std::vector<std::string> esm_i_packages;
-   // std::vector<std::string> esm_a_packages;
    result res = {0, 0, std::vector<std::string>(), 0, 0, std::vector<std::string>()};
    get_update_count(res);
    if (_error->PendingError())
@@ -332,6 +330,7 @@ int main(int argc, char *argv[])
    std::string esm_a_packages_count = std::to_string(res.esm_a_packages.size());
    std::string esm_i_packages_count = std::to_string(res.esm_i_packages.size());
 
+   // Execute specified subcommand
    if (subcommand == ProcessTemplates) {
       std::array<std::string, 4> template_file_names = {
          CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_TEMPLATE_PATH,
@@ -345,7 +344,6 @@ int main(int argc, char *argv[])
          ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH,
          ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH
       };
-
       for (uint i = 0; i < template_file_names.size(); i++) {
          process_template_file(
             template_file_names[i], 

--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -36,10 +36,8 @@
 
 #define CONTRACT_EXPIRY_STATUS_MESSAGE_TEMPLATE_PATH              "/var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl"
 #define CONTRACT_EXPIRY_STATUS_MESSAGE_STATIC_PATH                "/var/lib/ubuntu-advantage/messages/contract-expiry-status"
-#define ESM_APPS_NOT_ENABLED_MESSAGE_TEMPLATE_PATH                "/var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl"
-#define ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH                  "/var/lib/ubuntu-advantage/messages/esm-apps-not-enabled"
-#define ESM_INFRA_NOT_ENABLED_MESSAGE_TEMPLATE_PATH               "/var/lib/ubuntu-advantage/messages/esm-infra-not-enabled.tmpl"
-#define ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH                 "/var/lib/ubuntu-advantage/messages/esm-infra-not-enabled"
+#define CONTRACT_EXPIRY_STATUS_APT_MESSAGE_TEMPLATE_PATH          "/var/lib/ubuntu-advantage/messages/contract-expiry-status-apt.tmpl"
+#define CONTRACT_EXPIRY_STATUS_APT_MESSAGE_STATIC_PATH            "/var/lib/ubuntu-advantage/messages/contract-expiry-status-apt"
 
 #define ESM_APPS_PKGS_COUNT_TEMPLATE_VAR "{ESM_APPS_PKG_COUNT}"
 #define ESM_APPS_PACKAGES_TEMPLATE_VAR "{ESM_APPS_PACKAGES}"
@@ -249,13 +247,11 @@ static void process_all_templates(
 ) {
    std::array<std::string, 5> template_file_names = {
       CONTRACT_EXPIRY_STATUS_MESSAGE_TEMPLATE_PATH,
-      ESM_APPS_NOT_ENABLED_MESSAGE_TEMPLATE_PATH,
-      ESM_INFRA_NOT_ENABLED_MESSAGE_TEMPLATE_PATH
+      CONTRACT_EXPIRY_STATUS_APT_MESSAGE_TEMPLATE_PATH
    };
    std::array<std::string, 5> static_file_names = {
       CONTRACT_EXPIRY_STATUS_MESSAGE_STATIC_PATH,
-      ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH,
-      ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH
+      CONTRACT_EXPIRY_STATUS_APT_MESSAGE_STATIC_PATH
    };
    for (uint i = 0; i < template_file_names.size(); i++) {
       process_template_file(
@@ -373,12 +369,7 @@ int main(int argc, char *argv[])
    // Execute specified subcommand
    if (subcommand == PreInvoke) {
       if (command_used == "upgrade" || command_used == "dist-upgrade") {
-         // Try expiry status message
-         output_file_if_present(CONTRACT_EXPIRY_STATUS_MESSAGE_STATIC_PATH);
-
-         // Try not enabled messages
-         output_file_if_present(ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH);
-         output_file_if_present(ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH);
+         output_file_if_present(CONTRACT_EXPIRY_STATUS_APT_MESSAGE_STATIC_PATH);
       }
    }
 

--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -216,34 +216,24 @@ static void process_template_file(
       message_tmpl_file.close();
 
       // Process all template variables
-      std::string tmpl_var_names[] = {
+      std::array<std::string, 4> tmpl_var_names = {
          ESM_APPS_PKGS_COUNT_TEMPLATE_VAR,
          ESM_APPS_PACKAGES_TEMPLATE_VAR,
          ESM_INFRA_PKGS_COUNT_TEMPLATE_VAR,
          ESM_INFRA_PACKAGES_TEMPLATE_VAR
       };
-      std::string tmpl_var_vals[] = {
+      std::array<std::string, 4> tmpl_var_vals = {
          esm_a_pkgs_count,
          esm_a_pkgs,
          esm_i_pkgs_count,
          esm_i_pkgs
       };
-      for (uint i = 0; i < tmpl_var_names->size(); i++) {
+      for (uint i = 0; i < tmpl_var_names.size(); i++) {
          size_t pos = message_tmpl.find(tmpl_var_names[i]);
          if (pos != std::string::npos) {
             message_tmpl.replace(pos, tmpl_var_names[i].size(), tmpl_var_vals[i]);
          }
       }
-
-      // TODO remove
-      // for manual testing/debugging
-      ioprintf(std::cout, "\n");
-      ioprintf(std::cout, "\n");
-      ioprintf(std::cout, "\n");
-      ioprintf(std::cout, "%s", message_tmpl.c_str());
-      ioprintf(std::cout, "\n");
-      ioprintf(std::cout, "\n");
-      ioprintf(std::cout, "\n");
 
       std::ofstream message_static_file(static_file_name.c_str());
       if (message_static_file.is_open()) {
@@ -306,7 +296,7 @@ int main(int argc, char *argv[])
       subcommand = ProcessTemplates;
    }
 
-   if (!cmdline_eligible(getcmdline(getppid_of(getppid_of("self")))) && subcommand != ProcessTemplates && !test_run) {
+   if (!test_run && subcommand != ProcessTemplates && !cmdline_eligible(getcmdline(getppid_of(getppid_of("self"))))) {
       // Only run on valid apt commands, or when being used to process templates
       return 0;
    }
@@ -339,30 +329,24 @@ int main(int argc, char *argv[])
       }
       space_separated_esm_a_packages.append(res.esm_a_packages[res.esm_a_packages.size() - 1]);
    }
-   // TODO better way to convert int to string?
-   // Get complaint when trying to use std::to_string
-   std::stringstream temp;
-   temp << res.esm_a_packages.size();
-   std::string esm_a_packages_count = temp.str();
-   std::stringstream temp2;
-   temp2 << res.esm_i_packages.size();
-   std::string esm_i_packages_count = temp2.str();
+   std::string esm_a_packages_count = std::to_string(res.esm_a_packages.size());
+   std::string esm_i_packages_count = std::to_string(res.esm_i_packages.size());
 
    if (subcommand == ProcessTemplates) {
-      std::string template_file_names[] = {
+      std::array<std::string, 4> template_file_names = {
          CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_TEMPLATE_PATH,
          CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_TEMPLATE_PATH,
          ESM_APPS_NOT_ENABLED_MESSAGE_TEMPLATE_PATH,
          ESM_INFRA_NOT_ENABLED_MESSAGE_TEMPLATE_PATH
       };
-      std::string static_file_names[] = {
+      std::array<std::string, 4> static_file_names = {
          CONTRACT_EXPIRED_APT_UPGRADE_MESSAGE_STATIC_PATH,
          CONTRACT_EXPIRED_APT_DIST_UPGRADE_MESSAGE_STATIC_PATH,
          ESM_APPS_NOT_ENABLED_MESSAGE_STATIC_PATH,
          ESM_INFRA_NOT_ENABLED_MESSAGE_STATIC_PATH
       };
 
-      for (uint i = 0; i < template_file_names->size(); i++) {
+      for (uint i = 0; i < template_file_names.size(); i++) {
          process_template_file(
             template_file_names[i], 
             static_file_names[i], 
@@ -429,9 +413,7 @@ int main(int argc, char *argv[])
          // Print static message if present. Used for "Expiring soon" and "Expired but in grace period" messages.
          std::ifstream message_file(CONTRACT_EXPIRY_STATUS_MESSAGE_PATH);
          if (message_file.is_open()) {
-            ioprintf(std::cout, "\n");
             std::cout << message_file.rdbuf();
-            ioprintf(std::cout, "\n");
             message_file.close();
          }
 

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -90,41 +90,43 @@ Feature: Enable command behaviour when attached to an UA subscription
            | trusty  | libgit2-0 | https://esm.ubuntu.com/ubuntu/      |
            | xenial  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu |
 
-    @series.xenial
-    @series.bionic
-    @series.focal
-    Scenario Outline: Attached enable of a know service shows update in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua enable esm-infra` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            ESM Infra is already enabled.
-            See: sudo ua status
-            """
-        When I run `apt install -y <pkg-version>` with sudo, retrying exit [100]
-        And I run `apt update` with sudo
-        Then stdout matches regexp
-        """
-        \d+ of the updates (is|are) from UA Infra: ESM
-        """
-        Then if `<release>` in `xenial` and stdout matches regexp:
-        """
-        \d+ additional updates (is|are) available with UA Apps: ESM
-        """
-        When I run `ua disable esm-infra` with sudo
-        And I run `apt update` with sudo
-        Then stdout does not match regexp
-        """
-        \d+ of the updates (is|are) from UA Infra: ESM
-        """
-
-        Examples: ubuntu release
-           | release | pkg-version            |
-           | bionic  | libkrad0=1.16-2build1  |
-           | focal   | hello=2.10-2ubuntu2    |
-           | xenial  | libkrad0=1.13.2+dfsg-5 |
+# TODO Add back equivalent once these messages are in apt upgrade
+# Will be something like: "6 upgraded, including 4 esm-apps security updates and 1 esm-infra update"
+#    @series.xenial
+#    @series.bionic
+#    @series.focal
+#    Scenario Outline: Attached enable of a know service shows update in a ubuntu machine
+#        Given a `<release>` machine with ubuntu-advantage-tools installed
+#        When I attach `contract_token` with sudo
+#        Then I verify that running `ua enable esm-infra` `with sudo` exits `1`
+#        And I will see the following on stdout:
+#            """
+#            One moment, checking your subscription first
+#            ESM Infra is already enabled.
+#            See: sudo ua status
+#            """
+#        When I run `apt install -y <pkg-version>` with sudo, retrying exit [100]
+#        And I run `apt update` with sudo
+#        Then stdout matches regexp
+#        """
+#        \d+ of the updates (is|are) from UA Infra: ESM
+#        """
+#        Then if `<release>` in `xenial` and stdout matches regexp:
+#        """
+#        \d+ additional updates (is|are) available with UA Apps: ESM
+#        """
+#        When I run `ua disable esm-infra` with sudo
+#        And I run `apt update` with sudo
+#        Then stdout does not match regexp
+#        """
+#        \d+ of the updates (is|are) from UA Infra: ESM
+#        """
+#
+#        Examples: ubuntu release
+#           | release | pkg-version            |
+#           | bionic  | libkrad0=1.16-2build1  |
+#           | focal   | hello=2.10-2ubuntu2    |
+#           | xenial  | libkrad0=1.13.2+dfsg-5 |
 
     @series.all
     @uses.config.machine_type.lxd.container

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -17,7 +17,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found.
             """ 
 
-    @wip
     @series.xenial
     @series.bionic
     @series.focal

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -58,7 +58,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         esm-apps \d+:.*; esm-infra \d+:.*
         """
-        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl` with the following
+        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expiry-status-apt.tmpl` with the following
         """
         contract-expiring-soon {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
         """

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -46,6 +46,31 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         \s*\*\*\* .* 500
         \s*500 https://esm.staging.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
+        When I run `echo "esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with sudo
+        When I run `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` with sudo
+        When I run `cat /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade` with sudo
+        Then stdout matches regexp:
+        """
+        esm-apps \d+ .*; esm-infra \d+ .*
+        """
+        When I run `echo "contract-expiring-soon {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl` with sudo
+        When I run `apt upgrade --dry-run` with sudo
+        Then stdout matches regexp:
+        """
+        contract-expiring-soon \d+ .* \d+ .*
+        """
+        When I run `echo "contract-expired-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with sudo
+        When I run `apt upgrade --dry-run` with sudo
+        Then stdout matches regexp:
+        """
+        contract-expired-upgrade \d+ .* \d+ .*
+        """
+        When I run `echo "contract-expired-dist-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-dist-upgrade.tmpl` with sudo
+        When I run `apt dist-upgrade --dry-run` with sudo
+        Then stdout matches regexp:
+        """
+        contract-expired-dist-upgrade \d+ .* \d+ .*
+        """
 
         Examples: ubuntu release
            | release | apps-pkg |

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -48,12 +48,12 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         \s*500 https://esm.staging.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
-        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with the following
+        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl` with the following
         """
         esm-apps {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
         """
         When I run `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` with sudo
-        When I run `cat /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade` with sudo
+        When I run `cat /var/lib/ubuntu-advantage/messages/contract-expiry-status` with sudo
         Then stdout matches regexp:
         """
         esm-apps \d+:.*; esm-infra \d+:.*
@@ -66,24 +66,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Then stdout matches regexp:
         """
         contract-expiring-soon \d+ .* \d+ .*
-        """
-        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with the following
-        """
-        contract-expired-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
-        """
-        When I run `apt upgrade --dry-run` with sudo
-        Then stdout matches regexp:
-        """
-        contract-expired-upgrade \d+ .* \d+ .*
-        """
-        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expired-apt-dist-upgrade.tmpl` with the following
-        """
-        contract-expired-dist-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
-        """
-        When I run `apt dist-upgrade --dry-run` with sudo
-        Then stdout matches regexp:
-        """
-        contract-expired-dist-upgrade \d+ .* \d+ .*
         """
 
         Examples: ubuntu release

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -49,26 +49,38 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         \s*500 https://esm.staging.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
-        When I run `sh -c 'echo "esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl'` with sudo
+        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with the following
+        """
+        esm-apps {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
+        """
         When I run `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` with sudo
         When I run `cat /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade` with sudo
         Then stdout matches regexp:
         """
-        esm-apps \d+ .*; esm-infra \d+ .*
+        esm-apps \d+:.*; esm-infra \d+:.*
         """
-        When I run `echo "contract-expiring-soon {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl` with sudo
+        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl` with the following
+        """
+        contract-expiring-soon {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        """
         When I run `apt upgrade --dry-run` with sudo
         Then stdout matches regexp:
         """
         contract-expiring-soon \d+ .* \d+ .*
         """
-        When I run `echo "contract-expired-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with sudo
+        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with the following
+        """
+        contract-expired-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        """
         When I run `apt upgrade --dry-run` with sudo
         Then stdout matches regexp:
         """
         contract-expired-upgrade \d+ .* \d+ .*
         """
-        When I run `echo "contract-expired-dist-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-dist-upgrade.tmpl` with sudo
+        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expired-apt-dist-upgrade.tmpl` with the following
+        """
+        contract-expired-dist-upgrade {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        """
         When I run `apt dist-upgrade --dry-run` with sudo
         Then stdout matches regexp:
         """

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -16,6 +16,8 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             One moment, checking your subscription first
             GPG key '/usr/share/keyrings/ubuntu-cc-keyring.gpg' not found.
             """ 
+
+    @wip
     @series.xenial
     @series.bionic
     @series.focal
@@ -46,7 +48,8 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         \s*\*\*\* .* 500
         \s*500 https://esm.staging.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
-        When I run `echo "esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl` with sudo
+        When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
+        When I run `sh -c 'echo "esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl'` with sudo
         When I run `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` with sudo
         When I run `cat /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade` with sudo
         Then stdout matches regexp:

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -26,20 +26,6 @@ Feature: Command behaviour when unattached
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
-        When I create the file `/var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl` with the following
-        """
-        {ESM_APPS_PKG_COUNT} esm-apps packages: {ESM_APPS_PACKAGES}
-        """
-        When I run `apt upgrade --dry-run` with sudo
-        Then if `<release>` in `xenial` and stdout matches regexp:
-        """
-        \d+ esm-apps packages:
-        """
-        When I create the file `/var/lib/ubuntu-advantage/messages/esm-infra-not-enabled.tmpl` with the following
-        """
-        {ESM_INFRA_PKG_COUNT} esm-infra packages: {ESM_INFRA_PACKAGES}
-        """
         When I run `apt upgrade --dry-run` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:
         """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -26,6 +26,7 @@ Feature: Command behaviour when unattached
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
         When I run `echo "{ESM_APPS_PKG_COUNT} esm-apps packages: {ESM_APPS_PACKAGES}" > /var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl` with sudo
         When I run `apt upgrade --dry-run` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -26,11 +26,6 @@ Feature: Command behaviour when unattached
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `apt upgrade --dry-run` with sudo
-        Then if `<release>` in `xenial` and stdout matches regexp:
-        """
-        \d+ esm-infra packages:
-        """
         When I run `apt-cache policy` with sudo
         Then if `<release>` in `trusty` and stdout matches regexp:
         """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -26,6 +26,7 @@ Feature: Command behaviour when unattached
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt update` with sudo
         When I run `apt-cache policy` with sudo
         Then if `<release>` in `trusty` and stdout matches regexp:
         """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -22,18 +22,25 @@ Feature: Command behaviour when unattached
            | trusty  | nocloudnet |
            | xenial  | lxd        |
 
+    @wip
     @series.trusty
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
-        When I run `echo "{ESM_APPS_PKG_COUNT} esm-apps packages: {ESM_APPS_PACKAGES}" > /var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl` with sudo
+        When I create the file `/var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl` with the following
+        """
+        {ESM_APPS_PKG_COUNT} esm-apps packages: {ESM_APPS_PACKAGES}
+        """
         When I run `apt upgrade --dry-run` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:
         """
         \d+ esm-apps packages:
         """
-        When I run `echo "{ESM_INFRA_PKG_COUNT} esm-infra packages: {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/esm-infra-not-enabled.tmpl` with sudo
+        When I create the file `/var/lib/ubuntu-advantage/messages/esm-infra-not-enabled.tmpl` with the following
+        """
+        {ESM_INFRA_PKG_COUNT} esm-infra packages: {ESM_INFRA_PACKAGES}
+        """
         When I run `apt upgrade --dry-run` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:
         """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -22,7 +22,6 @@ Feature: Command behaviour when unattached
            | trusty  | nocloudnet |
            | xenial  | lxd        |
 
-    @wip
     @series.trusty
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -26,10 +26,17 @@ Feature: Command behaviour when unattached
     @series.xenial
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `apt update` with sudo
+        When I run `echo "{ESM_APPS_PKG_COUNT} esm-apps packages: {ESM_APPS_PACKAGES}" > /var/lib/ubuntu-advantage/messages/esm-apps-not-enabled.tmpl` with sudo
+        When I run `apt upgrade --dry-run` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:
         """
-        \d+ additional updates (is|are) available with UA Apps: ESM.
+        \d+ esm-apps packages:
+        """
+        When I run `echo "{ESM_INFRA_PKG_COUNT} esm-infra packages: {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/esm-infra-not-enabled.tmpl` with sudo
+        When I run `apt upgrade --dry-run` with sudo
+        Then if `<release>` in `xenial` and stdout matches regexp:
+        """
+        \d+ esm-infra packages:
         """
         When I run `apt-cache policy` with sudo
         Then if `<release>` in `trusty` and stdout matches regexp:


### PR DESCRIPTION
## New behavior

* on `apt upgrade/dist-upgrade`
  * find esm packages (names and count)
  * will insert values into message template for contract-expiry message if the template exists and print the message
* when called as `hook process-templates`
  * find esm packages (names and count)
  * will insert values into hardcoded message templates that exist
  * outputs those messages to static files with the values filled in
* on `apt update`
  * updates all the template files, but no longer prints the messages it used to


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> apt-hook: process template files and print messages with esm stats
>
> apt-esm-hook will now process a set of .tmpl files in the ua messages
> directory, both when apt calls it and when called separately with the
> "process-templates" argument. It replaces variables in the tmpl files
> with the values of ESM Apps/Infra package names and count. It then
> writes the result of the replacement back to the ua messages
> directory.
>
> When called on Post-Invoke for upgrade/dist-upgrade, the hook will
> print out the contents of message files if they are present.
>
> Fixes: #1546 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

In a new xenial lxd container, preferably one with outstanding esm updates:
1. `mkdir -p /var/lib/ubuntu-advantage/messages`
2. `echo "esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}" > /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade.tmpl`
3. `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates`
4. `cat /var/lib/ubuntu-advantage/messages/contract-expired-apt-upgrade` and make sure it has the expected output
5. `apt upgrade` and ensure expected output appears


## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
