### PR TITLE
behave: timestamp pub/priv keynames to avoid collisions w/ parallel …

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -214,16 +214,22 @@ class Cloud:
 
         return image_name
 
-    def manage_ssh_key(self, private_key_path: "Optional[str]" = None) -> None:
+    def manage_ssh_key(
+        self,
+        private_key_path: "Optional[str]" = None,
+        key_name: "Optional[str]" = None,
+    ) -> None:
         """Create and manage ssh key pairs to be used in the cloud provider.
 
         :param private_key_path:
             Location of the private key path to use. If None, the location
             will be a default location.
         """
+        if key_name:
+            self.key_name = key_name
         cloud_name = self.name.lower().replace("_", "-")
-        pub_key_path = "{}-pubkey".format(cloud_name)
-        priv_key_path = "{}-privkey".format(cloud_name)
+        pub_key_path = "{}-pub-{}".format(cloud_name, self.key_name)
+        priv_key_path = "{}-priv-{}".format(cloud_name, self.key_name)
         pub_key, priv_key = self.api.create_key_pair()
 
         with open(pub_key_path, "w") as f:
@@ -456,7 +462,11 @@ class Azure(Cloud):
         # instead of the instance id
         return instance.name
 
-    def manage_ssh_key(self, private_key_path: "Optional[str]" = None) -> None:
+    def manage_ssh_key(
+        self,
+        private_key_path: "Optional[str]" = None,
+        key_name: "Optional[str]" = None,
+    ) -> None:
         """Create and manage ssh key pairs to be used in the cloud provider.
 
         :param private_key_path:


### PR DESCRIPTION
## Proposed Commit Message
behave: timestamp ssh keynames to avoid collisions w/ parallel jobs

Avoid spurious failures due to parallel jenkins CI jobs when one 18.04 overwrites
the common `lxd-container-pubkey` or `lxd-container-privkey` files.

## Test Steps
```bash
UACLIENT_BEHAVE_BUILD_PR=1  tox -e behave-lxd-16.04 features/attach_invalidtoken.feature
ls -ltr # to see timestamped lxd*key file names
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
