### PR TITLE
test: uncomment additional xenial upgrade tests

### DIFF
--- a/tools/test_xenial_upgrade.sh
+++ b/tools/test_xenial_upgrade.sh
@@ -219,6 +219,6 @@ function test_upgrade_with_fips_in_vm() {
     teardown_vm
 }
 
-# test_upgrade_in_container
-# test_upgrade_with_livepatch_in_vm
+test_upgrade_in_container
+test_upgrade_with_livepatch_in_vm
 test_upgrade_with_fips_in_vm


### PR DESCRIPTION
I commented out these lines when testing the last couple fips changes and forgot to take them out before we merged last time :facepalm: 

It's probably a good idea to run the script with these lines uncommented again before merging. I already did and it was all good on my end.