### PR TITLE
repo: allow downgrading packages during enable (SC-69)

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -239,6 +239,7 @@ class RepoEntitlement(base.UAEntitlement):
         if self.apt_noninteractive:
             env = {"DEBIAN_FRONTEND": "noninteractive"}
             apt_options = [
+                "--allow-downgrades",
                 '-o Dpkg::Options::="--force-confdef"',
                 '-o Dpkg::Options::="--force-confold"',
             ]

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -88,6 +88,7 @@ class TestCISEntitlementEnable:
                     "apt-get",
                     "install",
                     "--assume-yes",
+                    "--allow-downgrades",
                     '-o Dpkg::Options::="--force-confdef"',
                     '-o Dpkg::Options::="--force-confold"',
                 ]

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -186,6 +186,7 @@ class TestFIPSEntitlementEnable:
                 "apt-get",
                 "install",
                 "--assume-yes",
+                "--allow-downgrades",
                 '-o Dpkg::Options::="--force-confdef"',
                 '-o Dpkg::Options::="--force-confold"',
             ]


### PR DESCRIPTION
## Proposed Commit Message
repo: allow downgrading packages during enable

When enabling a repo entitlement, like FIPS, we are currently not allowing for package downgrades. This is problematic if users are using package from a third party, that could have versions higher than the ones we are delivering. To enforce that users will run the right packages for the services we are enabling, we are now supporting downgrading packages when enabling a service.

Fixes: #1659

## Test Steps
Since we are just adding a new apt flag, run an existing FIPS vm test to confirm that the flag is not breaking the enable step

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
