### PR TITLE
shared MOTD and APT messaging generation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,8 +19,7 @@ APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:
-	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild \
-		--no-start
+	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild
 
 override_dh_auto_build:
 	dh_auto_build
@@ -41,6 +40,15 @@ endif
 override_dh_gencontrol:
 	echo extra:Depends=$(APT_PKG_DEPS) >> debian/ubuntu-advantage-tools.substvars
 	dh_gencontrol
+
+override_dh_systemd_enable:
+	dh_systemd_enable -pubuntu-advantage-pro ua-auto-attach.service
+	dh_systemd_enable -pubuntu-advantage-tools ua-reboot-cmds.service
+	dh_systemd_enable -pubuntu-advantage-tools ua-messaging.timer
+	dh_systemd_enable -pubuntu-advantage-tools ua-messaging.service
+
+override_dh_systemd_start:
+	dh_systemd_start -pubuntu-advantage-tools ua-messaging.timer
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -8,8 +8,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo, retrying exit [100]
         And I run `apt-get install -y <downrev_pkg>` with sudo, retrying exit [100]
-        When I verify that running ` --assume-yes --beta` `with sudo` exits `1`
-        And I run `/usr/lib/update-notifier/apt-check  --human-readable` as non-root
+        And I run `run-parts /etc/update-motd.d/` with sudo
         Then if `<release>` in `trusty` and stdout matches regexp:
         """
         UA Infrastructure Extended Security Maintenance \(ESM\) is not enabled.
@@ -35,7 +34,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
-        ESM Infra enabled
+        UA Infra: ESM enabled
         """
         And stdout matches regexp:
         """
@@ -53,7 +52,14 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Enabling default service esm-infra
         """
-        When I run `/usr/lib/update-notifier/apt-check  --human-readable` as non-root
+        When I append the following on uaclient config:
+            """
+            features:
+              allow_beta: true
+            """
+        And I run `apt update` with sudo
+        And I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
+        And I run `run-parts /etc/update-motd.d/` with sudo
         Then if `<release>` in `trusty` and stdout matches regexp:
         """
         UA (Infra:|Infrastructure) Extended Security Maintenance \(ESM\) is enabled.
@@ -89,6 +95,41 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         \d+ package(s)? can be updated.
         \d+ of these updates (is a|are) security update(s)?.
+        To see these additional updates run: apt list --upgradable
+
+        Enable UA Infra: ESM to receive \d+ additional security updates?.
+        See https:\/\/ubuntu.com\/security\/esm or run: sudo ua status
+        """
+        When I update contract to use `effectiveTo` as `days=-20`
+        And I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
+        And I run `run-parts /etc/update-motd.d` with sudo
+        Then if `<release>` in `xenial or bionic` and stdout matches regexp:
+        """
+
+        \*Your UA Infra: ESM subscription has EXPIRED\*
+
+        \d+ additional security updates could have been applied via UA Infra: ESM.
+
+        Renew your UA services at https:\/\/ubuntu.com\/esm
+
+        """
+        Then if `<release>` in `xenial` and stdout matches regexp:
+        """
+
+        Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
+        applicable law.
+
+        """
+        When I run `apt upgrade --dry-run` with sudo
+        Then if `<release>` in `xenial` and stdout matches regexp:
+        """
+        \*Your UA Infra: ESM subscription has EXPIRED\*
+        Enabling UA Infra: ESM service would provide security updates for following
+        packages:
+          .*libkrad.*
+        \d+ esm-infra security updates NOT APPLIED. Renew your UA services at
+        https:\/\/ubuntu.com\/advantage
+
         """
         Examples: ubuntu release packages
            | release | downrev_pkg                 |
@@ -99,12 +140,12 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
     @series.all
     @uses.config.machine_type.aws.generic
-    Scenario Outline: Attach command in a ubuntu lxd container
+    Scenario Outline: Attach command in an generic AWS Ubuntu VM
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
-        ESM Infra enabled
+        UA Infra: ESM enabled
         """
         And stdout matches regexp:
         """
@@ -137,7 +178,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
-        ESM Infra enabled
+        UA Infra: ESM enabled
         """
         And stdout matches regexp:
         """
@@ -170,7 +211,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
-        ESM Infra enabled
+        UA Infra: ESM enabled
         """
         And stdout matches regexp:
         """

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -64,6 +64,12 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Then if `<release>` in `focal` and stdout matches regexp:
         """
+        \* Introducing Extended Security Maintenance for Applications.
+          +Receive updates to over 30,000 software packages with your
+          +Ubuntu Advantage subscription. Free for personal use.
+
+            +https:\/\/ubuntu.com\/esm
+
         UA (Infra:|Infrastructure) Extended Security Maintenance \(ESM\) is enabled.
 
         \d+ update(s)? can be installed immediately.
@@ -73,6 +79,14 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Then if `<release>` in `xenial or bionic` and stdout matches regexp:
         """
+        \* Introducing Extended Security Maintenance for Applications.
+          +Receive updates to over 30,000 software packages with your
+          +Ubuntu Advantage subscription. Free for personal use.
+
+            +https:\/\/ubuntu.com\/esm
+
+        UA Infra: Extended Security Maintenance \(ESM\) is not enabled.
+
         \d+ package(s)? can be updated.
         \d+ of these updates (is a|are) security update(s)?.
         """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -66,7 +66,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            ESM Infra is already enabled.
+            UA Infra: ESM is already enabled.
             See: sudo ua status
             """
         When I run `apt-cache policy` with sudo
@@ -89,44 +89,6 @@ Feature: Enable command behaviour when attached to an UA subscription
            | focal   | hello     | https://esm.ubuntu.com/infra/ubuntu |
            | trusty  | libgit2-0 | https://esm.ubuntu.com/ubuntu/      |
            | xenial  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu |
-
-# TODO Add back equivalent once these messages are in apt upgrade
-# Will be something like: "6 upgraded, including 4 esm-apps security updates and 1 esm-infra update"
-#    @series.xenial
-#    @series.bionic
-#    @series.focal
-#    Scenario Outline: Attached enable of a know service shows update in a ubuntu machine
-#        Given a `<release>` machine with ubuntu-advantage-tools installed
-#        When I attach `contract_token` with sudo
-#        Then I verify that running `ua enable esm-infra` `with sudo` exits `1`
-#        And I will see the following on stdout:
-#            """
-#            One moment, checking your subscription first
-#            ESM Infra is already enabled.
-#            See: sudo ua status
-#            """
-#        When I run `apt install -y <pkg-version>` with sudo, retrying exit [100]
-#        And I run `apt update` with sudo
-#        Then stdout matches regexp
-#        """
-#        \d+ of the updates (is|are) from UA Infra: ESM
-#        """
-#        Then if `<release>` in `xenial` and stdout matches regexp:
-#        """
-#        \d+ additional updates (is|are) available with UA Apps: ESM
-#        """
-#        When I run `ua disable esm-infra` with sudo
-#        And I run `apt update` with sudo
-#        Then stdout does not match regexp
-#        """
-#        \d+ of the updates (is|are) from UA Infra: ESM
-#        """
-#
-#        Examples: ubuntu release
-#           | release | pkg-version            |
-#           | bionic  | libkrad0=1.16-2build1  |
-#           | focal   | hello=2.10-2ubuntu2    |
-#           | xenial  | libkrad0=1.13.2+dfsg-5 |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -184,7 +146,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
-            This subscription is not entitled to ESM Apps
+            This subscription is not entitled to UA Apps: ESM
             For more information see: https://ubuntu.com/advantage.
             """
 
@@ -288,7 +250,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stdout matches regexp:
             """
             Updating package lists
-            ESM Infra enabled
+            UA Infra: ESM enabled
             Installing canonical-livepatch snap
             Canonical livepatch enabled
             """
@@ -322,7 +284,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stdout matches regexp:
             """
             Updating package lists
-            ESM Infra enabled
+            UA Infra: ESM enabled
             Installing canonical-livepatch snap
             Canonical livepatch enabled
             """
@@ -350,7 +312,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then stdout matches regexp:
             """
             Updating package lists
-            ESM Infra enabled
+            UA Infra: ESM enabled
             """
         And stdout matches regexp:
             """
@@ -389,7 +351,7 @@ Feature: Enable command behaviour when attached to an UA subscription
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
             """
-            ESM Infra enabled
+            UA Infra: ESM enabled
             """
         And stdout matches regexp:
             """

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -48,24 +48,51 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         \s*500 https://esm.staging.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
-        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expiry-status.tmpl` with the following
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-no-packages-infra.tmpl` with the following
         """
-        esm-apps {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}; esm-infra {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
+        esm-infra-no {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
+        """
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-infra.tmpl` with the following
+        """
+        esm-infra {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
+        """
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-apps.tmpl` with the following
+        """
+        esm-apps {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}
+        """
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-no-packages-apps.tmpl` with the following
+        """
+        esm-apps-no {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}
         """
         When I run `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` with sudo
-        When I run `cat /var/lib/ubuntu-advantage/messages/contract-expiry-status` with sudo
+        When I run `cat /var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-apps` with sudo
         Then stdout matches regexp:
         """
-        esm-apps \d+:.*; esm-infra \d+:.*
+        esm-apps(-no)? \d+:(.*)?
         """
-        When I create the file `/var/lib/ubuntu-advantage/messages/contract-expiry-status-apt.tmpl` with the following
+        When I run `cat /var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-infra` with sudo
+        Then stdout matches regexp:
         """
-        contract-expiring-soon {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES} {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        esm-infra(-no)? \d+:(.*)?
+        """
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-infra.tmpl` with the following
+        """
+        esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        """
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-no-packages-infra.tmpl` with the following
+        """
+        esm-infra-no {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        """
+        When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-apps.tmpl` with the following
+        """
+        esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}
         """
         When I run `apt upgrade --dry-run` with sudo
         Then stdout matches regexp:
         """
-        contract-expiring-soon \d+ .* \d+ .*
+        esm-apps(-no)? \d+.*
+
+        esm-infra(-no)? \d+.*
         """
 
         Examples: ubuntu release

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -196,6 +196,11 @@ def when_i_fix_a_issue_by_updating_expired_token(context, issue):
 def when_i_update_contract_field_to_new_value(
     context, contract_field, new_value
 ):
+    if contract_field == "effectiveTo":
+        if "days=" in new_value:  # Set timedelta offset from current day
+            now = datetime.datetime.utcnow()
+            contract_expiry = now + datetime.timedelta(days=int(new_value[5:]))
+            new_value = contract_expiry.strftime("%Y-%m-%dT00:00:00Z")
     when_i_run_command(
         context,
         'sed -i \'s/"{}": "[^"]*"/"{}": "{}"/g\' {}'.format(

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -68,6 +68,24 @@ Feature: Command behaviour when unattached
         """
         -32768 <esm-apps-url> <release>-apps-security/main amd64 Packages
         """
+        When I append the following on uaclient config:
+            """
+            features:
+              allow_beta: true
+            """
+        And I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
+        And I run `run-parts /etc/update-motd.d/` with sudo
+        Then if `<release>` in `xenial` and stdout matches regexp:
+        """
+        \* Introducing Extended Security Maintenance for Applications.
+          +Receive updates to over 30,000 software packages with your
+          +Ubuntu Advantage subscription. Free for personal use.
+
+            +https:\/\/ubuntu.com\/esm
+
+        UA Infra: Extended Security Maintenance \(ESM\) is not enabled.
+
+        """
 
         Examples: ubuntu release
            | release | esm-infra-url                       | esm-apps-url |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -344,7 +344,7 @@ Feature: Command behaviour when unattached
             > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
             > .*\{ ua attach .*\}.*
             Updating package lists
-            ESM Infra enabled
+            UA Infra: ESM enabled
             """
         And stdout matches regexp:
             """
@@ -369,7 +369,7 @@ Feature: Command behaviour when unattached
             > .*\{ ua enable esm-infra \}.*
             One moment, checking your subscription first
             Updating package lists
-            ESM Infra enabled
+            UA Infra: ESM enabled
             """
         And stdout matches regexp:
             """
@@ -399,7 +399,7 @@ Feature: Command behaviour when unattached
             This machine is now detached.
             .*\{ ua attach .* \}.*
             Updating package lists
-            ESM Infra enabled
+            UA Infra: ESM enabled
             """
         And stdout matches regexp:
             """

--- a/lib/ua_update_messaging.py
+++ b/lib/ua_update_messaging.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+
+"""
+Update messaging text for use in MOTD and APT custom Ubuntu Advantage messages.
+
+Messaging files will be emitted to /var/lib/ubuntu-advantage/message-* which
+will be sourced by apt-hook/hook.cc and various /etc/update-motd.d/ hooks to
+present updated text about Ubuntu Advantage service and token state.
+"""
+
+import enum
+import logging
+import os
+
+try:
+    from typing import Dict, List, Optional, Tuple  # noqa
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
+from uaclient.cli import setup_logging
+from uaclient import config
+from uaclient import entitlements
+from uaclient import defaults
+from uaclient.status import (
+    MESSAGE_ANNOUNCE_ESM,
+    MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_MOTD_PKGS_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_SOON_TMPL,
+    MESSAGE_DISABLED_MOTD_PKGS_TMPL,
+    MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
+    MESSAGE_DISABLED_APT_PKGS_TMPL,
+    MESSAGE_UBUNTU_NO_WARRANTY,
+    ApplicationStatus,
+)
+from uaclient import util
+
+
+@enum.unique
+class ContractExpiryStatus(enum.Enum):
+    NONE = 0
+    ACTIVE = 1
+    ACTIVE_EXPIRED_SOON = 2
+    EXPIRED_GRACE_PERIOD = 3
+    EXPIRED = 4
+
+
+# Type of message file used for external messaging (APT and MOTD)
+@enum.unique
+class ExternalMessage(enum.Enum):
+    MOTD_APPS_NO_PKGS = "motd-no-packages-apps.tmpl"
+    MOTD_INFRA_NO_PKGS = "motd-no-packages-infra.tmpl"
+    MOTD_APPS_PKGS = "motd-packages-apps.tmpl"
+    MOTD_INFRA_PKGS = "motd-packages-infra.tmpl"
+    APT_PRE_INVOKE_APPS_NO_PKGS = "apt-pre-invoke-no-packages-apps.tmpl"
+    APT_PRE_INVOKE_INFRA_NO_PKGS = "apt-pre-invoke-no-packages-infra.tmpl"
+    APT_PRE_INVOKE_APPS_PKGS = "apt-pre-invoke-packages-apps.tmpl"
+    APT_PRE_INVOKE_INFRA_PKGS = "apt-pre-invoke-packages-infra.tmpl"
+    APT_PRE_INVOKE_SERVICE_STATUS = "apt-pre-invoke-esm-service-status"
+    MOTD_ESM_SERVICE_STATUS = "motd-esm-service-status"
+    ESM_ANNOUNCE = "motd-esm-announce"
+    UBUNTU_NO_WARRANTY = "ubuntu-no-warranty"
+
+
+def get_contract_expiry_status(
+    cfg: config.UAConfig
+) -> "Tuple[ContractExpiryStatus, int]":
+    """Return a tuple [ContractExpiryStatus, num_days]"""
+    if not cfg.is_attached:
+        return ContractExpiryStatus.NONE, 0
+
+    grace_period = defaults.CONTRACT_EXPIRY_GRACE_PERIOD_DAYS
+    pending_expiry = defaults.CONTRACT_EXPIRY_PENDING_DAYS
+    remaining_days = cfg.contract_remaining_days
+    if 0 <= remaining_days <= pending_expiry:
+        return ContractExpiryStatus.ACTIVE_EXPIRED_SOON, remaining_days
+    elif -grace_period <= remaining_days < 0:
+        return ContractExpiryStatus.EXPIRED_GRACE_PERIOD, remaining_days
+    elif remaining_days < -grace_period:
+        return ContractExpiryStatus.EXPIRED, remaining_days
+    return ContractExpiryStatus.ACTIVE, remaining_days
+
+
+def _write_template_or_remove(msg: str, tmpl_file: str):
+    """Write a template to tmpl_file.
+
+    When msg is empty, remove both tmpl_file and the generated msg.
+    """
+    if msg:
+        util.write_file(tmpl_file, msg)
+    else:
+        util.remove_file(tmpl_file)
+        if tmpl_file.endswith(".tmpl"):
+            util.remove_file(tmpl_file.replace(".tmpl", ""))
+
+
+def _write_esm_service_msg_templates(
+    cfg: config.UAConfig,
+    ent: entitlements.base.UAEntitlement,
+    expiry_status: ContractExpiryStatus,
+    remaining_days: int,
+    pkgs_file: str,
+    no_pkgs_file: str,
+    motd_pkgs_file: str,
+    motd_no_pkgs_file: str,
+    no_warranty_file: str,
+):
+
+    pkgs_msg = no_pkgs_msg = motd_pkgs_msg = motd_no_pkgs_msg = ""
+    no_warranty_msg = ""
+    tmpl_prefix = ent.name.upper().replace("-", "_")
+    tmpl_pkg_count_var = "{{{}_PKG_COUNT}}".format(tmpl_prefix)
+    tmpl_pkg_names_var = "{{{}_PACKAGES}}".format(tmpl_prefix)
+    if ent.application_status()[0] == ApplicationStatus.ENABLED:
+        if expiry_status == ContractExpiryStatus.ACTIVE_EXPIRED_SOON:
+            pkgs_msg = MESSAGE_CONTRACT_EXPIRED_SOON_TMPL.format(
+                title=ent.title,
+                remaining_days=remaining_days,
+                url=defaults.BASE_UA_URL,
+            )
+            # Same cautionary message when contract is about to expire
+            motd_pkgs_msg = motd_no_pkgs_msg = no_pkgs_msg = pkgs_msg
+        elif expiry_status == ContractExpiryStatus.EXPIRED_GRACE_PERIOD:
+            grace_period_remaining = (
+                defaults.CONTRACT_EXPIRY_GRACE_PERIOD_DAYS + remaining_days
+            )
+            pkgs_msg = MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL.format(
+                title=ent.title,
+                expired_date=cfg.contract_expiry_datetime.strftime("%d %b %Y"),
+                remaining_days=grace_period_remaining,
+                url=defaults.BASE_UA_URL,
+            )
+            # Same cautionary message when in grace period
+            motd_pkgs_msg = motd_no_pkgs_msg = no_pkgs_msg = pkgs_msg
+        elif expiry_status == ContractExpiryStatus.EXPIRED:
+            if util.is_active_esm(util.get_platform_info()["series"]):
+                no_warranty_msg = MESSAGE_UBUNTU_NO_WARRANTY
+            pkgs_msg = MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL.format(
+                pkg_num=tmpl_pkg_count_var,
+                pkg_names=tmpl_pkg_names_var,
+                title=ent.title,
+                name=ent.name,
+                url=defaults.BASE_UA_URL,
+            )
+            no_pkgs_msg = MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL.format(
+                title=ent.title, url=defaults.BASE_ESM_URL
+            )
+            motd_no_pkgs_msg = no_pkgs_msg
+            motd_pkgs_msg = MESSAGE_CONTRACT_EXPIRED_MOTD_PKGS_TMPL.format(
+                title=ent.title,
+                pkg_num=tmpl_pkg_count_var,
+                url=defaults.BASE_ESM_URL,
+            )
+    elif expiry_status != ContractExpiryStatus.EXPIRED:  # Service not enabled
+        pkgs_msg = MESSAGE_DISABLED_APT_PKGS_TMPL.format(
+            title=ent.title,
+            pkg_num=tmpl_pkg_count_var,
+            pkg_names=tmpl_pkg_names_var,
+            url=defaults.BASE_ESM_URL,
+        )
+        no_pkgs_msg = MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL.format(
+            title=ent.title, url=defaults.BASE_ESM_URL
+        )
+        motd_pkgs_msg = MESSAGE_DISABLED_MOTD_PKGS_TMPL.format(
+            title=ent.title,
+            pkg_num=tmpl_pkg_count_var,
+            url=defaults.BASE_ESM_URL,
+        )
+        motd_no_pkgs_msg = MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL.format(
+            title=ent.title, url=defaults.BASE_ESM_URL
+        )
+
+    msg_dir = os.path.join(cfg.data_dir, "messages")
+    _write_template_or_remove(
+        no_warranty_msg, os.path.join(msg_dir, no_warranty_file)
+    )
+    _write_template_or_remove(no_pkgs_msg, os.path.join(msg_dir, no_pkgs_file))
+    _write_template_or_remove(pkgs_msg, os.path.join(msg_dir, pkgs_file))
+    _write_template_or_remove(
+        motd_no_pkgs_msg, os.path.join(msg_dir, motd_no_pkgs_file)
+    )
+    _write_template_or_remove(
+        motd_pkgs_msg, os.path.join(msg_dir, motd_pkgs_file)
+    )
+
+
+def write_apt_and_motd_templates(cfg: config.UAConfig, series: str) -> None:
+    """Write messaging templates about available esm packages.
+
+    :param cfg: UAConfig instance for this environment.
+    :param series: string of Ubuntu release series: 'xenial'.
+    """
+    apps_no_pkg_file = ExternalMessage.APT_PRE_INVOKE_APPS_NO_PKGS.value
+    apps_pkg_file = ExternalMessage.APT_PRE_INVOKE_APPS_PKGS.value
+    infra_no_pkg_file = ExternalMessage.APT_PRE_INVOKE_INFRA_NO_PKGS.value
+    infra_pkg_file = ExternalMessage.APT_PRE_INVOKE_INFRA_PKGS.value
+    motd_apps_no_pkg_file = ExternalMessage.MOTD_APPS_NO_PKGS.value
+    motd_apps_pkg_file = ExternalMessage.MOTD_APPS_PKGS.value
+    motd_infra_no_pkg_file = ExternalMessage.MOTD_INFRA_NO_PKGS.value
+    motd_infra_pkg_file = ExternalMessage.MOTD_INFRA_PKGS.value
+    no_warranty_file = ExternalMessage.UBUNTU_NO_WARRANTY.value
+
+    apps_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME["esm-apps"]
+    apps_inst = apps_cls(cfg)
+    config_allow_beta = util.is_config_value_true(
+        config=cfg.cfg, path_to_value="features.allow_beta"
+    )
+    apps_not_beta = bool(config_allow_beta or not apps_cls.is_beta)
+    infra_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME["esm-infra"]
+    infra_inst = infra_cls(cfg)
+
+    expiry_status, remaining_days = get_contract_expiry_status(cfg)
+
+    if series != "trusty" and apps_not_beta:
+        _write_esm_service_msg_templates(
+            cfg,
+            apps_inst,
+            expiry_status,
+            remaining_days,
+            apps_pkg_file,
+            apps_no_pkg_file,
+            motd_apps_pkg_file,
+            motd_apps_no_pkg_file,
+            no_warranty_file,
+        )
+    if util.is_active_esm(series):
+        _write_esm_service_msg_templates(
+            cfg,
+            infra_inst,
+            expiry_status,
+            remaining_days,
+            infra_pkg_file,
+            infra_no_pkg_file,
+            motd_infra_pkg_file,
+            motd_infra_no_pkg_file,
+            no_warranty_file,
+        )
+
+
+def write_esm_announcement_message(cfg: config.UAConfig, series: str) -> None:
+    """Write human-readable messages if ESM is offered on this LTS release.
+
+    Do not write ESM announcements on trusty, esm-apps is enable or beta.
+
+    :param cfg: UAConfig instance for this environment.
+    :param series: string of Ubuntu release series: 'xenial'.
+    """
+    apps_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME["esm-apps"]
+    apps_inst = apps_cls(cfg)
+    enabled_status = ApplicationStatus.ENABLED
+    apps_not_enabled = apps_inst.application_status()[0] != enabled_status
+    config_allow_beta = util.is_config_value_true(
+        config=cfg.cfg, path_to_value="features.allow_beta"
+    )
+    apps_not_beta = bool(config_allow_beta or not apps_cls.is_beta)
+
+    msg_dir = os.path.join(cfg.data_dir, "messages")
+    esm_news_file = os.path.join(msg_dir, ExternalMessage.ESM_ANNOUNCE.value)
+    if all([series != "trusty", apps_not_beta, apps_not_enabled]):
+        util.write_file(esm_news_file, "\n" + MESSAGE_ANNOUNCE_ESM)
+    else:
+        util.remove_file(esm_news_file)
+
+
+def update_apt_and_motd_messages(cfg: config.UAConfig) -> None:
+    """Emit templates and human-readable status messages in msg_dir.
+
+    These structured messages will be sourced by both /etc/update.motd.d
+    and APT UA-configured hooks. APT hook content will orginate from
+    apt-hook/hook.cc
+
+    Call esm-apt-hook process-templates to render final human-readable
+    messages.
+
+    :param cfg: UAConfig instance for this environment.
+    """
+    setup_logging(logging.INFO, logging.DEBUG)
+    logging.debug("Updating UA messages for APT and MOTD.")
+    msg_dir = os.path.join(cfg.data_dir, "messages")
+    if not os.path.exists(msg_dir):
+        os.makedirs(msg_dir)
+
+    series = util.get_platform_info()["series"]
+    if not util.is_lts(series):
+        # ESM is only on LTS releases. Remove all messages and templates.
+        for msg_enum in ExternalMessage:
+            msg_path = os.path.join(msg_dir, msg_enum.value)
+            util.remove_file(msg_path)
+            if msg_path.endswith(".tmpl"):
+                util.remove_file(msg_path.replace(".tmpl", ""))
+        return
+
+    # Announce ESM availabilty on active ESM LTS releases
+    write_esm_announcement_message(cfg, series)
+    write_apt_and_motd_templates(cfg, series)
+    # Now that we've setup/cleanedup templates render them with apt-hook
+    util.subp(["/usr/lib/ubuntu-advantage/apt-esm-hook", "process-templates"])
+
+
+if __name__ == "__main__":
+    cfg = config.UAConfig()
+    update_apt_and_motd_messages(cfg=cfg)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def _get_version():
 def _get_data_files():
     data_files = [
         ("/etc/ubuntu-advantage", ["uaclient.conf", "help_data.yaml"]),
+        ("/etc/update-motd.d", glob.glob("update-motd.d/*")),
         ("/usr/lib/ubuntu-advantage", glob.glob("lib/[!_]*")),
         ("/usr/share/keyrings", glob.glob("keyrings/*")),
         (

--- a/systemd/ua-messaging.service
+++ b/systemd/ua-messaging.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Ubuntu Advantage APT and MOTD Messages
+After=network.target network-online.target systemd-networkd.service ua-auto-attach.service
+Wants=ua-auto-attach.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py

--- a/systemd/ua-messaging.timer
+++ b/systemd/ua-messaging.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ubuntu Advantage update messaging
+
+[Timer]
+OnCalendar=*-*-* 3,15:00
+RandomizedDelaySec=1h
+Persistent=true
+OnStartupSec=1min
+
+[Install]
+WantedBy=timers.target

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,8 @@ commands =
     flake8-bionic: flake8 features
     mypy: mypy --python-version 3.4 uaclient/
     mypy: mypy --python-version 3.5 uaclient/
-    mypy: mypy --python-version 3.6 uaclient/ features/
-    mypy-focal: mypy --python-version 3.7 uaclient/ features/
+    mypy: mypy --python-version 3.6 uaclient/ features/ lib/
+    mypy-focal: mypy --python-version 3.7 uaclient/ features/ lib/
     black: black --check --diff uaclient/ features/ lib/ setup.py
     behave-lxd-14.04: behave -v {posargs} --tags="series.trusty,series.all"  --tags="~upgrade"
     behave-lxd-16.04: behave -v {posargs} --tags="series.xenial,series.all" --tags="~upgrade"

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -652,6 +652,7 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     contract_id = cfg.machine_token["machineTokenInfo"]["contractInfo"]["id"]
     contract_client.detach_machine_from_contract(machine_token, contract_id)
     cfg.delete_cache()
+    config.update_ua_messages(cfg)
     print(ua_status.MESSAGE_DETACH_SUCCESS)
     return 0
 
@@ -669,10 +670,12 @@ def _attach_with_token(
             logging.exception(exc)
         print(ua_status.MESSAGE_ATTACH_FAILURE)
         cfg.status()  # Persist updated status in the event of partial attach
+        config.update_ua_messages(cfg)
         return 1
     except exceptions.UserFacingError as exc:
         logging.warning(exc.msg)
         cfg.status()  # Persist updated status in the event of partial attach
+        config.update_ua_messages(cfg)
         return 1
     contract_name = cfg.machine_token["machineTokenInfo"]["contractInfo"][
         "name"
@@ -683,6 +686,7 @@ def _attach_with_token(
         )
     )
 
+    config.update_ua_messages(cfg)
     action_status(args=None, cfg=cfg)
     return 0
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -217,6 +217,7 @@ class UAConfig:
 
     @property
     def contract_expiry_datetime(self) -> "datetime":
+        """Return a datetime of the attached contract expiration."""
         if not self._contract_expiry_datetime:
             contractInfo = self.machine_token["machineTokenInfo"][
                 "contractInfo"
@@ -231,6 +232,17 @@ class UAConfig:
     def is_attached(self):
         """Report whether this machine configuration is attached to UA."""
         return bool(self.machine_token)  # machine_token is removed on detach
+
+    @property
+    def contract_remaining_days(self) -> int:
+        """Report num days until contract expiration based on effectiveTo
+
+        :return: A positive int representing the number of days the attached
+            contract remains in effect. Return a negative int for the number
+            of days beyond contract's effectiveTo date.
+        """
+        delta = self.contract_expiry_datetime.date() - datetime.utcnow().date()
+        return delta.days
 
     @property
     def features(self):

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import sys
 import yaml
 from collections import namedtuple, OrderedDict
 
@@ -773,3 +774,25 @@ def depth_first_merge_overlay_dict(base_dict, overlay_dict):
                 base_dict[key] = value
         else:
             base_dict[key] = value
+
+
+def update_ua_messages(cfg: UAConfig):
+    """Helper to load and run ua_update_messaging.
+
+    This is needed because we don't have /usr/lib/ubuntu-advantage
+    python scripts in our path and we don't want to shell out with
+    subp to call python3 /path/to/ua_update_messaging.py.
+    """
+    sys.path.append("/usr/lib/ubuntu-advantage")
+    try:
+        __import__("ua_update_messaging")
+        update_msgs = getattr(
+            sys.modules["ua_update_messaging"], "update_apt_and_motd_messages"
+        )
+        update_msgs(cfg)
+    except ImportError:
+        logging.debug(
+            "Unable to update UA messages. Cannot import ua_update_messaging."
+        )
+    finally:
+        sys.path.pop()

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -14,7 +14,10 @@ DEFAULT_UPGRADE_CONTRACT_FLAG_FILE = UAC_ETC_PATH + "request-update-contract"
 BASE_CONTRACT_URL = "https://contracts.canonical.com"
 BASE_SECURITY_URL = "https://ubuntu.com/security"
 BASE_UA_URL = "https://ubuntu.com/advantage"
+BASE_ESM_URL = "https://ubuntu.com/esm"
 PRINT_WRAP_WIDTH = 80
+CONTRACT_EXPIRY_GRACE_PERIOD_DAYS = 14
+CONTRACT_EXPIRY_PENDING_DAYS = 20
 
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -15,7 +15,7 @@ class ESMBaseEntitlement(repo.RepoEntitlement):
 class ESMAppsEntitlement(ESMBaseEntitlement):
     origin = "UbuntuESMApps"
     name = "esm-apps"
-    title = "ESM Apps"
+    title = "UA Apps: ESM"
     description = "UA Apps: Extended Security Maintenance (ESM)"
     repo_key_file = "ubuntu-advantage-esm-apps.gpg"
     is_beta = True
@@ -51,7 +51,7 @@ class ESMAppsEntitlement(ESMBaseEntitlement):
 class ESMInfraEntitlement(ESMBaseEntitlement):
     name = "esm-infra"
     origin = "UbuntuESM"
-    title = "ESM Infra"
+    title = "UA Infra: ESM"
     description = "UA Infra: Extended Security Maintenance (ESM)"
     repo_key_file = "ubuntu-advantage-esm-infra-trusty.gpg"
 

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -1,5 +1,6 @@
 from uaclient.entitlements import repo
 from uaclient import util
+from uaclient.config import update_ua_messages
 
 try:
     from typing import Optional  # noqa: F401
@@ -10,6 +11,20 @@ except ImportError:
 
 class ESMBaseEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/security/esm"
+
+    def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
+        enable_performed = super().enable(
+            silent_if_inapplicable=silent_if_inapplicable
+        )
+        if enable_performed:
+            update_ua_messages(self.cfg)
+        return enable_performed
+
+    def disable(self, silent=False) -> bool:
+        disable_performed = super().disable(silent=silent)
+        if disable_performed:
+            update_ua_messages(self.cfg)
+        return disable_performed
 
 
 class ESMAppsEntitlement(ESMBaseEntitlement):

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -395,9 +395,9 @@ class RepoEntitlement(base.UAEntitlement):
         if not repo_url:
             raise exceptions.MissingAptURLDirective(self.name)
         if self.disable_apt_auth_only:
-            # We only remove the repo from the apt auth file, because ESM Infra
-            # is a special-case: we want to be able to report on the
-            # available ESM Infra updates even when it's disabled
+            # We only remove the repo from the apt auth file, because
+            # UA Infra: ESM is a special-case: we want to be able to report on
+            # the available UA Infra: ESM updates even when it's disabled
             apt.remove_repo_from_apt_auth_file(repo_url)
             apt.restore_commented_apt_list_file(repo_filename)
         else:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -2,7 +2,7 @@ import enum
 import sys
 import textwrap
 
-from uaclient.defaults import BASE_UA_URL, PRINT_WRAP_WIDTH
+from uaclient.defaults import BASE_ESM_URL, BASE_UA_URL, PRINT_WRAP_WIDTH
 
 try:
     from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
@@ -386,6 +386,79 @@ Found error: {error} when reading json file: {file_path}"""
 MESSAGE_SECURITY_APT_NON_ROOT = """\
 Package fixes cannot be installed.
 To install them, run this command as root (try using sudo)"""
+
+# MOTD and APT command messaging
+MESSAGE_ANNOUNCE_ESM = """\
+ * Introducing Extended Security Maintenance for Applications.
+   Receive updates to over 30,000 software packages with your
+   Ubuntu Advantage subscription. Free for personal use.
+
+     {url}
+""".format(
+    url=BASE_ESM_URL
+)
+
+MESSAGE_CONTRACT_EXPIRED_SOON_TMPL = """\
+CAUTION: Your {title} service will expire in {remaining_days} days.
+Renew UA subscription at {url} to ensure
+continued security coverage for your applications.
+"""
+
+MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL = """\
+CAUTION: Your {title} service expired on {expired_date}.
+
+Renew UA subscription at {url} to ensure
+continued security coverage for your applications.
+Your grace period will expire in {remaining_days} days.
+"""
+
+MESSAGE_CONTRACT_EXPIRED_MOTD_PKGS_TMPL = """\
+*Your {title} subscription has EXPIRED*
+
+{pkg_num} additional security updates could have been applied via {title}.
+
+Renew your UA services at {url}
+"""
+
+MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL = """\
+*Your {title} subscription has EXPIRED*
+Enabling {title} service would provide security updates for following
+packages:
+  {pkg_names}
+{pkg_num} {name} security updates NOT APPLIED. Renew your UA services at
+{url}
+"""
+
+MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL = """\
+Enable {title} to receive additional future security updates.
+
+See {url} or run: sudo ua status
+"""
+
+MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL = (
+    """\
+*Your {title} subscription has EXPIRED*
+"""
+    + MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL
+)
+
+
+MESSAGE_DISABLED_MOTD_PKGS_TMPL = """\
+{pkg_num} additional security updates can be applied with {title}
+Learn more about enabling {title} service at {url}
+"""
+
+MESSAGE_DISABLED_APT_PKGS_TMPL = """\
+*The following packages could receive security updates with
+ {title} service enabled:
+  {pkg_names}
+Learn more about {title} service at {url}
+"""
+
+MESSAGE_UBUNTU_NO_WARRANTY = """\
+Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
+applicable law.
+"""
 
 
 def colorize(string: str) -> str:

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -341,8 +341,10 @@ class TestActionAutoAttach:
     @mock.patch(M_PATH + "contract.request_updated_contract")
     @mock.patch(M_PATH + "_get_contract_token_from_cloud_identity")
     @mock.patch(M_PATH + "action_status")
+    @mock.patch(M_PATH + "config.update_ua_messages")
     def test_happy_path_on_aws_auto_attach(
         self,
+        update_ua_messages,
         action_status,
         get_contract_token_from_cloud_identity,
         request_updated_contract,

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -59,8 +59,10 @@ class TestActionDetach:
     )
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
+    @mock.patch("uaclient.config.update_ua_messages")
     def test_entitlements_disabled_appropriately(
         self,
+        update_ua_messages,
         m_client,
         m_entitlements,
         m_getuid,
@@ -122,8 +124,16 @@ class TestActionDetach:
 
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
+    @mock.patch("uaclient.config.update_ua_messages")
     def test_config_cache_deleted(
-        self, m_client, m_entitlements, m_getuid, _m_prompt, FakeConfig, tmpdir
+        self,
+        update_ua_messages,
+        m_client,
+        m_entitlements,
+        m_getuid,
+        _m_prompt,
+        FakeConfig,
+        tmpdir,
     ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = []
@@ -137,11 +147,14 @@ class TestActionDetach:
         action_detach(mock.MagicMock(), m_cfg)
 
         assert [mock.call()] == m_cfg.delete_cache.call_args_list
+        assert [mock.call(m_cfg)] == update_ua_messages.call_args_list
 
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
+    @mock.patch("uaclient.config.update_ua_messages")
     def test_correct_message_emitted(
         self,
+        update_ua_messages,
         m_client,
         m_entitlements,
         m_getuid,
@@ -164,11 +177,20 @@ class TestActionDetach:
         out, _err = capsys.readouterr()
 
         assert status.MESSAGE_DETACH_SUCCESS + "\n" == out
+        assert [mock.call(m_cfg)] == update_ua_messages.call_args_list
 
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
+    @mock.patch("uaclient.config.update_ua_messages")
     def test_returns_zero(
-        self, m_client, m_entitlements, m_getuid, _m_prompt, FakeConfig, tmpdir
+        self,
+        update_ua_messages,
+        m_client,
+        m_entitlements,
+        m_getuid,
+        _m_prompt,
+        FakeConfig,
+        tmpdir,
     ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = []
@@ -182,6 +204,7 @@ class TestActionDetach:
         ret = action_detach(mock.MagicMock(), m_cfg)
 
         assert 0 == ret
+        assert [mock.call(m_cfg)] == update_ua_messages.call_args_list
 
     @pytest.mark.parametrize(
         "classes,expected_message",
@@ -214,8 +237,10 @@ class TestActionDetach:
     )
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
+    @mock.patch("uaclient.config.update_ua_messages")
     def test_informational_message_emitted(
         self,
+        m_update_ua_messages,
         m_client,
         m_entitlements,
         m_getuid,

--- a/uaclient/tests/test_ua_update_messaging.py
+++ b/uaclient/tests/test_ua_update_messaging.py
@@ -206,30 +206,30 @@ class Test_WriteESMServiceAPTMsgTemplates:
             assert False is os.path.exists(no_pkgs_file.strpath)
 
     @pytest.mark.parametrize(
-        "contract_status, remaining_days, series",
+        "contract_status, remaining_days, is_active_esm",
         (
-            (ContractExpiryStatus.ACTIVE, 21, "xenial"),
-            (ContractExpiryStatus.ACTIVE_EXPIRED_SOON, 10, "xenial"),
-            (ContractExpiryStatus.EXPIRED_GRACE_PERIOD, -5, "xenial"),
-            (ContractExpiryStatus.EXPIRED, -20, "xenial"),
-            (ContractExpiryStatus.EXPIRED, -20, "bionic"),
+            (ContractExpiryStatus.ACTIVE, 21, True),
+            (ContractExpiryStatus.ACTIVE_EXPIRED_SOON, 10, True),
+            (ContractExpiryStatus.EXPIRED_GRACE_PERIOD, -5, True),
+            (ContractExpiryStatus.EXPIRED, -20, True),
+            (ContractExpiryStatus.EXPIRED, -20, False),
         ),
     )
-    @mock.patch(M_PATH + "util.get_platform_info")
+    @mock.patch(M_PATH + "util.is_active_esm")
     @mock.patch(
         M_PATH + "entitlements.repo.RepoEntitlement.application_status"
     )
     def test_apt_templates_written_for_enabled_services_by_contract_status(
         self,
         app_status,
-        get_platform_info,
+        util_is_active_esm,
         contract_status,
         remaining_days,
-        series,
+        is_active_esm,
         FakeConfig,
         tmpdir,
     ):
-        get_platform_info.return_value = {"series": series}
+        util_is_active_esm.return_value = is_active_esm
         m_entitlement_cls = mock.MagicMock()
         m_ent_obj = m_entitlement_cls.return_value
         disabled_status = ApplicationStatus.ENABLED, ""
@@ -306,7 +306,7 @@ class Test_WriteESMServiceAPTMsgTemplates:
             no_pkgs_msg = MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL.format(
                 title="UA Apps: ESM", url=BASE_ESM_URL
             )
-            if series == "xenial":
+            if is_active_esm:
                 assert MESSAGE_UBUNTU_NO_WARRANTY == no_warranty_file.read()
             else:
                 assert False is os.path.exists(no_warranty_file.strpath)

--- a/uaclient/tests/test_ua_update_messaging.py
+++ b/uaclient/tests/test_ua_update_messaging.py
@@ -1,0 +1,460 @@
+import datetime
+import mock
+import os
+
+import pytest
+
+from uaclient.defaults import (
+    BASE_ESM_URL,
+    BASE_UA_URL,
+    CONTRACT_EXPIRY_GRACE_PERIOD_DAYS,
+)
+from uaclient.status import (
+    MESSAGE_ANNOUNCE_ESM,
+    MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL,
+    MESSAGE_CONTRACT_EXPIRED_SOON_TMPL,
+    MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
+    MESSAGE_DISABLED_APT_PKGS_TMPL,
+    MESSAGE_UBUNTU_NO_WARRANTY,
+    ApplicationStatus,
+)
+from uaclient import util
+
+from lib.ua_update_messaging import (
+    ContractExpiryStatus,
+    ExternalMessage,
+    get_contract_expiry_status,
+    update_apt_and_motd_messages,
+    write_apt_and_motd_templates,
+    write_esm_announcement_message,
+    _write_esm_service_msg_templates,
+)
+
+M_PATH = "lib.ua_update_messaging."
+
+
+class TestGetContractExpiryStatus:
+    @pytest.mark.parametrize(
+        "contract_remaining_days,expected_status",
+        (
+            (21, ContractExpiryStatus.ACTIVE),
+            (20, ContractExpiryStatus.ACTIVE_EXPIRED_SOON),
+            (-1, ContractExpiryStatus.EXPIRED_GRACE_PERIOD),
+            (-20, ContractExpiryStatus.EXPIRED),
+        ),
+    )
+    def test_contract_expiry_status_based_on_remaining_days(
+        self, contract_remaining_days, expected_status, FakeConfig
+    ):
+        """Return a tuple of ContractExpiryStatus and remaining_days"""
+        now = datetime.datetime.utcnow()
+        expire_date = now + datetime.timedelta(days=contract_remaining_days)
+        cfg = FakeConfig.for_attached_machine()
+        m_token = cfg.machine_token
+        m_token["machineTokenInfo"]["contractInfo"][
+            "effectiveTo"
+        ] = expire_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        assert (
+            expected_status,
+            contract_remaining_days,
+        ) == get_contract_expiry_status(cfg)
+
+
+class TestWriteAPTAndMOTDTemplates:
+    @pytest.mark.parametrize(
+        "series, is_active_esm, esm_apps_beta, cfg_allow_beta",
+        (
+            ("xenial", True, True, None),
+            ("xenial", True, False, None),
+            ("xenial", False, True, None),
+            ("xenial", True, True, True),
+        ),
+    )
+    @mock.patch(M_PATH + "entitlements")
+    @mock.patch(M_PATH + "_write_esm_service_msg_templates")
+    @mock.patch(M_PATH + "util.is_active_esm")
+    @mock.patch(M_PATH + "get_contract_expiry_status")
+    def test_write_apps_and_infra_services(
+        self,
+        get_contract_expiry_status,
+        util_is_active_esm,
+        write_esm_service_templates,
+        entitlements,
+        series,
+        is_active_esm,
+        esm_apps_beta,
+        cfg_allow_beta,
+        FakeConfig,
+    ):
+        """Write both Infra and Apps when not-beta service."""
+        get_contract_expiry_status.return_value = (
+            ContractExpiryStatus.ACTIVE,
+            21,
+        )
+        util_is_active_esm.return_value = is_active_esm
+        infra_cls = mock.MagicMock()
+        infra_obj = infra_cls.return_value
+        type(infra_obj).name = mock.PropertyMock(return_value="esm-infra")
+        apps_cls = mock.MagicMock()
+        type(apps_cls).is_beta = esm_apps_beta
+        apps_obj = apps_cls.return_value
+        type(apps_obj).name = mock.PropertyMock(return_value="esm-apps")
+        entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            "esm-apps": apps_cls,
+            "esm-infra": infra_cls,
+        }
+        cfg = FakeConfig.for_attached_machine()
+        if cfg_allow_beta:
+            cfg.override_features({"allow_beta": cfg_allow_beta})
+        if cfg_allow_beta or not esm_apps_beta:
+            write_calls = [
+                mock.call(
+                    cfg,
+                    mock.ANY,
+                    ContractExpiryStatus.ACTIVE,
+                    21,
+                    ExternalMessage.APT_PRE_INVOKE_APPS_PKGS.value,
+                    ExternalMessage.APT_PRE_INVOKE_APPS_NO_PKGS.value,
+                    ExternalMessage.MOTD_APPS_PKGS.value,
+                    ExternalMessage.MOTD_APPS_NO_PKGS.value,
+                    ExternalMessage.UBUNTU_NO_WARRANTY.value,
+                )
+            ]
+        else:
+            write_calls = []
+        if is_active_esm:
+            write_calls.append(
+                mock.call(
+                    cfg,
+                    mock.ANY,
+                    ContractExpiryStatus.ACTIVE,
+                    21,
+                    ExternalMessage.APT_PRE_INVOKE_INFRA_PKGS.value,
+                    ExternalMessage.APT_PRE_INVOKE_INFRA_NO_PKGS.value,
+                    ExternalMessage.MOTD_INFRA_PKGS.value,
+                    ExternalMessage.MOTD_INFRA_NO_PKGS.value,
+                    ExternalMessage.UBUNTU_NO_WARRANTY.value,
+                )
+            )
+        write_apt_and_motd_templates(cfg, series)
+        assert [mock.call(cfg)] == get_contract_expiry_status.call_args_list
+        assert write_calls == write_esm_service_templates.call_args_list
+
+
+class Test_WriteESMServiceAPTMsgTemplates:
+    @pytest.mark.parametrize(
+        "contract_expiry, expect_messages",
+        (
+            (ContractExpiryStatus.ACTIVE, True),
+            (ContractExpiryStatus.EXPIRED, False),
+        ),
+    )
+    @mock.patch(
+        M_PATH + "entitlements.repo.RepoEntitlement.application_status"
+    )
+    def test_apt_templates_written_for_disabled_services(
+        self, app_status, contract_expiry, expect_messages, FakeConfig, tmpdir
+    ):
+        """Disabled service messages are omitted if contract expired.
+
+        This represents customer chosen disabling of service on an attached
+        machine. So, they've chosen to disable expired services.
+        """
+        m_entitlement_cls = mock.MagicMock()
+        m_ent_obj = m_entitlement_cls.return_value
+        disabled_status = ApplicationStatus.DISABLED, ""
+        m_ent_obj.application_status.return_value = disabled_status
+        type(m_ent_obj).name = mock.PropertyMock(return_value="esm-apps")
+        type(m_ent_obj).title = mock.PropertyMock(return_value="UA Apps: ESM")
+        pkgs_file = tmpdir.join("pkgs-msg")
+        no_pkgs_file = tmpdir.join("no-pkgs-msg")
+        motd_pkgs_file = tmpdir.join("motd-pkgs-msg")
+        motd_no_pkgs_file = tmpdir.join("motd-no-pkgs-msg")
+        no_warranty_file = tmpdir.join("ubuntu-no-warranty")
+        _write_esm_service_msg_templates(
+            FakeConfig.for_attached_machine(),
+            m_ent_obj,
+            contract_expiry,
+            21,
+            pkgs_file.strpath,
+            no_pkgs_file.strpath,
+            motd_pkgs_file.strpath,
+            motd_no_pkgs_file.strpath,
+            no_warranty_file.strpath,
+        )
+        if expect_messages:
+            assert (
+                MESSAGE_DISABLED_APT_PKGS_TMPL.format(
+                    title="UA Apps: ESM",
+                    pkg_num="{ESM_APPS_PKG_COUNT}",
+                    pkg_names="{ESM_APPS_PACKAGES}",
+                    url=BASE_ESM_URL,
+                )
+                == pkgs_file.read()
+            )
+            assert (
+                MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL.format(
+                    title="UA Apps: ESM", url=BASE_ESM_URL
+                )
+                == no_pkgs_file.read()
+            )
+        else:
+            assert False is os.path.exists(pkgs_file.strpath)
+            assert False is os.path.exists(no_pkgs_file.strpath)
+
+    @pytest.mark.parametrize(
+        "contract_status, remaining_days, series",
+        (
+            (ContractExpiryStatus.ACTIVE, 21, "xenial"),
+            (ContractExpiryStatus.ACTIVE_EXPIRED_SOON, 10, "xenial"),
+            (ContractExpiryStatus.EXPIRED_GRACE_PERIOD, -5, "xenial"),
+            (ContractExpiryStatus.EXPIRED, -20, "xenial"),
+            (ContractExpiryStatus.EXPIRED, -20, "bionic"),
+        ),
+    )
+    @mock.patch(M_PATH + "util.get_platform_info")
+    @mock.patch(
+        M_PATH + "entitlements.repo.RepoEntitlement.application_status"
+    )
+    def test_apt_templates_written_for_enabled_services_by_contract_status(
+        self,
+        app_status,
+        get_platform_info,
+        contract_status,
+        remaining_days,
+        series,
+        FakeConfig,
+        tmpdir,
+    ):
+        get_platform_info.return_value = {"series": series}
+        m_entitlement_cls = mock.MagicMock()
+        m_ent_obj = m_entitlement_cls.return_value
+        disabled_status = ApplicationStatus.ENABLED, ""
+        m_ent_obj.application_status.return_value = disabled_status
+        type(m_ent_obj).name = mock.PropertyMock(return_value="esm-apps")
+        type(m_ent_obj).title = mock.PropertyMock(return_value="UA Apps: ESM")
+        pkgs_tmpl = tmpdir.join("pkgs-msg.tmpl")
+        no_pkgs_tmpl = tmpdir.join("no-pkgs-msg.tmpl")
+        motd_pkgs_tmpl = tmpdir.join("motd-pkgs-msg.tmpl")
+        motd_no_pkgs_tmpl = tmpdir.join("motd-no-pkgs-msg.tmpl")
+        no_warranty_file = tmpdir.join("ubuntu-no-warranty")
+        pkgs_tmpl.write("oldcache")
+        no_pkgs_tmpl.write("oldcache")
+        motd_pkgs_tmpl.write("oldcache")
+        motd_no_pkgs_tmpl.write("oldcache")
+        no_pkgs_msg_file = no_pkgs_tmpl.strpath.replace(".tmpl", "")
+        pkgs_msg_file = pkgs_tmpl.strpath.replace(".tmpl", "")
+        util.write_file(no_pkgs_msg_file, "oldcache")
+        util.write_file(pkgs_msg_file, "oldcache")
+
+        now = datetime.datetime.utcnow()
+        expire_date = now + datetime.timedelta(days=remaining_days)
+        cfg = FakeConfig.for_attached_machine()
+        m_token = cfg.machine_token
+        m_token["machineTokenInfo"]["contractInfo"][
+            "effectiveTo"
+        ] = expire_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        _write_esm_service_msg_templates(
+            cfg,
+            m_ent_obj,
+            contract_status,
+            remaining_days,
+            pkgs_tmpl.strpath,
+            no_pkgs_tmpl.strpath,
+            motd_pkgs_tmpl.strpath,
+            motd_no_pkgs_tmpl.strpath,
+            no_warranty_file.strpath,
+        )
+        if contract_status == ContractExpiryStatus.ACTIVE:
+            # Old messages removed on ACTIVE status
+            assert False is os.path.exists(pkgs_tmpl.strpath)
+            assert False is os.path.exists(no_pkgs_tmpl.strpath)
+            assert False is os.path.exists(motd_pkgs_tmpl.strpath)
+            assert False is os.path.exists(motd_no_pkgs_tmpl.strpath)
+            assert False is os.path.exists(pkgs_msg_file)
+            assert False is os.path.exists(no_pkgs_msg_file)
+        elif contract_status == ContractExpiryStatus.ACTIVE_EXPIRED_SOON:
+            pkgs_msg = MESSAGE_CONTRACT_EXPIRED_SOON_TMPL.format(
+                title="UA Apps: ESM",
+                remaining_days=remaining_days,
+                url=BASE_UA_URL,
+            )
+            assert pkgs_msg == pkgs_tmpl.read()
+            assert pkgs_msg == no_pkgs_tmpl.read()
+        elif contract_status == ContractExpiryStatus.EXPIRED_GRACE_PERIOD:
+            pkgs_msg = MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL.format(
+                title="UA Apps: ESM",
+                expired_date=cfg.contract_expiry_datetime.strftime("%d %b %Y"),
+                remaining_days=remaining_days
+                + CONTRACT_EXPIRY_GRACE_PERIOD_DAYS,
+                url=BASE_UA_URL,
+            )
+            assert pkgs_msg == pkgs_tmpl.read()
+            assert pkgs_msg == no_pkgs_tmpl.read()
+        elif contract_status == ContractExpiryStatus.EXPIRED:
+            pkgs_msg = MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL.format(
+                pkg_num="{ESM_APPS_PKG_COUNT}",
+                pkg_names="{ESM_APPS_PACKAGES}",
+                title="UA Apps: ESM",
+                name="esm-apps",
+                url=BASE_UA_URL,
+            )
+            no_pkgs_msg = MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL.format(
+                title="UA Apps: ESM", url=BASE_ESM_URL
+            )
+            if series == "xenial":
+                assert MESSAGE_UBUNTU_NO_WARRANTY == no_warranty_file.read()
+            else:
+                assert False is os.path.exists(no_warranty_file.strpath)
+            assert pkgs_msg == pkgs_tmpl.read()
+            assert no_pkgs_msg == no_pkgs_tmpl.read()
+
+
+class TestWriteESMAnnouncementMessage:
+    @pytest.mark.parametrize(
+        "series,is_beta,cfg_allow_beta,apps_enabled,expected",
+        (
+            # No ESM announcement when trusty
+            ("trusty", False, True, False, None),
+            # ESMApps.is_beta == True no Announcement
+            ("xenial", True, None, False, None),
+            # Once release begins ESM and ESMApps.is_beta is false announce
+            ("xenial", False, None, False, "\n" + MESSAGE_ANNOUNCE_ESM),
+            # allow_beta uaclient.config overrides is_beta and days_until_esm
+            ("xenial", True, True, False, "\n" + MESSAGE_ANNOUNCE_ESM),
+            # when esm-apps already enabled don't show
+            ("xenial", False, True, True, None),
+            ("bionic", False, None, False, "\n" + MESSAGE_ANNOUNCE_ESM),
+            ("focal", False, None, False, "\n" + MESSAGE_ANNOUNCE_ESM),
+        ),
+    )
+    @mock.patch(
+        M_PATH + "entitlements.repo.RepoEntitlement.application_status"
+    )
+    @mock.patch(M_PATH + "entitlements")
+    @mock.patch(M_PATH + "util.get_platform_info")
+    def test_message_based_on_beta_status_and_count_until_active_esm(
+        self,
+        get_platform_info,
+        entitlements,
+        esm_application_status,
+        series,
+        is_beta,
+        cfg_allow_beta,
+        apps_enabled,
+        expected,
+        FakeConfig,
+    ):
+        get_platform_info.return_value = {"series": series}
+
+        cfg = FakeConfig.for_attached_machine()
+        msg_dir = os.path.join(cfg.data_dir, "messages")
+        os.makedirs(msg_dir)
+        esm_news_path = os.path.join(msg_dir, "motd-esm-announce")
+
+        if cfg_allow_beta:
+            cfg.override_features({"allow_beta": cfg_allow_beta})
+
+        m_entitlement_cls = mock.MagicMock()
+        type(m_entitlement_cls).is_beta = is_beta
+        m_ent_obj = m_entitlement_cls.return_value
+        if apps_enabled:
+            status_return = ApplicationStatus.ENABLED, ""
+        else:
+            status_return = ApplicationStatus.DISABLED, ""
+        m_ent_obj.application_status.return_value = status_return
+
+        type(m_entitlement_cls).is_beta = is_beta
+        entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            "esm-apps": m_entitlement_cls
+        }
+        write_esm_announcement_message(cfg, series)
+        if expected is None:
+            assert False is os.path.exists(esm_news_path)
+        else:
+            assert expected == util.load_file(esm_news_path)
+
+
+class TestUpdateAPTandMOTDMessages:
+    @pytest.mark.parametrize(
+        "series,is_lts,esm_active,cfg_allow_beta",
+        (
+            ("xenial", True, True, True),
+            ("bionic", True, False, True),
+            ("bionic", True, False, None),
+            ("groovy", False, False, None),
+        ),
+    )
+    @mock.patch(M_PATH + "util.is_lts")
+    @mock.patch(M_PATH + "util.is_active_esm")
+    @mock.patch(M_PATH + "write_apt_and_motd_templates")
+    @mock.patch(M_PATH + "write_esm_announcement_message")
+    @mock.patch(M_PATH + "util.subp")
+    @mock.patch(M_PATH + "util.get_platform_info")
+    def test_motd_and_apt_templates_written_separately(
+        self,
+        get_platform_info,
+        subp,
+        write_esm_announcement_message,
+        write_apt_and_motd_templates,
+        is_active_esm,
+        util_is_lts,
+        series,
+        is_lts,
+        esm_active,
+        cfg_allow_beta,
+        FakeConfig,
+    ):
+        """Update message templates for LTS releases with esm active.
+
+        Assert cleanup of cached template and rendered message files when
+        non-LTS release.
+
+        Allow config allow_beta overrides.
+        """
+        get_platform_info.return_value = {"series": series}
+        util_is_lts.return_value = is_lts
+        is_active_esm.return_value = esm_active
+        cfg = FakeConfig.for_attached_machine()
+        if cfg_allow_beta:
+            cfg.override_features({"allow_beta": cfg_allow_beta})
+        msg_dir = os.path.join(cfg.data_dir, "messages")
+        if not is_lts:
+            # setup old msg files to assert they are removed
+            os.makedirs(msg_dir)
+            for msg_enum in ExternalMessage:
+                msg_path = os.path.join(msg_dir, msg_enum.value)
+                util.write_file(msg_path, "old")
+                util.write_file(msg_path.replace(".tmpl", ""), "old")
+
+        update_apt_and_motd_messages(cfg)
+        os.path.exists(os.path.join(cfg.data_dir, "messages"))
+
+        if is_lts:
+            write_apt_calls = [mock.call(cfg, series)]
+            esm_announce_calls = [mock.call(cfg, series)]
+            subp_calls = [
+                mock.call(
+                    [
+                        "/usr/lib/ubuntu-advantage/apt-esm-hook",
+                        "process-templates",
+                    ]
+                )
+            ]
+        else:
+            write_apt_calls = esm_announce_calls = []
+            subp_calls = []
+            # Cached msg templates removed on non-LTS
+            for msg_enum in ExternalMessage:
+                msg_path = os.path.join(msg_dir, msg_enum.value)
+                assert False is os.path.exists(msg_path)
+                assert False is os.path.exists(msg_path.replace(".tmpl", ""))
+        assert (
+            esm_announce_calls == write_esm_announcement_message.call_args_list
+        )
+        assert write_apt_calls == write_apt_and_motd_templates.call_args_list
+        assert subp_calls == subp.call_args_list

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -144,7 +144,6 @@ class TestIsActiveESM:
     @pytest.mark.parametrize(
         "series, is_lts, days_until_esm,expected",
         (
-            ("trusty", True, 1, False),
             ("trusty", True, 0, True),
             ("xenial", True, 1, False),
             ("xenial", True, 0, True),
@@ -166,7 +165,7 @@ class TestIsActiveESM:
 
         # Use __wrapped__ to avoid hitting the lru_cached value across tests
         calls = []
-        if is_lts:
+        if is_lts and series != "trusty":
             calls.append(
                 mock.call(
                     [

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -359,6 +359,8 @@ def is_active_esm(series: str) -> bool:
     """Return True when Ubuntu series supports ESM and is actively in ESM."""
     if not is_lts(series):
         return False
+    if series == "trusty":
+        return True  # Trusty doesn't have a --series param
     out, _err = subp(
         ["/usr/bin/ubuntu-distro-info", "--series", series, "-yeol"]
     )

--- a/update-motd.d/88-esm-announce
+++ b/update-motd.d/88-esm-announce
@@ -1,0 +1,4 @@
+#!/bin/sh
+stamp="/var/lib/ubuntu-advantage/messages/motd-esm-announce"
+
+[ ! -r "$stamp" ] || cat "$stamp"

--- a/update-motd.d/91-contract-ua-esm-status
+++ b/update-motd.d/91-contract-ua-esm-status
@@ -1,0 +1,4 @@
+#!/bin/sh
+stamp="/var/lib/ubuntu-advantage/messages/motd-esm-service-status"
+
+[ ! -r "$stamp" ] || cat "$stamp"


### PR DESCRIPTION
## Proposed Commit Message

shared MOTD and APT messaging generation

APT and MOTD messaging share a number of common messages.
                                                                                
To share those message template between apt-hooks and MOTD-hooks
the ua_update_messaging script will generate message templates
appropriate for both APT and MOTD and store them in
/var/lib/ubuntu-advantage/messages/*tmpl.

The ua_update_messaging script will be triggered on every apt update
and will call esm-apt-hook to render those templates replacing
template variable names with dynamic ESM Apps and Infra package counts
and/or package names.
                                                                                
Fixes: #1536
Fixes: #1561

## Test Steps

build the package from this PR
install on a test system
```bash

sed -i 's/UNRELEASED/xenial'
git commit -am 'changelog'
build-package
sbuild-it ../out/*dsc
lxc launch ubuntu-daily:xenial test-x
lxc file push *deb test-x/
lxc exec test-x bash
dpkg -i /ubuntu-advantage-tools*deb
apt update
run-parts /etc/update-motd.d
ua attach <token>
apt update
run-parts /etc/update-motd.d # to see esm related messages
```

Update messages 
```bash
rm -rf /var/lib/ubuntu-advantage/messages
sudo python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py
for file in /var/lib/ubuntu-advantage/messages/*; do 
  echo ----- $file;
  cat $file;
done

sudo run-parts /etc/update-motd.d
apt upgrade

systemctl list-timers | grep ua-messag
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [x] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
