### PR TITLE
tests: add config for not caching source

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,10 @@ By default, integration tests will do the folowing on a given cloud platform:
    test runs
  * Launch a fresh instance based on the boot-image created and exercise tests
 
-The testing can be overridden to run using a local copy of the ubuntu-advantage-client source code instead of the daily PPA by providing the following environment variable to the behave test runner.
+The testing can be overridden to run using a local copy of the ubuntu-advantage-client source code instead of the daily PPA by providing the following environment variable to the behave test runner:
 ```UACLIENT_BEHAVE_BUILD_PR=1```
+
+> Note that, by default, we cache the source even when `UACLIENT_BEHAVE_BUILD_PR=1`. This means that if you change the python code locally and want to run the behave tests against your new version, you need to either delete the cache (`rm /tmp/pr_source.tar.gz`) or also set `UACLIENT_BEHAVE_CACHE_SOURCE=0`.
 
 To run the tests, you can use `tox`:
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -116,7 +116,12 @@ class UAClientBehaveConfig:
     # These variables are used in .from_environ() to convert the string
     # environment variable input to the appropriate Python types for use within
     # the test framework
-    boolean_options = ["build_pr", "image_clean", "destroy_instances"]
+    boolean_options = [
+        "build_pr",
+        "image_clean",
+        "destroy_instances",
+        "cache_source",
+    ]
     str_options = [
         "aws_access_key_id",
         "aws_secret_access_key",
@@ -169,6 +174,7 @@ class UAClientBehaveConfig:
         build_pr: bool = False,
         image_clean: bool = True,
         destroy_instances: bool = True,
+        cache_source: bool = True,
         machine_type: str = "lxd.container",
         private_key_file: str = None,
         private_key_name: str = "uaclient-integration",
@@ -192,6 +198,7 @@ class UAClientBehaveConfig:
         self.gcp_credentials_path = gcp_credentials_path
         self.gcp_project = gcp_project
         self.build_pr = build_pr
+        self.cache_source = cache_source
         self.contract_token = contract_token
         self.contract_token_staging = contract_token_staging
         self.image_clean = image_clean
@@ -615,6 +622,7 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
                 build_container_name,
                 output_deb_dir=os.path.join(tempfile.gettempdir(), series),
                 cloud_api=context.config.cloud_api,
+                cache_source=context.config.cache_source,
             )
 
     if "pro" in context.config.machine_type:

--- a/features/util.py
+++ b/features/util.py
@@ -87,6 +87,7 @@ def build_debs(
     container_name: str,
     output_deb_dir: str,
     cloud_api: "pycloudlib.cloud.BaseCloud",
+    cache_source: bool,
 ) -> "List[str]":
     """
     Push source PR code .tar.gz to the container.
@@ -110,7 +111,7 @@ def build_debs(
         )
         if not os.path.exists(os.path.dirname(SOURCE_PR_TGZ)):
             os.makedirs(os.path.dirname(SOURCE_PR_TGZ))
-        if not os.path.exists(SOURCE_PR_TGZ):
+        if not os.path.exists(SOURCE_PR_TGZ) or not cache_source:
             cwd = os.getcwd()
             os.chdir("..")
             subprocess.run(


### PR DESCRIPTION
***Not intended for 27.1. Wait to merge until 27.1 release is finalized***

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> tests: add config for not caching source
>
> It may be confusing for some that the source is cached when using
> UACLIENT_BUILD_PR=1 when running the integration tests. Here we add
> documentation that instructs the developer to remember to remove the
> source cache, and also introduces a new environment variable to ignore
> the cache altogether.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
* Run an integration test with `UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_CACHE_SOURCE=0`.
* make a change to the uaclient source
* do not `rm /tmp/pr_source.tar.gz`
* Run the integration test again with the same envvars, and verify the changes to uaclient are reflected in the test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
