### PR TITLE
Release 27 lintian warnings

### DIFF
--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -27,7 +27,7 @@ hook: hook.cc
 	$(CXX) -Wall -Wextra -pedantic -std=c++11 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
 
 json-hook:
-	[ $(SKIP_GO_HOOK) ] || (cd json-hook-src && GOCACHE=/tmp/ $(GO_BIN) build json-hook.go)
+	[ $(SKIP_GO_HOOK) ] || (cd json-hook-src && GOCACHE=/tmp/ $(GO_BIN) build -buildmode=pie -ldflags -extldflags=-z,relro json-hook.go)
 
 install: hook json-hook
 	install -D -m 644 20apt-esm-hook.conf $(DESTDIR)/etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,24 +8,27 @@ ubuntu-advantage-tools (27.0.2) impish; urgency=medium
     - apt-hook: refactor json hook messaging to be dry
     - tests: fix subp ls error case for powerpc builds
     - jenkinsfile: add --resolve-alternatives for trusty builds
+    - amend changelog: add omitted apt-hook message for 27.0.1 stanza
 
  -- Chad Smith <chad.smith@canonical.com>  Fri, 07 May 2021 11:58:03 -0600
 
 ubuntu-advantage-tools (27.0.1) impish; urgency=medium
 
   * Add .gitignore and cleanup ignored directory .pytest_cache
+  * apt-hook: mitigate failures with true
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 07 May 2021 11:55:07 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 28 Apr 2021 13:55:28 -0600
 
 ubuntu-advantage-tools (27.0) impish; urgency=medium
 
   * New upstream release 27.0:
-    - apt-hook: mitigate failures with true
+    - [redacted: actually landed in 27.0.1] apt-hook: mitigate failures with
+      true
     - messages: add optional (s) to apt messaging to include
       singular/plural pkgs
     - apt-hook: avoid reporting and counting duplicate package
       names (GH: #1578)
-    - fix: dont say reboot required when unnecessary (LP: #1926183)
+    - fix: don't say reboot required when unnecessary (LP: #1926183)
     - test: uncomment additional xenial upgrade tests
 
  -- Lucas Moura <lucas.moura@canonical.com>  Tue, 27 Apr 2021 15:31:06 -0300
@@ -409,9 +412,9 @@ ubuntu-advantage-tools (25.0~20.10.1~beta) groovy; urgency=medium
 ubuntu-advantage-tools (24.4) groovy; urgency=medium
 
   * New bug-fix-only release 24.4:
-     - uaclient.version bump to 24.4
-     - fips: honor additionalPackage directive from contract for bionic
-       (GH #1173)
+    - uaclient.version bump to 24.4
+    - fips: honor additionalPackage directive from contract for bionic
+      (GH #1173)
 
  -- Chad Smith <chad.smith@canonical.com>  Tue, 01 Sep 2020 11:14:39 -0600
 

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -3,3 +3,6 @@ ubuntu-advantage-tools: maintainer-script-calls-service postinst:*
 
 # Ubuntu doesn't require init.d scripts
 ubuntu-advantage-tools: package-supports-alternative-init-but-no-init.d-script
+
+# Avoid warning on wanted-by-target
+ubuntu-advantage-pro: systemd-service-file-refers-to-unusual-wantedby-target


### PR DESCRIPTION
#wip will update with content for what was released to impish

Sync changelog for what we just released in packaging branches on impish for 27.0.2

- Fix a number of lintian warnings as part of upload review and apt-json-hook compile time flags
- Also ignore lintian ubuntu-advantage-pro: systemd-service-file-refers-to-unusual-wantedby-target lib/systemd/system/ua-auto-attach.service cloud-config.service


Plan is to propose this PR back up into main after landing in release-27 to sync commits back up to tip

## Proposed Commit Message

-     lintian: override ubuntu-advantage-pro wanted-by-target cloud-init
    
    Silence warning for pro wanted-by-target cloud-init.service.

- apt-json-hook: fix lintian warnings based on compiled binary
    
    Provide -ldflgas and -buildmod=pie to go build of this hook.
    
    Fixes: #1626

- changelog: sync impish released changelog 27.0.2

 Fixes: #1624

## Test Steps
```bash
build-package
sbuild-it ../out/ubuntu-advantage-tools_27.0.2.dsc
lintian ubuntu-advantage-tools_27.0.2_amd64.deb
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
