### PR TITLE
status: show env vars on json output (SC-155)

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -871,9 +871,7 @@ def action_status(args, cfg):
             status = cfg.status(show_beta=show_beta)
         print("")
     if args and args.format == "json":
-        if status["expires"] != ua_status.UserFacingStatus.INAPPLICABLE.value:
-            status["expires"] = str(status["expires"])
-        print(json.dumps(status))
+        print(ua_status.format_json_status(status))
     else:
         output = ua_status.format_tabular(status)
         # Replace our Unicode dash with an ASCII dash if we aren't going to be

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -12,6 +12,7 @@ from collections import namedtuple, OrderedDict
 from uaclient import status, util
 from uaclient.defaults import (
     CONFIG_DEFAULTS,
+    CONFIG_FIELD_ENVVAR_ALLOWLIST,
     DEFAULT_CONFIG_FILE,
     BASE_CONTRACT_URL,
     BASE_SECURITY_URL,
@@ -55,13 +56,6 @@ MERGE_ID_KEY_MAP = {
     "resourceEntitlements": "type",
 }
 UNSET_SETTINGS_OVERRIDE_KEY = "_unset"
-
-CONFIG_FIELD_ENVVAR_ALLOWLIST = [
-    "data_dir",
-    "log_file",
-    "log_level",
-    "security_url",
-]
 
 
 # A data path is a filename, and an attribute ("private") indicating whether it
@@ -722,7 +716,7 @@ def parse_config(config_path=None):
                     cfg["features"] = {feature_field_name: value}
                 else:
                     cfg["features"][feature_field_name] = value
-            elif field_name in CONFIG_FIELD_ENVVAR_ALLOWLIST:
+            elif key in CONFIG_FIELD_ENVVAR_ALLOWLIST:
                 env_keys[field_name] = value
     cfg.update(env_keys)
     cfg["log_level"] = cfg["log_level"].upper()

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -27,3 +27,10 @@ CONFIG_DEFAULTS = {
     "log_level": "INFO",
     "log_file": "/var/log/ubuntu-advantage.log",
 }
+
+CONFIG_FIELD_ENVVAR_ALLOWLIST = [
+    "ua_data_dir",
+    "ua_log_file",
+    "ua_log_level",
+    "ua_security_url",
+]

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,8 +1,14 @@
 import enum
+import json
 import sys
 import textwrap
+import os
 
-from uaclient.defaults import BASE_UA_URL, PRINT_WRAP_WIDTH
+from uaclient.defaults import (
+    BASE_UA_URL,
+    CONFIG_FIELD_ENVVAR_ALLOWLIST,
+    PRINT_WRAP_WIDTH,
+)
 
 try:
     from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
@@ -628,3 +634,18 @@ def format_tabular(status: "Dict[str, Any]") -> str:
         content.extend(get_section_column_content(column_data=pairs))
 
     return "\n".join(content)
+
+
+def format_json_status(status: "Dict[str, Any]") -> str:
+    if status["expires"] != UserFacingStatus.INAPPLICABLE.value:
+        status["expires"] = str(status["expires"])
+
+    status["environment_vars"] = [
+        {"name": name, "value": value}
+        for name, value in sorted(os.environ.items())
+        if name.lower() in CONFIG_FIELD_ENVVAR_ALLOWLIST
+        or name.startswith("UA_FEATURES")
+        or name == "UA_CONFIG_FILE"
+    ]
+
+    return json.dumps(status)


### PR DESCRIPTION
## Proposed Commit Message
status: show env vars on json output

We are now displaying if there is any ua specific environment variables set when the user runs ua status --format json

## Test Steps
Run the updated unittest or set a valid UA env variable locally and verify that it appears in the json output
of `ua status --format json`

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
