### PR TITLE
livepatch: alert when snapd does not have wait cmd

### DIFF
--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -251,6 +251,11 @@ MESSAGE_REBOOT_SCRIPT_FAILED = (
 MESSAGE_LIVEPATCH_LTS_REBOOT_REQUIRED = (
     "Livepatch support requires a system reboot across LTS upgrade."
 )
+MESSAGE_SNAPD_DOES_NOT_HAVE_WAIT_CMD = (
+    "snapd does not have wait command.\n"
+    "Enabling Livepatch can fail under this scenario\n"
+    "Please, upgrade snapd if Livepatch enable fails and try again."
+)
 MESSAGE_FIPS_INSTALL_OUT_OF_DATE = (
     "This FIPS install is out of date, run: sudo ua enable fips"
 )


### PR DESCRIPTION
## Proposed Commit Message
livepatch: alert when snapd does not have wait cmd

When enablig livepatch, we run a snapd wait operation before
installing the canonical-livepatch snap. On older system that did
not upgrade snapd, the wait command may not be available. In that
situation, enabling livepatch will fail. We are now updating the code
to alert the user about this situation, but we proceed with enabling
livepatch.

LP: #1927905

## Test Steps
Run the new unit test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
