### PR TITLE
status: add account info into json output (SC-152)

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -52,6 +52,12 @@ DEFAULT_STATUS = {
         "products": [],
         "tech_support_level": status.UserFacingStatus.INAPPLICABLE.value,
     },
+    "account": {
+        "name": "",
+        "id": "",
+        "created_at": "",
+        "external_account_ids": [],
+    },
 }  # type: Dict[str, Any]
 
 LOG = logging.getLogger(__name__)
@@ -550,8 +556,6 @@ class UAConfig:
         response.update(
             {
                 "attached": True,
-                "account": self.accounts[0]["name"],
-                "account-id": self.accounts[0]["id"],
                 "origin": contractInfo.get("origin"),
                 "notices": self.read_cache("notices") or [],
                 "contract": {
@@ -560,6 +564,14 @@ class UAConfig:
                     "created_at": contractInfo.get("createdAt", ""),
                     "products": contractInfo.get("products", []),
                     "tech_support_level": tech_support_level,
+                },
+                "account": {
+                    "name": self.accounts[0]["name"],
+                    "id": self.accounts[0]["id"],
+                    "created_at": self.accounts[0].get("createdAt", ""),
+                    "external_account_ids": self.accounts[0].get(
+                        "externalAccountIDs", []
+                    ),
                 },
             }
         )

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -96,7 +96,14 @@ def FakeConfig(tmpdir):
                     "availableResources": [],
                     "machineToken": "not-null",
                     "machineTokenInfo": {
-                        "accountInfo": {"id": "acct-1", "name": account_name},
+                        "accountInfo": {
+                            "id": "acct-1",
+                            "name": account_name,
+                            "createdAt": "2019-06-14T06:45:50Z",
+                            "externalAccountIDs": [
+                                {"IDs": ["id1"], "Origin": "AWS"}
+                            ],
+                        },
                         "contractInfo": {
                             "id": "cid",
                             "name": "test_contract",

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -622,8 +622,9 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     content.append("\nEnable services with: ua enable <service>")
     pairs = []
 
-    if status["account"]:
-        pairs.append(("Account", status["account"]))
+    account_name = status["account"]["name"]
+    if account_name:
+        pairs.append(("Account", account_name))
 
     contract_name = status["contract"]["name"]
     if contract_name:
@@ -659,5 +660,8 @@ def format_json_status(status: "Dict[str, Any]") -> str:
         if service.get("available", "yes") == "yes"
     ]
     status["services"] = available_services
+
+    # We don't need the origin info in the json output
+    status.pop("origin", "")
 
     return json.dumps(status, cls=DatetimeAwareJSONEncoder)

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -340,7 +340,6 @@ class TestActionStatus:
             "attached": False,
             "expires": "n/a",
             "notices": [],
-            "origin": None,
             "services": [
                 {
                     "name": "livepatch",
@@ -355,6 +354,12 @@ class TestActionStatus:
                 "created_at": "",
                 "products": [],
                 "tech_support_level": "n/a",
+            },
+            "account": {
+                "name": "",
+                "id": "",
+                "created_at": "",
+                "external_account_ids": [],
             },
         }
         assert expected == json.loads(capsys.readouterr()[0])
@@ -431,10 +436,7 @@ class TestActionStatus:
             "attached": True,
             "expires": "n/a",
             "notices": [],
-            "origin": None,
             "services": filtered_services,
-            "account": "test_account",
-            "account-id": "acct-1",
             "environment_vars": expected_environment,
             "contract": {
                 "id": "cid",
@@ -442,6 +444,12 @@ class TestActionStatus:
                 "created_at": "2020-05-08T19:02:26+00:00",
                 "products": ["free"],
                 "tech_support_level": tech_support_level,
+            },
+            "account": {
+                "id": "acct-1",
+                "name": "test_account",
+                "created_at": "2019-06-14T06:45:50+00:00",
+                "external_account_ids": [{"IDs": ["id1"], "Origin": "AWS"}],
             },
         }
         assert expected == json.loads(capsys.readouterr()[0])

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -676,7 +676,12 @@ class TestStatus:
         token = {
             "availableResources": [],
             "machineTokenInfo": {
-                "accountInfo": {"id": "acct-1", "name": "test_account"},
+                "accountInfo": {
+                    "id": "acct-1",
+                    "name": "test_account",
+                    "createdAt": "2019-06-14T06:45:50Z",
+                    "externalAccountIDs": [{"IDs": ["id1"], "Origin": "AWS"}],
+                },
                 "contractInfo": {
                     "id": "cid",
                     "name": "test_contract",
@@ -725,8 +730,6 @@ class TestStatus:
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected.update(
             {
-                "account-id": "acct-1",
-                "account": "test_account",
                 "attached": True,
                 "services": expected_services,
                 "contract": {
@@ -737,6 +740,16 @@ class TestStatus:
                     ),
                     "products": ["free"],
                     "tech_support_level": "n/a",
+                },
+                "account": {
+                    "name": "test_account",
+                    "id": "acct-1",
+                    "created_at": datetime.datetime(
+                        2019, 6, 14, 6, 45, 50, tzinfo=datetime.timezone.utc
+                    ),
+                    "external_account_ids": [
+                        {"IDs": ["id1"], "Origin": "AWS"}
+                    ],
                 },
             }
         )
@@ -899,7 +912,12 @@ class TestStatus:
         token = {
             "availableResources": ALL_RESOURCES_AVAILABLE,
             "machineTokenInfo": {
-                "accountInfo": {"id": "1", "name": "accountname"},
+                "accountInfo": {
+                    "id": "1",
+                    "name": "accountname",
+                    "createdAt": "2019-06-14T06:45:50Z",
+                    "externalAccountIDs": [{"IDs": ["id1"], "Origin": "AWS"}],
+                },
                 "contractInfo": {
                     "id": "contract-1",
                     "name": "contractname",
@@ -922,8 +940,6 @@ class TestStatus:
         expected.update(
             {
                 "attached": True,
-                "account": "accountname",
-                "account-id": "1",
                 "contract": {
                     "name": "contractname",
                     "id": "contract-1",
@@ -932,6 +948,16 @@ class TestStatus:
                     ),
                     "products": ["free"],
                     "tech_support_level": support_level,
+                },
+                "account": {
+                    "name": "accountname",
+                    "id": "1",
+                    "created_at": datetime.datetime(
+                        2019, 6, 14, 6, 45, 50, tzinfo=datetime.timezone.utc
+                    ),
+                    "external_account_ids": [
+                        {"IDs": ["id1"], "Origin": "AWS"}
+                    ],
                 },
             }
         )

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -18,14 +18,14 @@ def status_dict_attached(request):
     # The following are required so we don't get an "unattached" error
     status["attached"] = True
     status["expires"] = "expires"
-    status["account"] = ""
+    status["account"] = {"name": ""}
     status["contract"] = {
         "name": "",
         "tech_support_level": UserFacingStatus.INAPPLICABLE.value,
     }
 
     if request.param:
-        status["account"] = "account"
+        status["account"]["name"] = "account"
         status["contract"]["name"] = "subscription"
 
     return status
@@ -162,7 +162,7 @@ class TestFormatTabular:
 
         if status_dict_attached["contract"].get("name"):
             expected_headers = ("Subscription",) + expected_headers
-        if status_dict_attached["account"]:
+        if status_dict_attached["account"].get("name"):
             expected_headers = ("Account",) + expected_headers
 
         tabular_output = format_tabular(status_dict_attached)


### PR DESCRIPTION
## Proposed Commit Message
status: add account info into json output

We are now creating a separate account object in the status json output. We are moving all account related info into that object while also adding new fields to into, such as created_at

## Test Steps
Launch a PRO instance and check that the account info we are adding appears when running `ua status --format json`

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
