### PR TITLE
tests: avoid running dist-upgrade on -proposed to avoid reboot errors

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -310,7 +310,12 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         """
         1
         """
-        When I run `apt-get dist-upgrade -y --allow-downgrades` with sudo
+        # Since this test runs dist-upgrade. Let's make sure we are not sourcing
+        # -proposed. Otherwise bad things happen due to upgrade/removal of all
+        # packages  in -proposed.
+        When I run `rm -f /etc/apt/sources.list.d/uaclient-proposed.list` with sudo
+        And I run `apt update` with sudo
+        And I run `apt-get dist-upgrade -y --allow-downgrades` with sudo
         # A package may need a reboot after running dist-upgrade
         And I reboot the `<release>` machine
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following


### PR DESCRIPTION
Avoid running dist-upgrade if -proposed  is enabled.

## Proposed Commit Message
Remove our sources.list.d/uaclient-proposed.list prior to running
dist-upgrade in tests.

Running apt dist-upgrade may remove packages on the system due to
"smart" dependency resolution if certain package dependencies are
unavailable for some reason in the APT repos.

This is a considerable concern if we are running on tests with -proposed
enabled because there is a high likelihood of some packages hitting FTBFS
(fail to build from source) and smart dependency resolution will remove
them across dist-upgrade.

This behavior broke and UACLIENT_BEHAVE_ENABLE_PROPOSED=1 testing on
lxd.vm platforms because LP: #21551181 shim-signed never built properly
in -proposed.

The result is dist-upgrade  removed shim-signed, and any subsequent reboot
got us an UEFI "Access Denied" message on the default boot option
because we didn't have the proper secureboot signed bits in place.

The only workaround to boot in that integration test case was to:
lxc config set <VM_NAME> security.secureboot=false

## Steps to test
```bash
UACLIENT_BEHAVE_ENABLE_PROPOSED=1 UACLIENT_BEHAVE_DESTROY_INSTANCES=0 UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING=<REDACT> UACLIENT_BEHAVE_CONTRACT_TOKEN=<REDACT> tox -e behave-vm-16.04 features/staging_commands.feature:355
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
