### PR TITLE
errors: print a more helpful message when ssl fails

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -196,6 +196,36 @@ Feature: Command behaviour when unattached
            | groovy   | no           |
            | hirsute  | no           |
 
+
+    @series.all
+    Scenario Outline: Useful SSL failure message when there aren't any ca-certs
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt remove ca-certificates -y` with sudo
+        When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
+        Then I will see the following on stderr:
+            """
+            Failed to access URL: https://ubuntu.com/security/cves/CVE-1800-123456.json
+            Cannot verify certificate of server
+            Please install "ca-certificates" and try again.
+            """
+        When I run `apt install ca-certificates -y` with sudo
+        When I run `mv /etc/ssl/certs /etc/ssl/wronglocation` with sudo
+        When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
+        Then I will see the following on stderr:
+            """
+            Failed to access URL: https://ubuntu.com/security/cves/CVE-1800-123456.json
+            Cannot verify certificate of server
+            Please check your openssl configuration.
+            """
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | groovy  |
+           | hirsute |
+
+
     @series.focal
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1006,14 +1006,24 @@ def main_error_handler(func):
                 _CLEAR_LOCK_FILE("lock")
             sys.exit(1)
         except util.UrlError as exc:
-            with util.disable_log_to_console():
-                msg_args = {"url": exc.url, "error": exc}
-                if exc.url:
-                    msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL
-                else:
-                    msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_TMPL
-                logging.exception(msg_tmpl.format(**msg_args))
-            print(ua_status.MESSAGE_CONNECTIVITY_ERROR, file=sys.stderr)
+            if "CERTIFICATE_VERIFY_FAILED" in str(exc):
+                tmpl = ua_status.MESSAGE_SSL_VERIFICATION_ERROR_CA_CERTIFICATES
+                if util.is_installed("ca-certificates"):
+                    tmpl = (
+                        ua_status.MESSAGE_SSL_VERIFICATION_ERROR_OPENSSL_CONFIG
+                    )
+                print(tmpl.format(url=exc.url), file=sys.stderr)
+            else:
+                with util.disable_log_to_console():
+                    msg_args = {"url": exc.url, "error": exc}
+                    if exc.url:
+                        msg_tmpl = (
+                            ua_status.LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL
+                        )
+                    else:
+                        msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_TMPL
+                    logging.exception(msg_tmpl.format(**msg_args))
+                print(ua_status.MESSAGE_CONNECTIVITY_ERROR, file=sys.stderr)
             if _CLEAR_LOCK_FILE:
                 _CLEAR_LOCK_FILE("lock")
             sys.exit(1)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -186,6 +186,14 @@ LOG_CONNECTIVITY_ERROR_TMPL = MESSAGE_CONNECTIVITY_ERROR + " {error}"
 LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (
     MESSAGE_CONNECTIVITY_ERROR + " Failed to access URL: {url}. {error}"
 )
+MESSAGE_SSL_VERIFICATION_ERROR_CA_CERTIFICATES = """\
+Failed to access URL: {url}
+Cannot verify certificate of server
+Please install "ca-certificates" and try again."""
+MESSAGE_SSL_VERIFICATION_ERROR_OPENSSL_CONFIG = """\
+Failed to access URL: {url}
+Cannot verify certificate of server
+Please check your openssl configuration."""
 MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)."
 MESSAGE_ALREADY_DISABLED_TMPL = """\
 {title} is not currently enabled\nSee: sudo ua status"""

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -719,3 +719,11 @@ def redact_sensitive_logs(
 def should_reboot() -> bool:
     """Check if the system needs to be rebooted."""
     return os.path.exists(REBOOT_FILE_CHECK_PATH)
+
+
+def is_installed(package_name: str) -> bool:
+    try:
+        out, _ = subp(["dpkg", "-l", package_name])
+        return "ii  {} ".format(package_name) in out
+    except ProcessExecutionError:
+        return False


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> errors: print a more helpful message when ssl fails
> 
> Fixes: #1618

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
* In some way, mess with ssl's ability to verify a certificate.
    * For example, uninstall `ca-certificates`
* Try to run any `ua` command that talks to the network (attach, fix, etc.)
* Verify that a descriptive and actionable message is printed

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
