### PR TITLE
Esm apps all lts

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -85,6 +85,28 @@ print(*ENTITLEMENT_CLASS_BY_NAME.keys(), sep=' ')
 }
 
 
+# Ubuntu LTS release all support-esm
+check_is_lts() {
+    release_name=$1
+    ubuntu-distro-info --supported-esm | grep -q "${release_name}"
+}
+
+
+# Check whether this series is under active ESM
+check_is_active_esm() {
+    release_name=$1
+    # Trusty doesn't support --series param
+    if [ "${release_name}" = "trusty" ]; then
+        return 0
+    else
+        _DAYS_UNTIL_ESM=$(ubuntu-distro-info --series "${release_name}" -yeol)
+        if [ "${_DAYS_UNTIL_ESM}" -lt "1" ]; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
 # Check whether a given service is beta
 check_service_is_beta() {
     service_name=$1
@@ -205,17 +227,14 @@ EOF
 
 configure_esm() {
     rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove legacy esm keys
-    if [ "14.04" = "${VERSION_ID}" ]; then
-            enable_apps="false"
-    else
-            enable_apps="true"
+    if check_is_active_esm "${UBUNTU_CODENAME}"; then
+        install_esm_apt_key_and_source "infra" "$UBUNTU_CODENAME"
     fi
-    if [ "${enable_apps}" = "true" ]; then
-        if ! check_service_is_beta esm-apps; then
+    if ! check_service_is_beta esm-apps; then
+        if [ "${UBUNTU_CODENAME}" != "trusty" ]; then
             install_esm_apt_key_and_source "apps" "$UBUNTU_CODENAME"
         fi
     fi
-    install_esm_apt_key_and_source "infra" "$UBUNTU_CODENAME"
 }
 
 
@@ -292,7 +311,7 @@ case "$1" in
       # machine-access cache files no longer present or used since 20.1
       rm -f /var/lib/ubuntu-advantage/private/machine-access-*.json
 
-      if [ "14.04" = "$VERSION_ID" ] || [ "16.04" = "$VERSION_ID" ]; then
+      if check_is_lts "${UBUNTU_CODENAME}"; then
         if echo "$ESM_SUPPORTED_ARCHS" | grep -qw "$MYARCH"; then
           configure_esm
         else

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -349,6 +349,23 @@ def get_platform_info() -> "Dict[str, str]":
 
 
 @lru_cache(maxsize=None)
+def is_lts(series: str) -> bool:
+    out, _err = subp(["/usr/bin/ubuntu-distro-info", "--supported-esm"])
+    return series in out
+
+
+@lru_cache(maxsize=None)
+def is_active_esm(series: str) -> bool:
+    """Return True when Ubuntu series supports ESM and is actively in ESM."""
+    if not is_lts(series):
+        return False
+    out, _err = subp(
+        ["/usr/bin/ubuntu-distro-info", "--series", series, "-yeol"]
+    )
+    return int(out) <= 0
+
+
+@lru_cache(maxsize=None)
 def is_container(run_path: str = "/run") -> bool:
     """Checks to see if this code running in a container of some sort"""
 


### PR DESCRIPTION
## Proposed Commit Message  

esm: enable infra when EOL LTS and apps on all LTS
    
    Enable showing unauthenticated APT package counts for the following:
     - ESM Infra on any end of life Ubuntu LTS release
     - ESM Apps when non-beta on any Ubuntu LTS release except Trusty
    
    Fixes: #1558

---
    util: add is_lts and is_active_esm funtions to support ESM
    
    Shell out to ubuntu-distro-info to determine the following:
     - is_lts: the provided Ubuntu release is an LTS release
     - is_active_esm: the provided Ubuntu release has entered EOL and is
                      entitled to ESM Infra

---

    d/postinst: configure esminfra when is_active_esm and apps on LTS
    
    use ubuntu-distro-info to check_is_lts and check_is_active_esm.
    When on LTS, setup unauthenticated ESM Apps APT sources when
    apps is not beta.
    
    Setup ESM Infra on pkg install when ESM lifecycle has started
    via ubuntu-distro-info --series -yeol.



## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
