### PR TITLE
status: do not remove notices on non-root call

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -540,15 +540,6 @@ class UAConfig:
         Write the status-cache when called by root.
         """
 
-        # Try to remove fix reboot notices if not applicable
-        if not util.should_reboot():
-            self.remove_notice(
-                "",
-                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation="fix operation"
-                ),
-            )
-
         if os.getuid() != 0:
             response = cast("Dict[str, Any]", self.read_cache("status-cache"))
             if not response:
@@ -560,6 +551,15 @@ class UAConfig:
         response.update(self._get_config_status())
         if os.getuid() == 0:
             self.write_cache("status-cache", response)
+
+            # Try to remove fix reboot notices if not applicable
+            if not util.should_reboot():
+                self.remove_notice(
+                    "",
+                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation="fix operation"
+                    ),
+                )
 
         config_allow_beta = util.is_config_value_true(
             config=self.cfg, path_to_value="features.allow_beta"

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1017,17 +1017,6 @@ class TestStatus:
 
         assert expected_status == cfg.status()
 
-        expected_calls = [
-            mock.call(
-                "",
-                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation="fix operation"
-                ),
-            )
-        ]
-
-        assert expected_calls == m_remove_notice.call_args_list
-
 
 ATTACHED_SERVICE_STATUS_PARAMETERS = [
     # ENTITLED => display the given user-facing status


### PR DESCRIPTION
## Proposed Commit Message
status: do not remove notices on non-root call

When we run ua status we try to remove notices that are created by fix operations. However, non-root users do not have the right permissions to remove them. We are now fixing the code to only attempt to remove the notices if ua status is run by root users.

Fixes: #1550

## Test Steps
Run the modified tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
