### PR TITLE
config: avoid tracebacks on invalid features value in uaclient.conf

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -248,7 +248,17 @@ class UAConfig:
     @property
     def features(self):
         """Return a dictionary of any features provided in uaclient.conf."""
-        return self.cfg.get("features", {})
+        features = self.cfg.get("features")
+        if features:
+            if isinstance(features, dict):
+                return features
+            else:
+                logging.warning(
+                    "Unexpected uaclient.conf features value."
+                    " Expected dict, but found %s",
+                    features,
+                )
+        return {}
 
     @property
     def machine_token(self):

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -780,6 +780,8 @@ class TestIsConfigValueTrue:
         [
             ({}, False),
             ({}, False),
+            (None, False),
+            ({None}, False),
             ({"allow_beta": "true"}, True),
             ({"allow_beta": "True"}, True),
             ({"allow_beta": "false"}, False),

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -678,7 +678,10 @@ def is_config_value_true(config: "Dict[str, Any]", path_to_value: str):
         if key == leaf_value:
             default_value = "false"
 
-        value = value.get(key, default_value)
+        if isinstance(value, dict):
+            value = value.get(key, default_value)
+        else:
+            return False
 
     value_str = str(value)
     if value_str.lower() == "true":


### PR DESCRIPTION
## Proposed Commit Message

If /etc/ubuntu-advantage/uaclient.conf contains unexpected values
in features: settings log a warning and return an empty dict.

Avoid tracing on every ua subcommand call.

Fixes: #1564

## Test Steps
```bash
lxc launch ubuntu-daily:xenial test-ua
lxc exec test-ua -- add-apt-repository ppa:ua-client/daily -y
lxc exec test-ua -- apt update
lxc exec test-ua -- apt install ubuntu-advantage-tools --assume-yes

cat > uaclient.conf <<EOF
features: null
EOF
lxc file push uaclient.conf test-ua/etc/ubuntu-advantage
lxc exec test-ua -- ua status   # expect to see failure
# apply the fix
lxc file push uaclient/config.py test-ua/usr/lib/python3/dist-packages/uaclient
lxc exec test-ua -- ua status   # expect no failure
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
