### PR TITLE
status: do not show unavailable services on json

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -520,6 +520,7 @@ class UAConfig:
                 description_override = inapplicable_resources[ent.name]
             else:
                 ent_status, details = ent.user_facing_status()
+
         return {
             "name": ent.name,
             "description": ent.description,
@@ -527,6 +528,9 @@ class UAConfig:
             "status": ent_status.value,
             "statusDetails": details,
             "description_override": description_override,
+            "available": "yes"
+            if ent.name not in inapplicable_resources
+            else "no",
         }
 
     def _attached_status(self) -> "Dict[str, Any]":
@@ -565,6 +569,7 @@ class UAConfig:
             response["services"].append(
                 self._attached_service_status(ent, inapplicable_resources)
             )
+
         support = self.entitlements.get("support", {}).get("entitlement")
         if support:
             supportLevel = support.get("affordances", {}).get("supportLevel")

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -648,4 +648,11 @@ def format_json_status(status: "Dict[str, Any]") -> str:
         or name == "UA_CONFIG_FILE"
     ]
 
+    available_services = [
+        service
+        for service in status.get("services", [])
+        if service.get("available", "yes") == "yes"
+    ]
+    status["services"] = available_services
+
     return json.dumps(status)

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -253,7 +253,7 @@ class TestCLIParser:
 
         status_msg = "enabled" if ent_msg == "yes" else "—"
         ufs_call_count = 1 if ent_msg == "yes" else 0
-        ent_name_call_count = 2 if ent_msg == "yes" else 1
+        ent_name_call_count = 3 if ent_msg == "yes" else 2
         is_beta_call_count = 1 if status_msg == "enabled" else 0
 
         expected_msgs = [

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -715,6 +715,7 @@ class TestStatus:
                 else default_status,
                 "statusDetails": mock.ANY,
                 "description_override": None,
+                "available": mock.ANY,
             }
             for cls in entitlements.ENTITLEMENT_CLASSES
             if not self.check_beta(cls, show_beta, cfg)
@@ -939,6 +940,7 @@ class TestStatus:
                     "status": expected_status,
                     "statusDetails": details,
                     "description_override": None,
+                    "available": mock.ANY,
                 }
             )
         with mock.patch(


### PR DESCRIPTION
## Proposed Commit Message
status: do not show unavailable services on json

We are now only showing available services in the status json output. Because of that, we are also dropping the available key from the json output, since now it is a redundant key.

## Test Steps
Run the modified unittests
Launch a container and verify that `cc-eal` does not appear when unattaches and attached

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
