### PR TITLE
pro: obtain AWS IMDSv2 API token before trying to grab pkcs7 doc

### DIFF
--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -10,21 +10,50 @@ from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util
 
 
+IMDS_V2_TOKEN_URL = "http://169.254.169.254/latest/api/token"
 IMDS_URL = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
 SYS_HYPERVISOR_PRODUCT_UUID = "/sys/hypervisor/uuid"
 DMI_PRODUCT_SERIAL = "/sys/class/dmi/id/product_serial"
 DMI_PRODUCT_UUID = "/sys/class/dmi/id/product_uuid"
 
+AWS_TOKEN_TTL_SECONDS = "21600"
+AWS_TOKEN_PUT_HEADER = "X-aws-ec2-metadata-token"
+AWS_TOKEN_REQ_HEADER = AWS_TOKEN_PUT_HEADER + "-ttl-seconds"
+
 
 class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
+
+    _api_token = None
 
     # mypy does not handle @property around inner decorators
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
     def identity_doc(self) -> "Dict[str, Any]":
-        response, _headers = util.readurl(IMDS_URL)
+        headers = self._get_imds_v2_token_headers()
+        response, _headers = util.readurl(IMDS_URL, headers=headers)
         return {"pkcs7": response}
+
+    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
+    def _get_imds_v2_token_headers(self):
+        if self._api_token == "IMDSv1":
+            return None
+        elif self._api_token:
+            return {AWS_TOKEN_PUT_HEADER: self._api_token}
+        try:
+            response, _headers = util.readurl(
+                IMDS_V2_TOKEN_URL,
+                method="PUT",
+                headers={AWS_TOKEN_REQ_HEADER: AWS_TOKEN_TTL_SECONDS},
+            )
+        except HTTPError as e:
+            if e.code == 404:
+                self._api_token = "IMDSv1"
+                return None
+            else:
+                raise
+        self._api_token = response
+        return {AWS_TOKEN_PUT_HEADER: self._api_token}
 
     @property
     def cloud_type(self) -> str:

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -5,7 +5,12 @@ from urllib.error import HTTPError
 
 import pytest
 
-from uaclient.clouds.aws import UAAutoAttachAWSInstance
+from uaclient.clouds.aws import (
+    AWS_TOKEN_PUT_HEADER,
+    AWS_TOKEN_REQ_HEADER,
+    AWS_TOKEN_TTL_SECONDS,
+    UAAutoAttachAWSInstance,
+)
 
 M_PATH = "uaclient.clouds.aws."
 
@@ -16,13 +21,95 @@ class TestUAAutoAttachAWSInstance:
         assert "aws" == instance.cloud_type
 
     @mock.patch(M_PATH + "util.readurl")
+    def test__get_imds_v2_token_headers_none_on_404(self, readurl):
+        """A 404 on private AWS regions indicates lack IMDSv2 support."""
+        readurl.side_effect = HTTPError(
+            "http://me", 404, "No IMDSv2 support", None, BytesIO()
+        )
+        instance = UAAutoAttachAWSInstance()
+        assert None is instance._get_imds_v2_token_headers()
+        assert "IMDSv1" == instance._api_token
+        # No retries on 404. It is a permanent indication of no IMDSv2 support.
+        instance._get_imds_v2_token_headers()
+        assert 1 == readurl.call_count
+
+    @mock.patch(M_PATH + "util.readurl")
+    def test__get_imds_v2_token_headers_caches_response(self, readurl):
+        """Return API token headers for IMDSv2 access. Response is cached."""
+        instance = UAAutoAttachAWSInstance()
+        url = "http://169.254.169.254/latest/api/token"
+        readurl.return_value = "somebase64token==", {"header": "stuff"}
+        assert {
+            AWS_TOKEN_PUT_HEADER: "somebase64token=="
+        } == instance._get_imds_v2_token_headers()
+        instance._get_imds_v2_token_headers()
+        assert "somebase64token==" == instance._api_token
+        assert [
+            mock.call(
+                url,
+                method="PUT",
+                headers={AWS_TOKEN_REQ_HEADER: AWS_TOKEN_TTL_SECONDS},
+            )
+        ] == readurl.call_args_list
+
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @pytest.mark.parametrize("fail_count,exception", ((3, False), (4, True)))
+    @mock.patch(M_PATH + "util.time.sleep")
+    @mock.patch(M_PATH + "util.readurl")
+    def test_retry_backoff_on__get_imds_v2_token_headers_caches_response(
+        self, readurl, sleep, fail_count, exception, caplog_text
+    ):
+        """Retry backoff before failing _get_imds_v2_token_headers."""
+
+        def fake_someurlerrors(url, method=None, headers=None):
+            if readurl.call_count <= fail_count:
+                raise HTTPError(
+                    "http://me",
+                    700 + readurl.call_count,
+                    "funky error msg",
+                    None,
+                    BytesIO(),
+                )
+            return "base64token==", {"header": "stuff"}
+
+        readurl.side_effect = fake_someurlerrors
+        instance = UAAutoAttachAWSInstance()
+        if exception:
+            with pytest.raises(HTTPError) as excinfo:
+                instance._get_imds_v2_token_headers()
+            assert 704 == excinfo.value.code
+        else:
+            assert {
+                AWS_TOKEN_PUT_HEADER: "base64token=="
+            } == instance._get_imds_v2_token_headers()
+
+        expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
+        assert expected_sleep_calls == sleep.call_args_list
+        expected_logs = [
+            "HTTP Error 701: funky error msg Retrying 3 more times.",
+            "HTTP Error 702: funky error msg Retrying 2 more times.",
+            "HTTP Error 703: funky error msg Retrying 1 more times.",
+        ]
+        logs = caplog_text()
+        for log in expected_logs:
+            assert log in logs
+
+    @mock.patch(M_PATH + "util.readurl")
     def test_identity_doc_from_aws_url_pkcs7(self, readurl):
         """Return pkcs7 content from IMDS as AWS' identity doc"""
         readurl.return_value = "pkcs7WOOT!==", {"header": "stuff"}
         instance = UAAutoAttachAWSInstance()
         assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
         url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
-        assert [mock.call(url)] == readurl.call_args_list
+        token_url = "http://169.254.169.254/latest/api/token"
+        assert [
+            mock.call(
+                token_url,
+                method="PUT",
+                headers={AWS_TOKEN_REQ_HEADER: AWS_TOKEN_TTL_SECONDS},
+            ),
+            mock.call(url, headers={AWS_TOKEN_PUT_HEADER: "pkcs7WOOT!=="}),
+        ] == readurl.call_args_list
 
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
     @pytest.mark.parametrize("fail_count,exception", ((3, False), (4, True)))
@@ -33,8 +120,11 @@ class TestUAAutoAttachAWSInstance:
     ):
         """Retry backoff is attempted before failing to get AWS.identity_doc"""
 
-        def fake_someurlerrors(url):
-            if readurl.call_count <= fail_count:
+        def fake_someurlerrors(url, method=None, headers=None):
+            # due to _get_imds_v2_token_headers
+            if "latest/api/token" in url:
+                return "base64token==", {"header": "stuff"}
+            if readurl.call_count <= fail_count + 1:
                 raise HTTPError(
                     "http://me",
                     700 + readurl.call_count,
@@ -49,16 +139,16 @@ class TestUAAutoAttachAWSInstance:
         if exception:
             with pytest.raises(HTTPError) as excinfo:
                 instance.identity_doc
-            assert 704 == excinfo.value.code
+            assert 705 == excinfo.value.code
         else:
             assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
 
         expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
         assert expected_sleep_calls == sleep.call_args_list
         expected_logs = [
-            "HTTP Error 701: funky error msg Retrying 3 more times.",
-            "HTTP Error 702: funky error msg Retrying 2 more times.",
-            "HTTP Error 703: funky error msg Retrying 1 more times.",
+            "HTTP Error 702: funky error msg Retrying 3 more times.",
+            "HTTP Error 703: funky error msg Retrying 2 more times.",
+            "HTTP Error 704: funky error msg Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -703,6 +703,8 @@ REDACT_SENSITIVE_LOGS = [
     r"(\'attach\', \')[^\']+",
     r"(\'machineToken\': \')[^\']+",
     r"(\'token\': \')[^\']+",
+    r"(\'X-aws-ec2-metadata-token\': \')[^\']+",
+    r"(.*\[PUT\] response.*api/token,.*data: ).*",
 ]
 
 


### PR DESCRIPTION
## Proposed Commit Message
Avoid 401 Unauthorized errors from IMDSv2 API on AWS by
obtaining an API token from latest/api/token.

The Unauthorized errors result in inability to auto-attach on
Ubuntu PRO instances which are configured at launch to only
allow IMDSv2 traffic.

Use this token with any GET calls to read the pkcs7 metadata
by providing the API token as a header X-aws-ec2-metadata-token.

Some regions may not have IMDSv2 support, in those cases fallback
to using no token.

Also redact this IMDSv2 token from GET and PUT response logs.

Fixes: #1608


## Test Steps
```bash
1. Click the button to launch Ubuntu PRO 18.04 on AWs instance https://ubuntu.com/aws/pro
2. "Continue to subscribe"
3. "Continue to configuration"
4. "Continue to Launch"
5. "Choose Action: Launch through EC2"   # not launch through website   then "Launch"
6.  On ec2 launch configuration  make sure to "Configure instance details" setting "Metadata version"  = "V2 (token required)"

Note that launch will fail to auto-attach to PRO. 
7. you can scp  uaclient/util.py uaclient/clouds/aws.py <AWS_VM>
# on VM
8. sudo cp util.py /usr/lib/python3/dist-packages/uaclient
9. sudo cp aws.py usr/lib/python3/dist-packages/uaclient/clouds
10. sudo ua --debug auto-attach
```

 

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
