### PR TITLE
tests: fix apt and motd messaging test

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -66,6 +66,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         \d+ update(s)? can be applied immediately.
         \d+ of these updates (is|are) (a|an)? UA Infra: ESM security update(s)?.
+        \d+ of these updates (is a|are) standard security update(s)?.
         To see these additional updates run: apt list --upgradable
         """
         Then if `<release>` in `bionic` and stdout matches regexp:
@@ -91,6 +92,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         UA Infra: Extended Security Maintenance \(ESM\) is enabled.
 
         \d+ package(s)? can be updated.
+        \d+ of these updates (is|are) fixed through UA Infra: ESM.
         \d+ of these updates (is a|are) security update(s)?.
         To see these additional updates run: apt list --upgradable
         """
@@ -119,8 +121,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         \*Your UA Infra: ESM subscription has EXPIRED\*
         Enabling UA Infra: ESM service would provide security updates for following packages:
-          libkrad0
-        1 esm-infra security update\(s\) NOT APPLIED. Renew your UA services at
+          .*
+        \d+ esm-infra security update\(s\) NOT APPLIED. Renew your UA services at
         https:\/\/ubuntu.com\/advantage
 
         """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -404,7 +404,7 @@ Feature: Command behaviour when attached to an UA subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `ua disable esm-infra` with sudo
-        And I run `add-apt-repository ppa:ua-client/staging -y` with sudo, retrying exit [1]
+        And I run `add-apt-repository ppa:cloud-init-dev/daily -y` with sudo, retrying exit [1]
         And I run `apt update` with sudo
         And I run `sed -i 's/ubuntu/ubun/' /etc/apt/sources.list.d/<ppa_file>.list` with sudo
         And I run `ua enable esm-infra` with sudo
@@ -414,11 +414,11 @@ Feature: Command behaviour when attached to an UA subscription
         Updating package lists
         APT update failed.
         APT update failed to read APT config for the following URL:
-        - http://ppa.launchpad.net/ua-client/staging/ubun
+        - http://ppa.launchpad.net/cloud-init-dev/daily/ubun
         """
 
         Examples: ubuntu release
-           | release | ppa_file                         |
-           | xenial  | ua-client-ubuntu-staging-xenial  |
-           | bionic  | ua-client-ubuntu-staging-bionic  |
-           | focal   | ua-client-ubuntu-staging-focal   |
+           | release | ppa_file                           |
+           | xenial  | cloud-init-dev-ubuntu-daily-xenial |
+           | bionic  | cloud-init-dev-ubuntu-daily-bionic |
+           | focal   | cloud-init-dev-ubuntu-daily-focal  |


### PR DESCRIPTION
## Proposed Commit Message
tests: fix apt and motd messaging test

Both xenial and focal now have esm-infra packages that show up in the `motd` message. Also, xenial now has more `esm-infra` packages that can be installed, therefore we are also updating the apt upgrade message as well



## Test Steps
Run the modified integration test for xenial and focal

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
