### PR TITLE
Fix pytest run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
                 python3 -m venv $TMPDIR
                 . $TMPDIR/bin/activate
                 pip install tox  # for tox supporting --parallel--safe-build
+                pip install tox-pip-version  # To freeze pip version on some tests
                 '''
             }
         }
@@ -67,6 +68,8 @@ pipeline {
                 set +x
                 . $TMPDIR/bin/activate
                 tox --parallel--safe-build -e py3
+                tox --parallel--safe-build -e py3-xenial
+                tox --parallel--safe-build -e py3-bionic
                 '''
             }
         }

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -443,7 +443,7 @@ class TestFIPSEntitlementEnable:
         expected_msg = "Cannot enable FIPS when FIPS Updates is enabled."
         assert expected_msg.strip() == fake_stdout.getvalue().strip()
 
-    @mock.patch("uaclient.entitlements.repo.handle_message_operations")
+    @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch(
         M_LIVEPATCH_PATH + "application_status",
         return_value=((status.ApplicationStatus.DISABLED, "")),


### PR DESCRIPTION
We have a wrong test now that is incorrectly mocking `handle_message_operations`. This PR is fixing that test while also adding pytest runs for xenial and bionic

## Test Steps
Run the modified unittest

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
