### PR TITLE
logging: remove tracebacks for UserFacingErrors

### DIFF
--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -78,7 +78,7 @@ def fix_pro_pkg_holds(cfg):
                 try:
                     entitlement.install_packages(cleanup_on_failure=False)
                 except UserFacingError as e:
-                    logging.exception(e)
+                    logging.error(e.msg)
                     logging.warning(
                         "Failed to install packages at boot: {}".format(
                             ", ".join(entitlement.packages)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1004,7 +1004,7 @@ def main_error_handler(func):
             return func(*args, **kwargs)
         except KeyboardInterrupt:
             with util.disable_log_to_console():
-                logging.exception("KeyboardInterrupt")
+                logging.error("KeyboardInterrupt")
             print("Interrupt received; exiting.", file=sys.stderr)
             if _CLEAR_LOCK_FILE:
                 _CLEAR_LOCK_FILE("lock")
@@ -1023,7 +1023,7 @@ def main_error_handler(func):
             sys.exit(1)
         except exceptions.UserFacingError as exc:
             with util.disable_log_to_console():
-                logging.exception(exc.msg)
+                logging.error(exc.msg)
             print("{}".format(exc.msg), file=sys.stderr)
             if _CLEAR_LOCK_FILE:
                 if not isinstance(exc, exceptions.LockHeldError):

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -262,7 +262,7 @@ def process_entitlements_delta(
         except exceptions.UserFacingError:
             delta_error = True
             with util.disable_log_to_console():
-                logging.exception(
+                logging.error(
                     "Failed to process contract delta for {name}:"
                     " {delta}".format(name=name, delta=new_entitlement)
                 )


### PR DESCRIPTION
## Proposed Commit Message

> logging: remove tracebacks for UserFacingErrors
> 
> UserFacingErrors are used for known situations that
> our code can handle and present the correct message to
> the user. They are not truly "exceptional" and do not
> warrant printing a traceback when they occur. This commit
> changes our logging of these types of errors to continue
> to use the ERROR logging level but no longer include
> tracebacks.
> 
> Fixes: #1586

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

To reproduce:
On a xenial container you'll get tracebacks in logs for several things
```
apt update && apt upgrade
ua detach
# check log for traceback
ua attach # no token
# check log for traceback
ua attach <token>
ua attach <token>
# check log for traceback
ua enable esm-apps
# check log for traceback
```

To see fix, install this version and run through the above steps. You should still see error messages, but no tracebacks.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
