### PR TITLE
fips: don't install openssh hmac packages on focal

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -13,8 +13,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And I run `run-parts /etc/update-motd.d/` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:
         """
-        \d+ package(s)? can be updated.
-        \d+ of these updates (is a|are) security update(s)?.
+        \d+ update(s)? can be applied immediately.
+        \d+ of these updates (is a|are) standard security update(s)?.
         """
         Then if `<release>` in `bionic` and stdout matches regexp:
         """
@@ -91,9 +91,9 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         UA Infra: Extended Security Maintenance \(ESM\) is enabled.
 
-        \d+ package(s)? can be updated.
-        \d+ of these updates (is|are) fixed through UA Infra: ESM.
-        \d+ of these updates (is a|are) security update(s)?.
+        \d+ update(s)? can be applied immediately.
+        \d+ of these updates (is|are) UA Infra: ESM security update(s)?.
+        \d+ of these updates (is a|are) standard security update(s)?.
         To see these additional updates run: apt list --upgradable
         """
         When I update contract to use `effectiveTo` as `days=-20`


### PR DESCRIPTION
## Proposed Commit Message
fips: don't install openssh hmac packages on focal

On Focal, we don't have the openssh hmac packages. Because of that, we must exclude then when enabling any FIPS service on Focal

PS:  Originally, i though about using a different solution that check if the package can be installed before adding it to the list of installable FIPS packages. However, this could create scenarios were we partially install FIPS packages, which is not ideal. That's why I am explicit on which package should be included based on the distro version

## Test Steps
1) attach a valid fips-preview contract on a focal machine
2) manually change the name of `fips-updates'  to `fips-preview`
3) enable `fips-preview`  and test to see if everything is working as expected

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
