### PR TITLE
apt-hook: avoid segfault when comparing null Apt file origin to esm (SC-2)

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -151,7 +151,7 @@ static void check_esm_upgrade(pkgCache::PkgIterator pkg, pkgPolicy *policy, resu
    {
       for (pkgCache::VerFileIterator pf = ver.FileList(); !pf.end(); pf++)
       {
-         if (pf.File().Archive() != 0 && pf.File().Origin() == std::string("UbuntuESM"))
+         if (pf.File().Archive() != 0 && DeNull(pf.File().Origin()) == std::string("UbuntuESM"))
          {
             if (std::find(res.esm_i_packages.begin(), res.esm_i_packages.end(), pkg.Name()) == res.esm_i_packages.end()) {
                 res.esm_i_packages.push_back(pkg.Name());
@@ -167,7 +167,7 @@ static void check_esm_upgrade(pkgCache::PkgIterator pkg, pkgPolicy *policy, resu
                 }
             }
          }
-         if (pf.File().Archive() != 0 && pf.File().Origin() == std::string("UbuntuESMApps"))
+         if (pf.File().Archive() != 0 && DeNull(pf.File().Origin()) == std::string("UbuntuESMApps"))
          {
             if (std::find(res.esm_a_packages.begin(), res.esm_a_packages.end(), pkg.Name()) == res.esm_a_packages.end()) {
                 res.esm_a_packages.push_back(pkg.Name());

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -87,7 +87,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
           +Receive updates to over 30,000 software packages with your
           +Ubuntu Advantage subscription. Free for personal use.
 
-            +https:\/\/ubuntu.com\/esm
+            +https:\/\/ubuntu.com\/16-04
 
         UA Infra: Extended Security Maintenance \(ESM\) is enabled.
 
@@ -98,14 +98,14 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         When I update contract to use `effectiveTo` as `days=-20`
         And I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
         And I run `update-motd` with sudo
-        Then if `<release>` in `xenial or bionic` and stdout matches regexp:
+        Then if `<release>` in `xenial` and stdout matches regexp:
         """
 
         \*Your UA Infra: ESM subscription has EXPIRED\*
 
         \d+ additional security update\(s\) could have been applied via UA Infra: ESM.
 
-        Renew your UA services at https:\/\/ubuntu.com\/esm
+        Renew your UA services at https:\/\/ubuntu.com\/advantage
 
         """
         Then if `<release>` in `xenial` and stdout matches regexp:
@@ -119,8 +119,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Then if `<release>` in `xenial` and stdout matches regexp:
         """
         \*Your UA Infra: ESM subscription has EXPIRED\*
-        Enabling UA Infra: ESM service would provide security updates for following
-        packages:
+        Enabling UA Infra: ESM service would provide security updates for following packages:
           libkrad0
         1 esm-infra security update\(s\) NOT APPLIED. Renew your UA services at
         https:\/\/ubuntu.com\/advantage

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -84,6 +84,13 @@ Feature: Command behaviour when unattached
         """
         apt-esm-json-hook
         """
+        When I create the file `/etc/apt/sources.list.d/empty-release-origin.list` with the following
+        """
+        deb [ allow-insecure=yes ] https://packages.irods.org/apt xenial main
+        """
+        Then I verify that running `apt-get update` `with sudo` exits `0`
+        When I run `python3 /usr/lib/ubuntu-advantage/ua_update_messaging.py` with sudo
+        Then I verify that running `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` `with sudo` exits `0`
 
         Examples: ubuntu release
            | release | esm-infra-url                       | esm-apps-url |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -69,7 +69,7 @@ Feature: Command behaviour when unattached
           +Receive updates to over 30,000 software packages with your
           +Ubuntu Advantage subscription. Free for personal use.
 
-            +https:\/\/ubuntu.com\/esm
+            +https:\/\/ubuntu.com\/16-04
 
         UA Infra: Extended Security Maintenance \(ESM\) is not enabled.
         """


### PR DESCRIPTION
WIP: Based on integration test fixes in https://github.com/canonical/ubuntu-advantage-client/pull/1643. Land that PR first. then rebase this on upstream/main before landing
-----
## Proposed Commit Message

Wrap apt.File.Origin in DeNull in case the Origin is not yet setup or
in the event that an APT repo does not have a valid origin set.
This will allow the apt-esm-hook to compare "(null)" to "ESM*" and
avoid segfaults.

LP: #1929123
## Test Steps
New integration test should cover this by adding a known APT repo which has an empty Origin: value in the repo Release file.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
