### PR TITLE
Hook no dupes

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -23,6 +23,7 @@
 #include <apt-pkg/policy.h>
 #include <apt-pkg/strutl.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -152,30 +153,34 @@ static void check_esm_upgrade(pkgCache::PkgIterator pkg, pkgPolicy *policy, resu
       {
          if (pf.File().Archive() != 0 && pf.File().Origin() == std::string("UbuntuESM"))
          {
-            res.esm_i_packages.push_back(pkg.Name());
+            if (std::find(res.esm_i_packages.begin(), res.esm_i_packages.end(), pkg.Name()) == res.esm_i_packages.end()) {
+                res.esm_i_packages.push_back(pkg.Name());
 
-            // Pin-Priority: never unauthenticated APT repos == -32768
-            if (policy->GetPriority(pf.File()) == -32768)
-            {
-               res.disabled_esms_i++;
-            }
-            else
-            {
-               res.enabled_esms_i++;
+                // Pin-Priority: never unauthenticated APT repos == -32768
+                if (policy->GetPriority(pf.File()) == -32768)
+                {
+                   res.disabled_esms_i++;
+                }
+                else
+                {
+                   res.enabled_esms_i++;
+                }
             }
          }
          if (pf.File().Archive() != 0 && pf.File().Origin() == std::string("UbuntuESMApps"))
          {
-            res.esm_a_packages.push_back(pkg.Name());
+            if (std::find(res.esm_a_packages.begin(), res.esm_a_packages.end(), pkg.Name()) == res.esm_a_packages.end()) {
+                res.esm_a_packages.push_back(pkg.Name());
 
-            // Pin-Priority: never unauthenticated APT repos == -32768
-            if (policy->GetPriority(pf.File()) == -32768)
-            {
-               res.disabled_esms_a++;
-            }
-            else
-            {
-               res.enabled_esms_a++;
+                // Pin-Priority: never unauthenticated APT repos == -32768
+                if (policy->GetPriority(pf.File()) == -32768)
+                {
+                   res.disabled_esms_a++;
+                }
+                else
+                {
+                   res.enabled_esms_a++;
+                }
             }
          }
       }

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -88,7 +88,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         \*Your UA Infra: ESM subscription has EXPIRED\*
 
-        \d+ additional security updates could have been applied via UA Infra: ESM.
+        \d+ additional security update\(s\) could have been applied via UA Infra: ESM.
 
         Renew your UA services at https:\/\/ubuntu.com\/esm
 
@@ -106,8 +106,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         \*Your UA Infra: ESM subscription has EXPIRED\*
         Enabling UA Infra: ESM service would provide security updates for following
         packages:
-          .*libkrad.*
-        \d+ esm-infra security updates NOT APPLIED. Renew your UA services at
+          libkrad0
+        1 esm-infra security update\(s\) NOT APPLIED. Renew your UA services at
         https:\/\/ubuntu.com\/advantage
 
         """

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -415,7 +415,7 @@ Your grace period will expire in {remaining_days} days.
 MESSAGE_CONTRACT_EXPIRED_MOTD_PKGS_TMPL = """\
 *Your {title} subscription has EXPIRED*
 
-{pkg_num} additional security updates could have been applied via {title}.
+{pkg_num} additional security update(s) could have been applied via {title}.
 
 Renew your UA services at {url}
 """
@@ -425,7 +425,7 @@ MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL = """\
 Enabling {title} service would provide security updates for following
 packages:
   {pkg_names}
-{pkg_num} {name} security updates NOT APPLIED. Renew your UA services at
+{pkg_num} {name} security update(s) NOT APPLIED. Renew your UA services at
 {url}
 """
 


### PR DESCRIPTION
## Proposed Commit Message
    apt-hook: avoid reporting and counting duplicate package names
    
    Only track unique named package upgrades in ESM.
    Both esm -updates and esm-security pockets can contain same
    packages. Avoid counting duplicates.
    
    Fixes: #1578

- messages: add optional (s) to apt messaging to include singular/plural pkgs


## Test Steps
```bash
UACLIENT_BEHAVE_DESTROY_INSTANCES=0 UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_CONTRACT_TOKEN=<YOUR_CONTRACT_TOKEN> tox -e behave-lxd-16.04 features/attach_validtoken.feature:117
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
