### PR TITLE
Allow setting proxy for web requests (SC-105)

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -523,7 +523,7 @@ def after_step(context, step):
                 )
                 print("-- pull instance:{} {}".format(log_file, artifact_file))
                 try:
-                    result = context.instance.execute(
+                    result = context.instances["uaclient"].execute(
                         ["cat", log_file], use_sudo=True
                     )
                     content = result.stdout if result.ok else ""
@@ -532,7 +532,9 @@ def after_step(context, step):
                 with open(artifact_file, "w") as stream:
                     stream.write(content)
             for artifact_file, cmd in FAILURE_CMDS.items():
-                result = context.instance.execute(cmd, use_sudo=True)
+                result = context.instances["uaclient"].execute(
+                    cmd, use_sudo=True
+                )
                 artifact_file = os.path.join(artifacts_dir, artifact_file)
                 with open(artifact_file, "w") as stream:
                     stream.write(result.stdout)

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -1,0 +1,28 @@
+@uses.config.contract_token
+Feature: Attach command when proxy is configured
+
+    @series.lts
+    Scenario Outline: Attach command when proxy is configured
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I launch a `focal` `proxy` machine
+        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
+            """
+            acl all src 0.0.0.0\/0\nhttp_access allow all
+            """
+        And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
+        And I configure uaclient `http` proxy to use `proxy` machine
+        And I configure uaclient `https` proxy to use `proxy` machine
+        And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        And I attach `contract_token` with sudo
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT contracts.canonical.com.*
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1037,6 +1037,11 @@ def main(sys_argv=None):
         sys.exit(1)
     args = parser.parse_args(args=cli_arguments)
     cfg = config.UAConfig()
+
+    http_proxy = cfg.http_proxy
+    https_proxy = cfg.https_proxy
+    util.configure_web_proxy(http_proxy=http_proxy, https_proxy=https_proxy)
+
     log_level = cfg.log_level
     console_level = logging.DEBUG if args.debug else logging.INFO
     setup_logging(console_level, log_level, cfg.log_file)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -109,6 +109,14 @@ class UAConfig:
     def security_url(self):
         return self.cfg.get("security_url", "https://ubuntu.com/security")
 
+    @property
+    def http_proxy(self):
+        return self.cfg.get("http_proxy")
+
+    @property
+    def https_proxy(self):
+        return self.cfg.get("https_proxy")
+
     def check_lock_info(self) -> "Tuple[int, str]":
         """Return lock info if config lock file is present the lock is active.
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -472,6 +472,31 @@ def prompt_for_confirmation(msg: str = "", assume_yes: bool = False) -> bool:
     return False
 
 
+def configure_web_proxy(
+    http_proxy: "Optional[str]", https_proxy: "Optional[str]"
+) -> None:
+    """
+    Configure urllib to use http and https proxies.
+
+    :param http_proxy: http proxy to be used by urllib. If None, it will
+                       not be configured
+    :param https_proxy: https proxy to be used by urllib. If None, it will
+                        not be configured
+    """
+    proxy_dict = {}
+
+    if http_proxy:
+        proxy_dict["http"] = http_proxy
+
+    if https_proxy:
+        proxy_dict["https"] = https_proxy
+
+    if proxy_dict:
+        proxy_handler = request.ProxyHandler(proxy_dict)
+        opener = request.build_opener(proxy_handler)
+        request.install_opener(opener)
+
+
 def readurl(
     url: str,
     data: "Optional[bytes]" = None,


### PR DESCRIPTION
## Proposed Commit Message
Allow setting proxy for web requests

During some uaclient operations, we perform requests to communicate with the contract backend. If an user wants uaclient to respect a proxy configuration, we need to allow proxy configuration for these types of requests.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
