### PR TITLE
enable: correct messaging for beta service

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -94,6 +94,13 @@ Feature: Enable command behaviour when attached to an UA staging subscription
 
         esm-infra(-no)? \d+.*
         """
+        When I verify that running `ua enable esm-apps` `with sudo` exits `1`
+        Then stdout matches regexp
+        """
+        One moment, checking your subscription first
+        UA Apps: ESM is already enabled.
+        See: sudo ua status
+        """
 
         Examples: ubuntu release
            | release | apps-pkg |
@@ -369,6 +376,13 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         And stdout matches regexp:
         """
         \s* 500 https://esm.staging.ubuntu.com/cis/ubuntu <release>/main amd64 Packages
+        """
+        When I verify that running `ua enable cis` `with sudo` exits `1`
+        Then stdout matches regexp
+        """
+        One moment, checking your subscription first
+        CIS Audit is already enabled.
+        See: sudo ua status
         """
 
         Examples: not entitled services

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -12,8 +12,8 @@ except ImportError:
 class ESMBaseEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/security/esm"
 
-    def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
-        enable_performed = super().enable(
+    def _perform_enable(self, *, silent_if_inapplicable: bool = False) -> bool:
+        enable_performed = super()._perform_enable(
             silent_if_inapplicable=silent_if_inapplicable
         )
         if enable_performed:

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -328,8 +328,10 @@ class FIPSEntitlement(FIPSCommonEntitlement):
             )
         super().setup_apt_config()
 
-    def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
-        if super().enable(silent_if_inapplicable=silent_if_inapplicable):
+    def _perform_enable(self, *, silent_if_inapplicable: bool = False) -> bool:
+        if super()._perform_enable(
+            silent_if_inapplicable=silent_if_inapplicable
+        ):
             self.cfg.remove_notice("", status.MESSAGE_FIPS_INSTALL_OUT_OF_DATE)
             return True
         return False

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -76,7 +76,8 @@ class LivepatchEntitlement(base.UAEntitlement):
 
         @return: True on success, False otherwise.
         """
-        if not self.can_enable(silent=silent_if_inapplicable):
+        can_enable, _ = self.can_enable(silent=silent_if_inapplicable)
+        if not can_enable:
             return False
         if not util.which("/snap/bin/canonical-livepatch"):
             if not util.which(SNAP_CMD):

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -67,7 +67,7 @@ class LivepatchEntitlement(base.UAEntitlement):
             ),
         )
 
-    def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
+    def _perform_enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.
 
         :param silent_if_inapplicable:
@@ -76,9 +76,6 @@ class LivepatchEntitlement(base.UAEntitlement):
 
         @return: True on success, False otherwise.
         """
-        can_enable, _ = self.can_enable(silent=silent_if_inapplicable)
-        if not can_enable:
-            return False
         if not util.which("/snap/bin/canonical-livepatch"):
             if not util.which(SNAP_CMD):
                 print("Installing snapd")

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -107,7 +107,8 @@ class RepoEntitlement(base.UAEntitlement):
         msg_ops = self.messaging.get("pre_enable", [])
         if not handle_message_operations(msg_ops):
             return False
-        if not self.can_enable(silent=silent_if_inapplicable):
+        can_enable, _ = self.can_enable(silent=silent_if_inapplicable)
+        if not can_enable:
             return False
         self.setup_apt_config()
         if self.packages:

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -44,7 +44,7 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         )
         return self._disable
 
-    def enable(self, silent_if_inapplicable: bool = False):
+    def _perform_enable(self, silent_if_inapplicable: bool = False):
         return self._enable
 
     def applicability_status(self):
@@ -100,8 +100,8 @@ class TestUaEntitlement:
             base.UAEntitlement()
         expected_msg = (
             "Can't instantiate abstract class UAEntitlement with abstract"
-            " methods application_status, description, disable, enable, name,"
-            " title"
+            " methods _perform_enable, application_status, description,"
+            " disable, name, title"
         )
         assert expected_msg == str(excinfo.value)
 

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -97,7 +97,7 @@ class TestCommonCriteriaEntitlementCanEnable:
         assert status.UserFacingStatus.INACTIVE == uf_status
         details = "{} is not configured".format(entitlement.title)
         assert details == uf_status_details
-        assert True is entitlement.can_enable()
+        assert (True, None) == entitlement.can_enable()
         assert ("", "") == capsys.readouterr()
 
 

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -233,7 +233,7 @@ class TestESMInfraEntitlementEnable:
                 mock.patch.object(type(entitlement), "packages", m_packages)
             )
 
-            m_can_enable.return_value = True
+            m_can_enable.return_value = (True, None)
 
             assert True is entitlement.enable()
 
@@ -334,7 +334,7 @@ class TestESMInfraEntitlementEnable:
                 mock.patch("uaclient.apt.os.unlink")
             )
 
-            m_can_enable.return_value = True
+            m_can_enable.return_value = (True, None)
 
             with pytest.raises(exceptions.UserFacingError) as excinfo:
                 entitlement.enable()

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -122,7 +122,7 @@ class TestFIPSEntitlementCanEnable:
                 "application_status",
                 return_value=(status.ApplicationStatus.DISABLED, ""),
             ):
-                assert True is entitlement.can_enable()
+                assert (True, None) == entitlement.can_enable()
         assert ("", "") == capsys.readouterr()
 
 
@@ -157,7 +157,7 @@ class TestFIPSEntitlementEnable:
                 mock.patch.object(type(entitlement), "packages", m_packages)
             )
 
-            m_can_enable.return_value = True
+            m_can_enable.return_value = (True, None)
 
             assert True is entitlement.enable()
 
@@ -255,7 +255,9 @@ class TestFIPSEntitlementEnable:
         self, m_platform_info, entitlement
     ):
         """When can_enable is false enable returns false and noops."""
-        with mock.patch.object(entitlement, "can_enable", return_value=False):
+        with mock.patch.object(
+            entitlement, "can_enable", return_value=(False, None)
+        ):
             with mock.patch(M_REPOPATH + "handle_message_operations"):
                 assert False is entitlement.enable()
         assert 0 == m_platform_info.call_count
@@ -270,7 +272,9 @@ class TestFIPSEntitlementEnable:
         """When directives do not contain suites returns false."""
         entitlement = fips_entitlement_factory(suites=[])
 
-        with mock.patch.object(entitlement, "can_enable", return_value=True):
+        with mock.patch.object(
+            entitlement, "can_enable", return_value=(True, None)
+        ):
             with mock.patch(M_REPOPATH + "handle_message_operations"):
                 with pytest.raises(exceptions.UserFacingError) as excinfo:
                     entitlement.enable()
@@ -291,7 +295,11 @@ class TestFIPSEntitlementEnable:
             m_add_pinning = stack.enter_context(
                 mock.patch("uaclient.apt.add_ppa_pinning")
             )
-            stack.enter_context(mock.patch.object(entitlement, "can_enable"))
+            stack.enter_context(
+                mock.patch.object(
+                    entitlement, "can_enable", return_value=(True, None)
+                )
+            )
             stack.enter_context(
                 mock.patch(M_REPOPATH + "handle_message_operations")
             )
@@ -330,7 +338,9 @@ class TestFIPSEntitlementEnable:
                 mock.patch("uaclient.util.subp", side_effect=fake_subp)
             )
             stack.enter_context(
-                mock.patch.object(entitlement, "can_enable", return_value=True)
+                mock.patch.object(
+                    entitlement, "can_enable", return_value=(True, None)
+                )
             )
             stack.enter_context(
                 mock.patch(M_REPOPATH + "handle_message_operations")

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -144,7 +144,7 @@ class TestFIPSEntitlementEnable:
                 mock.patch.object(entitlement, "can_enable")
             )
             stack.enter_context(
-                mock.patch(M_REPOPATH + "handle_message_operations")
+                mock.patch("uaclient.util.handle_message_operations")
             )
             stack.enter_context(
                 mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
@@ -233,7 +233,7 @@ class TestFIPSEntitlementEnable:
             (False, []),
         ],
     )
-    @mock.patch("uaclient.entitlements.repo.RepoEntitlement.enable")
+    @mock.patch("uaclient.entitlements.repo.RepoEntitlement._perform_enable")
     @mock.patch("uaclient.config.UAConfig.remove_notice")
     def test_enable_removes_out_of_date_notice_on_success(
         self,
@@ -245,7 +245,7 @@ class TestFIPSEntitlementEnable:
     ):
         m_repo_enable.return_value = repo_enable_return_value
         fips_entitlement = entitlement_factory(FIPSEntitlement)
-        assert repo_enable_return_value is fips_entitlement.enable()
+        assert repo_enable_return_value is fips_entitlement._perform_enable()
         assert expected_remove_notice_calls == m_remove_notice.call_args_list
 
     @mock.patch(
@@ -258,7 +258,7 @@ class TestFIPSEntitlementEnable:
         with mock.patch.object(
             entitlement, "can_enable", return_value=(False, None)
         ):
-            with mock.patch(M_REPOPATH + "handle_message_operations"):
+            with mock.patch("uaclient.util.handle_message_operations"):
                 assert False is entitlement.enable()
         assert 0 == m_platform_info.call_count
 
@@ -275,7 +275,7 @@ class TestFIPSEntitlementEnable:
         with mock.patch.object(
             entitlement, "can_enable", return_value=(True, None)
         ):
-            with mock.patch(M_REPOPATH + "handle_message_operations"):
+            with mock.patch("uaclient.util.handle_message_operations"):
                 with pytest.raises(exceptions.UserFacingError) as excinfo:
                     entitlement.enable()
         error_msg = "Empty {} apt suites directive from {}".format(
@@ -301,7 +301,7 @@ class TestFIPSEntitlementEnable:
                 )
             )
             stack.enter_context(
-                mock.patch(M_REPOPATH + "handle_message_operations")
+                mock.patch("uaclient.util.handle_message_operations")
             )
             m_remove_apt_config = stack.enter_context(
                 mock.patch.object(entitlement, "remove_apt_config")
@@ -343,7 +343,7 @@ class TestFIPSEntitlementEnable:
                 )
             )
             stack.enter_context(
-                mock.patch(M_REPOPATH + "handle_message_operations")
+                mock.patch("uaclient.util.handle_message_operations")
             )
             stack.enter_context(
                 mock.patch.object(
@@ -371,7 +371,7 @@ class TestFIPSEntitlementEnable:
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.is_config_value_true", return_value=False)
     @mock.patch("uaclient.util.prompt_for_confirmation", return_value=False)
-    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_livepatch_service_is_enabled(
         self,
@@ -408,7 +408,7 @@ class TestFIPSEntitlementEnable:
         )
         assert expected_msg.strip() in fake_stdout.getvalue().strip()
 
-    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch(
         M_LIVEPATCH_PATH + "application_status",
         return_value=((status.ApplicationStatus.DISABLED, "")),
@@ -445,7 +445,7 @@ class TestFIPSEntitlementEnable:
 
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.entitlements.fips.get_cloud_type")
-    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_on_xenial_cloud_instance(
         self,
@@ -475,7 +475,7 @@ class TestFIPSEntitlementEnable:
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.is_config_value_true", return_value=False)
     @mock.patch("uaclient.entitlements.fips.get_cloud_type")
-    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_on_gcp_instance_with_default_fips(
         self,
@@ -634,7 +634,7 @@ class TestFIPSEntitlementRemovePackages:
         assert exc_info.value.msg.strip() == expected_msg
 
 
-@mock.patch(M_REPOPATH + "handle_message_operations", return_value=True)
+@mock.patch("uaclient.util.handle_message_operations", return_value=True)
 @mock.patch("uaclient.util.should_reboot", return_value=True)
 @mock.patch(
     "uaclient.util.get_platform_info", return_value={"series": "xenial"}

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -687,7 +687,7 @@ class TestLivepatchEntitlementEnable:
             ("FIPSUpdatesEntitlement", "FIPS Updates"),
         ),
     )
-    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch("uaclient.util.is_container", return_value=False)
     def test_enable_fails_when_blocking_service_is_enabled(
         self,
@@ -750,7 +750,7 @@ class TestLivepatchEntitlementEnable:
         fake_stdout = io.StringIO()
 
         with mock.patch.object(entitlement, "can_enable") as m_can_enable:
-            m_can_enable.return_value = True
+            m_can_enable.return_value = (True, None)
             with mock.patch.object(
                 entitlement, "setup_livepatch_config"
             ) as m_setup_livepatch:
@@ -786,7 +786,7 @@ class TestLivepatchEntitlementEnable:
         )
 
         with mock.patch.object(entitlement, "can_enable") as m_can_enable:
-            m_can_enable.return_value = True
+            m_can_enable.return_value = (True, None)
             with mock.patch.object(
                 entitlement, "setup_livepatch_config"
             ) as m_setup_livepatch:

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -393,7 +393,9 @@ class TestProcessContractDeltas:
 
 class TestRepoEnable:
     @pytest.mark.parametrize("silent_if_inapplicable", (True, False, None))
-    @mock.patch.object(RepoTestEntitlement, "can_enable", return_value=False)
+    @mock.patch.object(
+        RepoTestEntitlement, "can_enable", return_value=(False, None)
+    )
     def test_enable_passes_silent_if_inapplicable_through(
         self, m_can_enable, caplog_text, tmpdir, silent_if_inapplicable
     ):
@@ -416,7 +418,9 @@ class TestRepoEnable:
             (["msg1", (lambda: True, {}), "msg2"], "msg1\nmsg2\n", 1),
         ),
     )
-    @mock.patch.object(RepoTestEntitlement, "can_enable", return_value=False)
+    @mock.patch.object(
+        RepoTestEntitlement, "can_enable", return_value=(False, None)
+    )
     def test_enable_can_exit_on_pre_enable_messaging_hooks(
         self,
         m_can_enable,
@@ -497,7 +501,9 @@ class TestRepoEnable:
     @mock.patch(M_PATH + "apt.add_auth_apt_repo")
     @mock.patch(M_PATH + "os.path.exists", return_value=True)
     @mock.patch(M_PATH + "util.get_platform_info")
-    @mock.patch.object(RepoTestEntitlement, "can_enable", return_value=True)
+    @mock.patch.object(
+        RepoTestEntitlement, "can_enable", return_value=(True, None)
+    )
     def test_enable_calls_adds_apt_repo_and_calls_apt_update(
         self,
         m_can_enable,
@@ -614,7 +620,7 @@ class TestRepoEnable:
         packages = ["fake_pkg", "and_another"]
         with mock.patch.object(entitlement, "setup_apt_config"):
             with mock.patch.object(
-                entitlement, "can_enable", return_value=True
+                entitlement, "can_enable", return_value=(True, None)
             ):
                 with mock.patch.object(
                     type(entitlement), "packages", packages

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -6,10 +6,7 @@ from types import MappingProxyType
 
 from uaclient import apt
 from uaclient import config
-from uaclient.entitlements.repo import (
-    RepoEntitlement,
-    handle_message_operations,
-)
+from uaclient.entitlements.repo import RepoEntitlement
 from uaclient.entitlements.tests.conftest import machine_token
 from uaclient import exceptions
 from uaclient import status
@@ -1043,6 +1040,6 @@ class TestHandleMessageOperations:
     def test_handle_message_operations_for_strings_and_callables(
         self, msg_ops, retval, output, capsys
     ):
-        assert retval is handle_message_operations(msg_ops)
+        assert retval is util.handle_message_operations(msg_ops)
         out, _err = capsys.readouterr()
         assert output == out

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -100,6 +100,19 @@ class UserFacingStatus(enum.Enum):
     UNAVAILABLE = "—"
 
 
+@enum.unique
+class CanEnableFailureReason(enum.Enum):
+    """
+    An enum representing the reasons an entitlement can't be enabled.
+    """
+
+    NOT_ENTITLED = object()
+    ALREADY_ENABLED = object()
+    INAPPLICABLE = object()
+    IS_BETA = object()
+    INCOMPATIBLE_SERVICE = object()
+
+
 ESSENTIAL = "essential"
 STANDARD = "standard"
 ADVANCED = "advanced"

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -23,6 +23,7 @@ REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
 try:
     from typing import (  # noqa: F401
         Any,
+        Callable,
         Dict,
         List,
         Mapping,
@@ -729,3 +730,25 @@ def is_installed(package_name: str) -> bool:
         return "ii  {} ".format(package_name) in out
     except ProcessExecutionError:
         return False
+
+
+def handle_message_operations(
+    msg_ops: "List[Union[str, Tuple[Callable, Dict]]]"
+) -> bool:
+    """Emit messages to the console for user interaction
+
+    :param msg_op: A list of strings or tuples. Any string items are printed.
+        Any tuples will contain a callable and a dict of args to pass to the
+        callable. Callables are expected to return True on success and
+        False upon failure.
+
+    :return: True upon success, False on failure.
+    """
+    for msg_op in msg_ops:
+        if isinstance(msg_op, str):
+            print(msg_op)
+        else:  # Then we are a callable and dict of args
+            functor, args = msg_op
+            if not functor(**args):
+                return False
+    return True


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> enable: correct messaging for beta service
>
> Previously, if the user tried to enable a beta service
> that was already enabled without using --beta, they
> would get incorrect messaging. Now they are correctly
> told that the service is already enabled.
> 
> Fixes: #1588

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Enable a beta service such as esm-apps
Then run `ua enable esm-apps` without the `--beta` flag.
Verify that the output correctly states that esm-apps is already enabled.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
