### PR TITLE
config: only allow some fields to be set by envvar (SC-111)

### DIFF
--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -100,6 +100,10 @@ The following configuration options are available:
 The ubuntu advantage contract server URL
 .TP
 .B
+\fBsecurity_url\fP
+The ubuntu advantage security server URL
+.TP
+.B
 \fBdata_dir\fP
 Where Ubuntu Advantage client stores its data files
 .TP
@@ -112,9 +116,10 @@ The logging level used when writing to \fBlog_file\fP
 The log file for the Ubuntu Advantage client
 
 .P
-Additionally, any configuration option can be overridden in the environment
+Additionally, some configuration options can be overridden in the environment
 by setting an environment variable prefaced by \fBUA_<option_name>\fP. Both
-uppercase and lowercase environment variables are allowed.
+uppercase and lowercase environment variables are allowed. The configuration
+options that support this are: data_dir, log_file, log_level, and security_url.
 
 For example, the following overrides the log_level found in uaclient.conf:
 .PP


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> config: only allow some fields to be set by envvar

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Verify `UA_CONTRACT_URL=https://contracts.staging.canonical.com ua attach STAGING_TOKEN` doesn't work
Verify `LOG_LEVEL=debug ua status` does work

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
