### PR TITLE
proxy: print message when setting proxy (SC-179)

### DIFF
--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -27,6 +27,10 @@ Feature: Proxy configuration
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         Then I verify that no files exist matching `/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy`
         When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        Setting APT proxy
+        """
         Then I verify that files exist matching `/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy`
         When I run `cat /etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy` with sudo
         Then stdout matches regexp:
@@ -78,7 +82,15 @@ Feature: Proxy configuration
         And I configure uaclient `https` proxy to use `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I attach `contract_token` with sudo
-        And I run `canonical-livepatch config check-interval=0` with sudo
+        Then stdout matches regexp:
+        """
+        Setting snap proxy
+        """
+        Then stdout matches regexp:
+        """
+        Setting Livepatch proxy
+        """
+        When I run `canonical-livepatch config check-interval=0` with sudo
         And I run `canonical-livepatch refresh` with sudo
         And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
         Then stdout matches regexp:

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -408,12 +408,15 @@ def setup_apt_proxy(
     :param https_proxy: the url of the https proxy apt should use, or None
     :return: None
     """
+    if http_proxy or https_proxy:
+        print(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"))
+
     apt_proxy_config = ""
-    if http_proxy is not None:
+    if http_proxy:
         apt_proxy_config += status.MESSAGE_APT_PROXY_HTTP.format(
             proxy_url=http_proxy
         )
-    if https_proxy is not None:
+    if https_proxy:
         apt_proxy_config += status.MESSAGE_APT_PROXY_HTTPS.format(
             proxy_url=https_proxy
         )

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -525,6 +525,8 @@ MESSAGE_APT_PROXY_CONFIG_HEADER = """\
 MESSAGE_APT_PROXY_HTTP = """Acquire::http::Proxy "{proxy_url}";\n"""
 MESSAGE_APT_PROXY_HTTPS = """Acquire::https::Proxy "{proxy_url}";\n"""
 
+MESSAGE_SETTING_SERVICE_PROXY = "Setting {service} proxy"
+
 
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -921,9 +921,9 @@ class TestRunAptCommand:
 
 class TestAptProxyConfig:
     @pytest.mark.parametrize(
-        "kwargs, expected_remove_calls, expected_write_calls",
+        "kwargs, expected_remove_calls, expected_write_calls, expected_out",
         [
-            ({}, [mock.call(APT_PROXY_CONF_FILE)], []),
+            ({}, [mock.call(APT_PROXY_CONF_FILE)], [], ""),
             (
                 {"http_proxy": "mock_http_proxy"},
                 [],
@@ -936,6 +936,7 @@ class TestAptProxyConfig:
                         ),
                     )
                 ],
+                status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"),
             ),
             (
                 {"https_proxy": "mock_https_proxy"},
@@ -949,6 +950,7 @@ class TestAptProxyConfig:
                         ),
                     )
                 ],
+                status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"),
             ),
             (
                 {
@@ -968,6 +970,7 @@ class TestAptProxyConfig:
                         ),
                     )
                 ],
+                status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"),
             ),
         ],
     )
@@ -980,7 +983,12 @@ class TestAptProxyConfig:
         kwargs,
         expected_remove_calls,
         expected_write_calls,
+        expected_out,
+        capsys,
     ):
         setup_apt_proxy(**kwargs)
         assert expected_remove_calls == m_util_remove_file.call_args_list
         assert expected_write_calls == m_util_write_file.call_args_list
+        out, err = capsys.readouterr()
+        assert expected_out == out.strip()
+        assert "" == err


### PR DESCRIPTION
This replaces #1687 

Note this also includes the same bugfix as mentioned here: https://github.com/canonical/ubuntu-advantage-client/pull/1687/files#r658167087

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> proxy: print message when setting proxy

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Set the proxy variables in the config.
Enable an apt based service and livepatch.
Verify concise messages are printed that help you understand what UA is doing.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
