### PR TITLE
Remove redundant messaging from uaclient

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -248,6 +248,8 @@ static void process_template_file(
          message_static_file << message_tmpl;
          message_static_file.close();
       }
+   } else {
+      remove(static_file_name.c_str());
    }
 }
 
@@ -257,6 +259,7 @@ static void process_all_templates(
    int esm_i_pkgs_count,
    std::string esm_i_pkgs
 ) {
+   int bytes_written;
    std::array<std::string, 4> static_file_names = {
       APT_PRE_INVOKE_APPS_PKGS_STATIC_PATH,
       MOTD_APPS_PKGS_STATIC_PATH,
@@ -310,8 +313,16 @@ static void process_all_templates(
            message_file.close();
        };
    }
-   apt_pre_invoke_msg << std::endl;
+   bytes_written = apt_pre_invoke_msg.tellp();
+   if (bytes_written > 0) {
+       // Then we wrote some content add trailing newline
+       apt_pre_invoke_msg << std::endl;
+   }
    apt_pre_invoke_msg.close();
+   if (bytes_written == 0) {
+       // We added nothing. Remove the file
+       remove(APT_PRE_INVOKE_MESSAGE_STATIC_PATH);
+   }
 
    std::ofstream motd_msg;
    motd_msg.open(MOTD_ESM_SERVICE_STATUS_MESSAGE_STATIC_PATH);
@@ -325,8 +336,16 @@ static void process_all_templates(
            message_file.close();
        };
    }
-   motd_msg << std::endl;
+   bytes_written = motd_msg.tellp();
+   if (bytes_written > 0) {
+       // Then we wrote some content add trailing newline
+       motd_msg << std::endl;
+   }
    motd_msg.close();
+   if (bytes_written == 0) {
+       // We added nothing. Remove the file
+       remove(MOTD_ESM_SERVICE_STATUS_MESSAGE_STATIC_PATH);
+   }
 }
 
 static void output_file_if_present(std::string file_name) {

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -2,25 +2,15 @@
 Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         subscription using a valid token
 
-    @series.all
+    @series.xenial
+    @series.bionic
+    @series.focal
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo, retrying exit [100]
         And I run `apt-get install -y <downrev_pkg>` with sudo, retrying exit [100]
         And I run `run-parts /etc/update-motd.d/` with sudo
-        Then if `<release>` in `trusty` and stdout matches regexp:
-        """
-        UA Infrastructure Extended Security Maintenance \(ESM\) is not enabled.
-
-        \d+ update(s)? can be installed immediately.
-        \d+ of these updates (is a|are) security update(s)?.
-        """
-        Then if `<release>` in `trusty` and stdout matches regexp:
-        """
-        Enable UA Infrastructure ESM to receive \d+ additional security update(s)?.
-        See https://ubuntu.com/advantage or run: sudo ua status
-        """
         Then if `<release>` in `xenial or bionic` and stdout matches regexp:
         """
         \d+ package(s)? can be updated.
@@ -59,15 +49,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
             """
         And I run `apt update` with sudo
         And I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
-        And I run `run-parts /etc/update-motd.d/` with sudo
-        Then if `<release>` in `trusty` and stdout matches regexp:
-        """
-        UA (Infra:|Infrastructure) Extended Security Maintenance \(ESM\) is enabled.
-
-        \d+ update(s)? can be installed immediately.
-        \d+ of these updates (is|are) (fixed|provided) through UA (Infra:|Infrastructure) ESM.
-        \d+ of these updates (is a|are) security update(s)?.
-        """
+        And I run `apt install update-motd` with sudo, retrying exit [100]
+        And I run `update-motd` with sudo
         Then if `<release>` in `focal` and stdout matches regexp:
         """
         \* Introducing Extended Security Maintenance for Applications.
@@ -91,18 +74,15 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
             +https:\/\/ubuntu.com\/esm
 
-        UA Infra: Extended Security Maintenance \(ESM\) is not enabled.
+        UA Infra: Extended Security Maintenance \(ESM\) is enabled.
 
         \d+ package(s)? can be updated.
         \d+ of these updates (is a|are) security update(s)?.
         To see these additional updates run: apt list --upgradable
-
-        Enable UA Infra: ESM to receive \d+ additional security updates?.
-        See https:\/\/ubuntu.com\/security\/esm or run: sudo ua status
         """
         When I update contract to use `effectiveTo` as `days=-20`
         And I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
-        And I run `run-parts /etc/update-motd.d` with sudo
+        And I run `update-motd` with sudo
         Then if `<release>` in `xenial or bionic` and stdout matches regexp:
         """
 

--- a/lib/ua_update_messaging.py
+++ b/lib/ua_update_messaging.py
@@ -29,7 +29,6 @@ from uaclient.status import (
     MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL,
     MESSAGE_CONTRACT_EXPIRED_MOTD_PKGS_TMPL,
     MESSAGE_CONTRACT_EXPIRED_SOON_TMPL,
-    MESSAGE_DISABLED_MOTD_PKGS_TMPL,
     MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
     MESSAGE_DISABLED_APT_PKGS_TMPL,
     MESSAGE_UBUNTU_NO_WARRANTY,
@@ -163,14 +162,6 @@ def _write_esm_service_msg_templates(
         no_pkgs_msg = MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL.format(
             title=ent.title, url=defaults.BASE_ESM_URL
         )
-        motd_pkgs_msg = MESSAGE_DISABLED_MOTD_PKGS_TMPL.format(
-            title=ent.title,
-            pkg_num=tmpl_pkg_count_var,
-            url=defaults.BASE_ESM_URL,
-        )
-        motd_no_pkgs_msg = MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL.format(
-            title=ent.title, url=defaults.BASE_ESM_URL
-        )
 
     msg_dir = os.path.join(cfg.data_dir, "messages")
     _write_template_or_remove(
@@ -225,7 +216,14 @@ def write_apt_and_motd_templates(cfg: config.UAConfig, series: str) -> None:
             motd_apps_no_pkg_file,
             no_warranty_file,
         )
-    if util.is_active_esm(series):
+
+    # We only have esm-infra apt alerts for esm distros.
+    # However, if we have expired credentials, we will
+    # produce esm-infra message showing that the contract is
+    # expiring/expired.
+    infra_status, _ = infra_inst.application_status()
+    is_infra_enabled = infra_status == ApplicationStatus.ENABLED
+    if is_infra_enabled or util.is_active_esm(series):
         _write_esm_service_msg_templates(
             cfg,
             infra_inst,

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -443,11 +443,6 @@ MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL = (
 )
 
 
-MESSAGE_DISABLED_MOTD_PKGS_TMPL = """\
-{pkg_num} additional security updates can be applied with {title}
-Learn more about enabling {title} service at {url}
-"""
-
 MESSAGE_DISABLED_APT_PKGS_TMPL = """\
 *The following packages could receive security updates with
  {title} service enabled:


### PR DESCRIPTION
## Proposed Commit Message
Currently, uaclient is advertising esm services by allowing motd to show messages saying that additional packages could be installed if esm service was enabled. We don't need those type of messages because update-notifier will handle them.

Also, we are updating the code to always show expired message for esm-infra services, even if the distro is not ESM

Message in update-notifer:
https://git.launchpad.net/update-notifier/tree/data/apt_check.py#n119

## Test Steps
Run the modified integration test

## Desired commit type::
Remove redundant messaging from uaclient

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
