### PR TITLE
status: update contract info on status json output

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -100,7 +100,9 @@ def FakeConfig(tmpdir):
                         "contractInfo": {
                             "id": "cid",
                             "name": "test_contract",
+                            "createdAt": "2020-05-08T19:02:26Z",
                             "resourceEntitlements": [],
+                            "products": ["free"],
                         },
                     },
                 }

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -611,7 +611,7 @@ def format_tabular(status: "Dict[str, Any]") -> str:
             "description": description,
         }
         content.append(STATUS_TMPL.format(**fmt_args))
-    tech_support_level = status["techSupportLevel"]
+    tech_support_level = status["contract"]["tech_support_level"]
 
     if status.get("notices"):
         content.extend(
@@ -625,8 +625,9 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     if status["account"]:
         pairs.append(("Account", status["account"]))
 
-    if status["subscription"]:
-        pairs.append(("Subscription", status["subscription"]))
+    contract_name = status["contract"]["name"]
+    if contract_name:
+        pairs.append(("Subscription", contract_name))
 
     if status["origin"] != "free":
         pairs.append(("Valid until", str(status["expires"])))
@@ -639,6 +640,8 @@ def format_tabular(status: "Dict[str, Any]") -> str:
 
 
 def format_json_status(status: "Dict[str, Any]") -> str:
+    from uaclient.util import DatetimeAwareJSONEncoder
+
     if status["expires"] != UserFacingStatus.INAPPLICABLE.value:
         status["expires"] = str(status["expires"])
 
@@ -657,4 +660,4 @@ def format_json_status(status: "Dict[str, Any]") -> str:
     ]
     status["services"] = available_services
 
-    return json.dumps(status)
+    return json.dumps(status, cls=DatetimeAwareJSONEncoder)

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -28,7 +28,9 @@ BASIC_MACHINE_TOKEN = {
         "contractInfo": {
             "name": "mycontract",
             "id": "contract-1",
+            "createdAt": "2020-05-08T19:02:26Z",
             "resourceEntitlements": [],
+            "products": ["free"],
         },
         "accountInfo": {"id": "acct-1", "name": "accountName"},
     },

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -348,8 +348,14 @@ class TestActionStatus:
                     "available": "yes",
                 }
             ],
-            "techSupportLevel": "n/a",
             "environment_vars": expected_environment,
+            "contract": {
+                "id": "",
+                "name": "",
+                "created_at": "",
+                "products": [],
+                "tech_support_level": "n/a",
+            },
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
@@ -414,6 +420,7 @@ class TestActionStatus:
             if service["name"] not in inapplicable_services
         ]
 
+        tech_support_level = status.UserFacingStatus.INAPPLICABLE.value
         expected = {
             "_doc": (
                 "Content provided in json response is currently "
@@ -428,10 +435,14 @@ class TestActionStatus:
             "services": filtered_services,
             "account": "test_account",
             "account-id": "acct-1",
-            "subscription": "test_contract",
-            "subscription-id": "cid",
-            "techSupportLevel": "n/a",
             "environment_vars": expected_environment,
+            "contract": {
+                "id": "cid",
+                "name": "test_contract",
+                "created_at": "2020-05-08T19:02:26+00:00",
+                "products": ["free"],
+                "tech_support_level": tech_support_level,
+            },
         }
         assert expected == json.loads(capsys.readouterr()[0])
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -680,7 +680,9 @@ class TestStatus:
                 "contractInfo": {
                     "id": "cid",
                     "name": "test_contract",
+                    "createdAt": "2020-05-08T19:02:26Z",
                     "resourceEntitlements": entitled_res,
+                    "products": ["free"],
                 },
             },
         }
@@ -727,8 +729,15 @@ class TestStatus:
                 "account": "test_account",
                 "attached": True,
                 "services": expected_services,
-                "subscription": "test_contract",
-                "subscription-id": "cid",
+                "contract": {
+                    "name": "test_contract",
+                    "id": "cid",
+                    "created_at": datetime.datetime(
+                        2020, 5, 8, 19, 2, 26, tzinfo=datetime.timezone.utc
+                    ),
+                    "products": ["free"],
+                    "tech_support_level": "n/a",
+                },
             }
         )
         with mock.patch(
@@ -894,7 +903,9 @@ class TestStatus:
                 "contractInfo": {
                     "id": "contract-1",
                     "name": "contractname",
+                    "createdAt": "2020-05-08T19:02:26Z",
                     "resourceEntitlements": entitlements,
+                    "products": ["free"],
                 },
             },
         }
@@ -913,9 +924,15 @@ class TestStatus:
                 "attached": True,
                 "account": "accountname",
                 "account-id": "1",
-                "subscription": "contractname",
-                "subscription-id": "contract-1",
-                "techSupportLevel": support_level,
+                "contract": {
+                    "name": "contractname",
+                    "id": "contract-1",
+                    "created_at": datetime.datetime(
+                        2020, 5, 8, 19, 2, 26, tzinfo=datetime.timezone.utc
+                    ),
+                    "products": ["free"],
+                    "tech_support_level": support_level,
+                },
             }
         )
         for cls in ENTITLEMENT_CLASSES:
@@ -981,7 +998,9 @@ class TestStatus:
                     "name": "contractname",
                     "id": "contract-1",
                     "effectiveTo": "2020-07-18T00:00:00Z",
+                    "createdAt": "2020-05-08T19:02:26Z",
                     "resourceEntitlements": [],
+                    "products": ["free"],
                 },
             },
         }

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -3,7 +3,12 @@ import pytest
 import string
 
 from uaclient import config
-from uaclient.status import format_tabular, TxtColor, colorize_commands
+from uaclient.status import (
+    format_tabular,
+    TxtColor,
+    colorize_commands,
+    UserFacingStatus,
+)
 
 
 @pytest.fixture(params=[True, False])
@@ -13,13 +18,15 @@ def status_dict_attached(request):
     # The following are required so we don't get an "unattached" error
     status["attached"] = True
     status["expires"] = "expires"
+    status["account"] = ""
+    status["contract"] = {
+        "name": "",
+        "tech_support_level": UserFacingStatus.INAPPLICABLE.value,
+    }
 
     if request.param:
         status["account"] = "account"
-        status["subscription"] = "subscription"
-    else:
-        status["account"] = ""
-        status["subscription"] = ""
+        status["contract"]["name"] = "subscription"
 
     return status
 
@@ -113,7 +120,7 @@ class TestFormatTabular:
         istty,
         status_dict_attached,
     ):
-        status_dict_attached["techSupportLevel"] = support_level
+        status_dict_attached["contract"]["tech_support_level"] = support_level
 
         m_isatty.return_value = istty
         tabular_output = format_tabular(status_dict_attached)
@@ -153,7 +160,7 @@ class TestFormatTabular:
     ):
         status_dict_attached["origin"] = origin
 
-        if status_dict_attached["subscription"]:
+        if status_dict_attached["contract"].get("name"):
             expected_headers = ("Subscription",) + expected_headers
         if status_dict_attached["account"]:
             expected_headers = ("Account",) + expected_headers


### PR DESCRIPTION
## Proposed Commit Message
status: update contract info on status json output

We are now removing from root contract based information and adding that info into a contract specific object. Additionally, the products and created_at info for the contract are now present in the json output as well

## Test Steps
Launch a container and verify that the contract object appears on the json output of `ua status --format json` when unattaches/attached

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
