### PR TITLE
bump pycloudlib version

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@cab5db70bdd5588aabcf7217e655ff90d2dee487
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@88b25081a2e74262e445f3208dc45f841afacc56
 
 
 # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
## Proposed Commit Message
bump pycloudlib version

Bump pycloudlib to fix the problem of running xenial vm tests. From now on, we will not even try to install the lxd-agent on xenial anymore

## Test Steps
Run a xenial vm test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
