### PR TITLE
Block enabling fips if fips-updates once enabled

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -259,6 +259,12 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             """
             <fips-service> +yes                disabled
             """
+        When I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
+        Then stdout matches regexp:
+            """
+            Cannot enable FIPS because FIPS Updates was once enabled.
+            """
+        And I verify that files exist matching `/var/lib/ubuntu-advantage/services-once-enabled`
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                                        |

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -68,6 +68,7 @@ class UAConfig:
         "status-cache": DataPath("status.json", False),
         "notices": DataPath("notices.json", False),
         "marker-reboot-cmds": DataPath("marker-reboot-cmds-required", False),
+        "services-once-enabled": DataPath("services-once-enabled", False),
     }  # type: Dict[str, DataPath]
 
     _entitlements = None  # caching to avoid repetitive file reads

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -100,21 +100,28 @@ def entitlement_factory(tmpdir):
         allow_beta: bool = False,
         assume_yes: "Optional[bool]" = None,
         suites: "List[str]" = None,
-        additional_packages: "List[str]" = None
+        additional_packages: "List[str]" = None,
+        services_once_enabled: "Dict[str, bool]" = None,
+        cfg: "Optional[config.UAConfig]" = None
     ):
-        cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
-        cfg.write_cache(
-            "machine-token",
-            machine_token(
-                cls.name,
-                affordances=affordances,
-                directives=directives,
-                obligations=obligations,
-                entitled=entitled,
-                suites=suites,
-                additional_packages=additional_packages,
-            ),
-        )
+        if not cfg:
+            cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
+            cfg.write_cache(
+                "machine-token",
+                machine_token(
+                    cls.name,
+                    affordances=affordances,
+                    directives=directives,
+                    obligations=obligations,
+                    entitled=entitled,
+                    suites=suites,
+                    additional_packages=additional_packages,
+                ),
+            )
+
+        if services_once_enabled:
+            cfg.write_cache("services-once-enabled", services_once_enabled)
+
         args = {"allow_beta": allow_beta}
         if assume_yes is not None:
             args["assume_yes"] = assume_yes


### PR DESCRIPTION
## Proposed Commit Message
Block enabling fips if fips-updates once enabled

When fips-updates is enabled in the system, we emit a file that will allows us to kept track of this status. This will be necessary if an user disables fips-updates and tries to enable fips. In that scenario, we cannot allow users to enable fips.

Fixes: #1600

## Test Steps
Run the modified integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
