### PR TITLE
proxy: allow configuring snap and livepatch (SC-87)

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -107,7 +107,7 @@ def given_a_machine(context, series):
 def launch_machine(context, series, instance_name):
     now = datetime.datetime.now()
     date_prefix = now.strftime("-%s%f")
-    name = CONTAINER_PREFIX + series + date_prefix + instance_name
+    name = CONTAINER_PREFIX + series + date_prefix + "-" + instance_name
 
     context.instances[instance_name] = context.config.cloud_manager.launch(
         series=series, instance_name=name
@@ -157,9 +157,8 @@ def when_i_configure_uaclient_using_proxy_machine(
     # But I don't think we need this at this moment.
     port = "3128"
 
+    # we are not configuring a full https proxy for the tests
     proxy_type = "http"
-    if "https" in proxy_cfg:
-        proxy_type = "https"
 
     proxy_cfg_value = "{}://{}:{}".format(proxy_type, proxy_ip, port)
 


### PR DESCRIPTION
## Proposed Commit Message
proxy: allow configuring snap and livepatch

Allow configuring both snap and livepatch proxies during the enable operation of livepatch

PS: There are still some points on this PR that we could improve. Currently, it seems that
requests for livepatch are arriving with a delay into the squid log, that's why I am running a sleep command
in the test. I can confirm that only running `canonical-livepatch refresh` does not remove that delay.

Furthermore, I am not seeing any log entries we I run 'ua detach`. Since we hit the contract backend on that
operation, I was expecting a log entry for it.

## Test Steps
Run the new vm test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
