### PR TITLE
fips: add gov clouds to metapackage override logic (SC-71)

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -265,6 +265,33 @@ mark_reboot_cmds_as_needed() {
     add_notice "$msg_name"
 }
 
+notify_wrong_fips_metapackage_on_cloud() {
+
+    # On xenial, we don't have FIPS optimized kernels on the clouds.
+    # Because of that, we block enabling FIPS on xenial clouds. However,
+    # we do have a config override that allows users to install the generic
+    # FIPS packages into the cloud instance. We don't want to notify those users
+    if [ "$VERSION_ID" = "16.04" ]; then
+        return
+    fi
+
+    fips_metapkg="ubuntu-fips"
+
+    cloud_id=""
+    if command -v "cloud-id" > /dev/null ; then
+      cloud_id=$(cloud-id)
+    fi
+
+    # If the package is not installed, we don't want the postinst script to fail
+    fips_installed=$(dpkg-query -W --showformat='${db:Status-Status}\n' $fips_metapkg 2>/dev/null || true)
+
+    if echo "$cloud_id" | grep -E -q "^(azure|aws)"; then
+      if echo "$fips_installed" | grep -E -q "installed"; then
+        add_notice NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD
+      fi
+    fi
+}
+
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -305,6 +332,8 @@ case "$1" in
             add_notice MESSAGE_FIPS_INSTALL_OUT_OF_DATE
         fi
       fi
+
+      notify_wrong_fips_metapackage_on_cloud
 
       # CACHE_DIR is no longer present or used since 19.1
       rm -rf /var/cache/ubuntu-advantage-tools

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from itertools import groupby
 
@@ -153,8 +154,12 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         if series != "bionic":
             return packages
 
-        cloud_id = get_cloud_type()
-        if not cloud_id or cloud_id not in ("azure", "aws"):
+        cloud_match = re.match(
+            r"^(?P<cloud>(azure|aws)).*", get_cloud_type() or ""
+        )
+        cloud_id = cloud_match.group("cloud") if cloud_match else ""
+
+        if cloud_id not in ("azure", "aws"):
             return packages
 
         cloud_metapkg = "ubuntu-{}-fips".format(cloud_id)

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -241,6 +241,15 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 env=env,
             )
 
+    def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
+        if super().enable(silent_if_inapplicable=silent_if_inapplicable):
+            self.cfg.remove_notice(
+                "", status.NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD
+            )
+            return True
+
+        return False
+
 
 class FIPSEntitlement(FIPSCommonEntitlement):
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -249,6 +249,30 @@ class TestFIPSEntitlementEnable:
         assert repo_enable_return_value is fips_entitlement._perform_enable()
         assert expected_remove_notice_calls == m_remove_notice.call_args_list
 
+    @pytest.mark.parametrize(
+        "repo_enable_return_value, expected_remove_notice_calls",
+        [
+            (
+                True,
+                [mock.call("", status.NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD)],
+            ),
+            (False, []),
+        ],
+    )
+    @mock.patch("uaclient.entitlements.repo.RepoEntitlement.enable")
+    @mock.patch("uaclient.config.UAConfig.remove_notice")
+    def test_enable_removes_wrong_met_notice_on_success(
+        self,
+        m_remove_notice,
+        m_repo_enable,
+        repo_enable_return_value,
+        expected_remove_notice_calls,
+        entitlement,
+    ):
+        m_repo_enable.return_value = repo_enable_return_value
+        assert repo_enable_return_value is entitlement.enable()
+        assert expected_remove_notice_calls == m_remove_notice.call_args_list
+
     @mock.patch(
         "uaclient.util.get_platform_info", return_value={"series": "xenial"}
     )

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -937,7 +937,18 @@ class TestFipsEntitlementPackages:
     @pytest.mark.parametrize(
         "series", (("trusty"), ("xenial"), ("bionic"), ("focal"))
     )
-    @pytest.mark.parametrize("cloud_id", (("azure"), ("aws"), ("gce"), (None)))
+    @pytest.mark.parametrize(
+        "cloud_id",
+        (
+            ("azure-china"),
+            ("aws-gov"),
+            ("aws-china"),
+            ("azure"),
+            ("aws"),
+            ("gce"),
+            (None),
+        ),
+    )
     @mock.patch("uaclient.util.is_config_value_true")
     @mock.patch(M_PATH + "get_cloud_type")
     @mock.patch("uaclient.util.get_platform_info")
@@ -967,10 +978,12 @@ class TestFipsEntitlementPackages:
         if all(
             [
                 series == "bionic",
-                cloud_id in ("azure", "aws"),
+                cloud_id
+                in ("azure", "aws", "aws-china", "aws-gov", "azure-china"),
                 not cfg_disable_fips_metapckage_override,
             ]
         ):
+            cloud_id = cloud_id.split("-")[0]
             assert packages == [
                 "test1",
                 "ubuntu-{}-fips".format(cloud_id),

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -290,6 +290,15 @@ NOTICE_FIPS_MANUAL_DISABLE_URL = """\
 FIPS kernel is running in a disabled state.
   To manually remove fips kernel: https://discourse.ubuntu.com/t/20738
 """
+NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD = """\
+Warning: FIPS kernel is not optimized for your specific cloud.
+To fix it, run the following commands:
+
+    1. sudo ua disable fips
+    2. sudo apt-get remove ubuntu-fips
+    3. sudo ua enable fips --assume-yes
+    4. sudo reboot
+"""
 PROMPT_FIPS_PRE_ENABLE = (
     """\
 This will install the FIPS core packages.


### PR DESCRIPTION
## Proposed Commit Message
fips: add gov clouds to metapackage override logic

When overriding the metapackage to be installed on cloud instances, we are not taking into consideration the cloud-id of government clouds. This is a problem, because those clouds should also install the cloud specific fips metapackages.

## Test Steps
Run FIPS tests for aws and azure generic scenarios

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
