### PR TITLE
cis: update cis help url

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -350,7 +350,7 @@ Feature: Enable command behaviour when attached to an UA staging subscription
             Updating package lists
             Installing CIS Audit packages
             CIS Audit enabled
-            Visit https://ubuntu.com/security/cis to learn how to use the CIS packages
+            Visit https://security-certs.docs.ubuntu.com/en/cis to learn how to use CIS
             """
         When I run `apt-cache policy usg-cisbenchmark` as non-root
         Then stdout does not match regexp:

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -6,7 +6,7 @@ except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
 
-CIS_DOCS_URL = "https://ubuntu.com/security/cis"
+CIS_DOCS_URL = "https://security-certs.docs.ubuntu.com/en/cis"
 
 
 class CISEntitlement(repo.RepoEntitlement):
@@ -25,8 +25,6 @@ class CISEntitlement(repo.RepoEntitlement):
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
             "post_enable": [
-                "Visit {} to learn how to use the CIS packages".format(
-                    CIS_DOCS_URL
-                )
+                "Visit {} to learn how to use CIS".format(CIS_DOCS_URL)
             ]
         }

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -107,8 +107,6 @@ class TestCISEntitlementEnable:
             "Updating package lists\n"
             "Installing CIS Audit packages\n"
             "CIS Audit enabled\n"
-            "Visit {} to learn how to use the CIS packages\n".format(
-                CIS_DOCS_URL
-            )
+            "Visit {} to learn how to use CIS\n".format(CIS_DOCS_URL)
         )
         assert (expected_stdout, "") == capsys.readouterr()


### PR DESCRIPTION
## Proposed Commit Message
Update of CIS URL to https://security-certs.docs.ubuntu.com/en/cis until ubuntu.com/security/cis is available

Also add a commit to fix failing integration tests due to messaging url changes for ESM on Xenial https;//ubuntu.com/16-04 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
