### PR TITLE
Lintian fixes per SRU of 27.0.2

### DIFF
--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -27,7 +27,7 @@ hook: hook.cc
 	$(CXX) -Wall -Wextra -pedantic -std=c++11 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
 
 json-hook:
-	[ $(SKIP_GO_HOOK) ] || (cd json-hook-src && GOCACHE=/tmp/ $(GO_BIN) build json-hook.go)
+	[ $(SKIP_GO_HOOK) ] || (cd json-hook-src && GOCACHE=/tmp/ $(GO_BIN) build -buildmode=pie -ldflags -extldflags=-z,relro json-hook.go)
 
 install: hook json-hook
 	install -D -m 644 20apt-esm-hook.conf $(DESTDIR)/etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -3,3 +3,6 @@ ubuntu-advantage-tools: maintainer-script-calls-service postinst:*
 
 # Ubuntu doesn't require init.d scripts
 ubuntu-advantage-tools: package-supports-alternative-init-but-no-init.d-script
+
+# Avoid warning on wanted-by-target
+ubuntu-advantage-pro: systemd-service-file-refers-to-unusual-wantedby-target


### PR DESCRIPTION
## Proposed Commit Message

 *   apt-json-hook: fix lintian warnings based on compiled binary
    
    Provide -ldflgas and -buildmod=pie to go build of this hook.
    
    Fixes: #1626

*    lintian: override ubuntu-advantage-pro wanted-by-target cloud-init
    
    Silence warning for pro wanted-by-target cloud-init.service.


## Test Steps

```bash
sed -i 's/UNRELEASED/focal/' debian/changelog
git commit -am 'changelog bump for testing'
build-package
sbuild-it ../out/*dsc
should emit less lintian warnings
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
