### PR TITLE
tests: remove clashing lxd user-data (SC-91)

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -36,15 +36,18 @@ bootcmd:
 # we can't use write_files because it will clash with the
 # lxd vendor-data write_files that is necessary to set up
 # the lxd_agent on some releases
-USERDATA_APT_SOURCE_PPA = """\
+USERDATA_RUNCMD_PIN_PPA = """\
 runcmd:
   - "printf \\"Package: *\\nPin: release o=LP-PPA-ua-client-daily\\nPin-Priority: 1001\\n\\" > /etc/apt/preferences.d/uaclient"
+"""  # noqa: E501
+
+USERDATA_APT_SOURCE_PPA = """\
 apt:
   sources:
     ua-tools-ppa:
         source: deb {ppa_url} $RELEASE main
         keyid: {ppa_keyid}
-"""  # noqa: E501
+"""
 
 PROCESS_LOG_TMPL = """\
 returncode: {}
@@ -685,6 +688,9 @@ def create_uat_image(context: Context, series: str) -> None:
         ppa_keyid = context.config.ppa_keyid
         if context.config.ppa.startswith("ppa:"):
             ppa = ppa.replace("ppa:", "http://ppa.launchpad.net/") + "/ubuntu"
+
+        if ppa == DAILY_PPA:
+            user_data += USERDATA_RUNCMD_PIN_PPA
 
         user_data += USERDATA_APT_SOURCE_PPA.format(
             ppa_url=ppa, ppa_keyid=ppa_keyid


### PR DESCRIPTION
## Background
We need this change before we upgrade pycloudlib to incorporate https://github.com/canonical/pycloudlib/pull/148

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> tests: remove clashing lxd user-data
>
> lxd relies on a write_files vendor-data directive to set up the
> lxd-agent on lxd vms of some ubuntu releases. Our use of write_files was
> overwriting the vendor-data and preventing the lxd-agent from coming up.
> 
> Here we use a runcmd to accomplish the same thing we were using
> write_files for in our integration tests.


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Make sure integration tests still pass

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
