### PR TITLE
enable: don't allow disabling services on beta check

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -547,7 +547,10 @@ def action_enable(args, cfg, **kwargs):
             cfg.status()  # Update the status cache
 
             if not ent_ret:
-                can_enable, reason = entitlement.can_enable(silent=True)
+                can_enable, reason = entitlement.can_enable(
+                    silent=True, allow_disable=False
+                )
+
                 if (
                     not can_enable
                     and reason == ua_status.CanEnableFailureReason.IS_BETA


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

If we fail to enable a service, we call the can_enable method directly. We do that to verify if the reason we failed to enable a service is because the service is in beta mode. However, the can_enable method calls the handle_incompatible_services method, which may prompt users to disable the incompatible service again. Since this check is only used to see if the service is beta, we should not allow for disabling incompatible services when we do it.

Fixes: #1652

PS: I believe we could have a better solution for this issue if we make the [enable](https://github.com/canonical/ubuntu-advantage-client/blob/main/uaclient/entitlements/base.py#L148) method return the reason why it failed. In that way, we would not need to perform the second `can_enable` call. However, this will be a bigger change in the codebase, since the `enable` method is not being called only by the `cli` module. We would need to modify some unittest and potentially test more integration scenarios.

## Test Steps
Run the modified unittest and run this [integration test](https://github.com/canonical/ubuntu-advantage-client/blob/main/features/attached_enable.feature#L350)

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
