### PR TITLE
Ship esm-infra pref file only on xenial and trusty

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -82,13 +82,6 @@ print(*ENTITLEMENT_CLASS_BY_NAME.keys(), sep=' ')
 }
 
 
-# Check whether a given distro has esm support
-check_release_supports_esm() {
-    release_name=$1
-    ubuntu-distro-info --supported-esm | grep -q "${release_name}"
-}
-
-
 # Check whether a given service is beta
 check_service_is_beta() {
     service_name=$1
@@ -284,7 +277,7 @@ case "$1" in
       # machine-access cache files no longer present or used since 20.1
       rm -f /var/lib/ubuntu-advantage/private/machine-access-*.json
 
-      if check_release_supports_esm "${UBUNTU_CODENAME}"; then
+      if [ "14.04" = "$VERSION_ID" ] || [ "16.04" = "$VERSION_ID" ]; then
         if echo "$ESM_SUPPORTED_ARCHS" | grep -qw "$MYARCH"; then
           configure_esm
         else

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -74,6 +74,16 @@ def given_a_machine(context, series):
         context.instance
     )
 
+    if series == "trusty":
+        # On trusty, the distro-info package is not directly
+        # installed when we install the ubuntu-advantage-client
+        # deb. This is fixing that problem on trusty
+        when_i_run_command(
+            context=context,
+            command="apt-get install -f -y",
+            user_spec="with sudo",
+        )
+
     def cleanup_instance() -> None:
         if not context.config.destroy_instances:
             print(
@@ -273,6 +283,13 @@ def then_conditional_stdout_matches_regexp(context, value1, value2):
     """Only apply regex assertion if value1 in value2."""
     if value1 in value2.split(" or "):
         then_stdout_matches_regexp(context)
+
+
+@then("if `{value1}` in `{value2}` and stdout does not match regexp")
+def then_conditional_stdout_does_not_match_regexp(context, value1, value2):
+    """Only apply regex assertion if value1 in value2."""
+    if value1 in value2.split(" or "):
+        then_stdout_does_not_match_regexp(context)
 
 
 @then("stdout matches regexp")

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -44,9 +44,7 @@ Feature: Command behaviour when unattached
         """
         -32768 <esm-apps-url> <release>-apps-security/main amd64 Packages
         """
-        # Trusty only issue
-        When I run `apt-get install -f -y` with sudo
-        And I append the following on uaclient config:
+        When I append the following on uaclient config:
             """
             features:
               allow_beta: true


### PR DESCRIPTION
## Proposed Commit Message
Ship esm-infra pref file only on xenial and trusty

Currently, we are shipping the esm-infra preference file on all LTS releases. However, our codebase only supports that preference file for trusty and xenial. Because of that, we are updating our postinst script to onoy ship that file for trusty and xenial

## Test Steps
Run the `Attach command in a ubuntu lxd container` scenario on `attach_valitoken.feature` without this change and with this change

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
