### PR TITLE
esm-apps: remove beta config flag for esm

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -178,7 +178,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             This subscription is not entitled to CIS Audit
             For more information see: https://ubuntu.com/advantage.
             """
-        And I verify that running `ua enable esm-apps --beta` `with sudo` exits `1`
+        And I verify that running `ua enable esm-apps` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -7,6 +7,7 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     yes        UA Infra: Extended Security Maintenance \(ESM\)
             fips          <fips>      +NIST-certified FIPS modules
             fips-updates  <fips>      +Uncertified security updates to FIPS modules
@@ -34,6 +35,7 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            esm-apps      <esm-apps>  +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     yes        UA Infra: Extended Security Maintenance \(ESM\)
             fips          <fips>      +NIST-certified FIPS modules
             fips-updates  <fips>      +Uncertified security updates to FIPS modules

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -18,7 +18,6 @@ class ESMAppsEntitlement(ESMBaseEntitlement):
     title = "ESM Apps"
     description = "UA Apps: Extended Security Maintenance (ESM)"
     repo_key_file = "ubuntu-advantage-esm-apps.gpg"
-    is_beta = True
 
     @property
     def repo_pin_priority(self) -> "Optional[str]":

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -61,6 +61,8 @@ Client to manage Ubuntu Advantage services on a machine.
 SERVICES_WRAPPED_HELP = textwrap.dedent(
     """
 Client to manage Ubuntu Advantage services on a machine.
+ - esm-apps: UA Apps: Extended Security Maintenance (ESM)
+   (https://ubuntu.com/security/esm)
  - esm-infra: UA Infra: Extended Security Maintenance (ESM)
    (https://ubuntu.com/security/esm)
  - fips-updates: Uncertified security updates to FIPS modules

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -24,7 +24,7 @@ Disable an Ubuntu Advantage service.
 
 Arguments:
   service       the name(s) of the Ubuntu Advantage services to disable One
-                of: esm-infra, fips, fips-updates, livepatch
+                of: esm-apps, esm-infra, fips, fips-updates, livepatch
 
 Flags:
   -h, --help    show this help message and exit

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -18,7 +18,7 @@ Enable an Ubuntu Advantage service.
 
 Arguments:
   service       the name(s) of the Ubuntu Advantage services to enable. One
-                of: esm-infra, fips, fips-updates, livepatch
+                of: esm-apps, esm-infra, fips, fips-updates, livepatch
 
 Flags:
   -h, --help    show this help message and exit

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -50,6 +50,8 @@ Technical support level: n/a
 # Omit beta services from status
 ATTACHED_STATUS_NOBETA = """\
 SERVICE       ENTITLED  STATUS    DESCRIPTION
+esm-apps      no        {dash}         UA Apps: Extended Security Maintenance\
+ (ESM)
 esm-infra     no        {dash}         UA Infra: Extended Security Maintenance\
  (ESM)
 fips          no        {dash}         NIST-certified FIPS modules
@@ -65,7 +67,7 @@ Enable services with: ua enable <service>
 Technical support level: n/a
 """
 
-BETA_SVC_NAMES = ["cc-eal", "cis", "esm-apps"]
+BETA_SVC_NAMES = ["cc-eal", "cis"]
 
 SERVICES_JSON_ALL = [
     {


### PR DESCRIPTION
Note, let's not land this until @lechsandecki confirms this is desired/docuemented behavior for beta customers.

## Proposed Commit Message

Treat esm-apps as a production service within UA client.
Any contracts entitled to esm-apps will be able to activate
access to UA Apps: ESM packages by running:
  ua enable esm-apps

Fixes: #1544


## Test Steps
```bash
echo > doit.yaml <<EOF
#cloud-config                                                                   
apt:                                                                            
  sources:                                                                      
    ua-daily.list:                                                              
       source: deb http://ppa.launchpad.net/ua-client/daily/ubuntu $RELEASE main
       keyid: 6E34E7116C0BC933   
packages: [ubuntu-advantage-tools]                                              
EOF
lxc launch ubuntu-daily:xenial -c user.user-data="$(cat doit.yaml)" test-pr-x

lxc exec test-pr-x -- cloud-init status --wait --long
lxc exec test-pr-x -- ua status --wait
# notice no esm-apps by default
lxc file push uaclient/entitlements/esm.py test-pr-x/usr/lib/python3/dist-packages/uaclient
# notice esm-apps show up because ! beta
lxc exec test-pr-x -- ua status --wait
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
