### PR TITLE
status: do not show info if not on contract

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -677,14 +677,19 @@ def _attach_with_token(
         cfg.status()  # Persist updated status in the event of partial attach
         config.update_ua_messages(cfg)
         return 1
+
     contract_name = cfg.machine_token["machineTokenInfo"]["contractInfo"][
         "name"
     ]
-    print(
-        ua_status.MESSAGE_ATTACH_SUCCESS_TMPL.format(
-            contract_name=contract_name
+
+    if contract_name:
+        print(
+            ua_status.MESSAGE_ATTACH_SUCCESS_TMPL.format(
+                contract_name=contract_name
+            )
         )
-    )
+    else:
+        print(ua_status.MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME)
 
     config.update_ua_messages(cfg)
     action_status(args=None, cfg=cfg)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -548,12 +548,19 @@ def format_tabular(status: "Dict[str, Any]") -> str:
             )
         )
     content.append("\nEnable services with: ua enable <service>")
-    pairs = [
-        ("Account", status["account"]),
-        ("Subscription", status["subscription"]),
-    ]
+    pairs = []
+
+    if status["account"]:
+        pairs.append(("Account", status["account"]))
+
+    if status["subscription"]:
+        pairs.append(("Subscription", status["subscription"]))
+
     if status["origin"] != "free":
         pairs.append(("Valid until", str(status["expires"])))
         pairs.append(("Technical support level", colorize(tech_support_level)))
-    content.extend(get_section_column_content(column_data=pairs))
+
+    if pairs:
+        content.extend(get_section_column_content(column_data=pairs))
+
     return "\n".join(content)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -332,6 +332,9 @@ Failed to enable default services, check: sudo ua status"""
 MESSAGE_ATTACH_SUCCESS_TMPL = """\
 This machine is now attached to '{contract_name}'
 """
+MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME = """\
+This machine is now successfully attached'
+"""
 
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} unknown service '{name}'.


### PR DESCRIPTION
## Proposed Commit Message
status: do not show info if not on contract

When running status on an attached machine, we present the account and subscription info in the the end. However, if the contract does not have that info, we will present them as empty. We are now updating the status to not show that info at the end if it is not present in the contract.

Fixes: #1592

## Test Steps
Run the modified unit test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
