### PR TITLE
status: do not modify internal status state

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -100,8 +100,8 @@ def FakeConfig(tmpdir):
                         "contractInfo": {
                             "id": "cid",
                             "name": "test_contract",
-                            "createdAt": "2020-05-08T19:02:26Z",
                             "resourceEntitlements": [],
+                            "createdAt": "2020-05-08T19:02:26Z",
                             "products": ["free"],
                         },
                     },

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -611,7 +611,7 @@ def format_tabular(status: "Dict[str, Any]") -> str:
             "description": description,
         }
         content.append(STATUS_TMPL.format(**fmt_args))
-    tech_support_level = status["contract"]["tech_support_level"]
+    tech_support_level = status["techSupportLevel"]
 
     if status.get("notices"):
         content.extend(
@@ -625,9 +625,8 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     if status["account"]:
         pairs.append(("Account", status["account"]))
 
-    contract_name = status["contract"]["name"]
-    if contract_name:
-        pairs.append(("Subscription", contract_name))
+    if status["subscription"]:
+        pairs.append(("Subscription", status["subscription"]))
 
     if status["origin"] != "free":
         pairs.append(("Valid until", str(status["expires"])))
@@ -659,5 +658,18 @@ def format_json_status(status: "Dict[str, Any]") -> str:
         if service.get("available", "yes") == "yes"
     ]
     status["services"] = available_services
+
+    contract_name = status.pop("subscription", "")
+    contract_id = status.pop("subscription-id", "")
+    contract_created_at = status.pop("contract-created-at", "")
+    contract_products = status.pop("contract-products", [])
+    tech_support_level = status.pop("techSupportLevel", "")
+    status["contract"] = {
+        "name": contract_name,
+        "id": contract_id,
+        "created_at": contract_created_at,
+        "products": contract_products,
+        "tech_support_level": tech_support_level,
+    }
 
     return json.dumps(status, cls=DatetimeAwareJSONEncoder)

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -28,9 +28,7 @@ BASIC_MACHINE_TOKEN = {
         "contractInfo": {
             "name": "mycontract",
             "id": "contract-1",
-            "createdAt": "2020-05-08T19:02:26Z",
             "resourceEntitlements": [],
-            "products": ["free"],
         },
         "accountInfo": {"id": "acct-1", "name": "accountName"},
     },

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -348,14 +348,14 @@ class TestActionStatus:
                     "available": "yes",
                 }
             ],
-            "environment_vars": expected_environment,
             "contract": {
-                "id": "",
                 "name": "",
+                "id": "",
                 "created_at": "",
                 "products": [],
                 "tech_support_level": "n/a",
             },
+            "environment_vars": expected_environment,
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
@@ -420,7 +420,6 @@ class TestActionStatus:
             if service["name"] not in inapplicable_services
         ]
 
-        tech_support_level = status.UserFacingStatus.INAPPLICABLE.value
         expected = {
             "_doc": (
                 "Content provided in json response is currently "
@@ -437,11 +436,11 @@ class TestActionStatus:
             "account-id": "acct-1",
             "environment_vars": expected_environment,
             "contract": {
-                "id": "cid",
                 "name": "test_contract",
+                "id": "cid",
                 "created_at": "2020-05-08T19:02:26+00:00",
                 "products": ["free"],
-                "tech_support_level": tech_support_level,
+                "tech_support_level": "n/a",
             },
         }
         assert expected == json.loads(capsys.readouterr()[0])

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -681,8 +681,8 @@ class TestStatus:
                     "id": "cid",
                     "name": "test_contract",
                     "createdAt": "2020-05-08T19:02:26Z",
-                    "resourceEntitlements": entitled_res,
                     "products": ["free"],
+                    "resourceEntitlements": entitled_res,
                 },
             },
         }
@@ -729,15 +729,12 @@ class TestStatus:
                 "account": "test_account",
                 "attached": True,
                 "services": expected_services,
-                "contract": {
-                    "name": "test_contract",
-                    "id": "cid",
-                    "created_at": datetime.datetime(
-                        2020, 5, 8, 19, 2, 26, tzinfo=datetime.timezone.utc
-                    ),
-                    "products": ["free"],
-                    "tech_support_level": "n/a",
-                },
+                "subscription": "test_contract",
+                "subscription-id": "cid",
+                "contract-products": ["free"],
+                "contract-created-at": datetime.datetime(
+                    2020, 5, 8, 19, 2, 26, tzinfo=datetime.timezone.utc
+                ),
             }
         )
         with mock.patch(
@@ -904,8 +901,8 @@ class TestStatus:
                     "id": "contract-1",
                     "name": "contractname",
                     "createdAt": "2020-05-08T19:02:26Z",
-                    "resourceEntitlements": entitlements,
                     "products": ["free"],
+                    "resourceEntitlements": entitlements,
                 },
             },
         }
@@ -924,15 +921,13 @@ class TestStatus:
                 "attached": True,
                 "account": "accountname",
                 "account-id": "1",
-                "contract": {
-                    "name": "contractname",
-                    "id": "contract-1",
-                    "created_at": datetime.datetime(
-                        2020, 5, 8, 19, 2, 26, tzinfo=datetime.timezone.utc
-                    ),
-                    "products": ["free"],
-                    "tech_support_level": support_level,
-                },
+                "subscription": "contractname",
+                "subscription-id": "contract-1",
+                "contract-products": ["free"],
+                "contract-created-at": datetime.datetime(
+                    2020, 5, 8, 19, 2, 26, tzinfo=datetime.timezone.utc
+                ),
+                "techSupportLevel": support_level,
             }
         )
         for cls in ENTITLEMENT_CLASSES:
@@ -998,9 +993,7 @@ class TestStatus:
                     "name": "contractname",
                     "id": "contract-1",
                     "effectiveTo": "2020-07-18T00:00:00Z",
-                    "createdAt": "2020-05-08T19:02:26Z",
                     "resourceEntitlements": [],
-                    "products": ["free"],
                 },
             },
         }

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -3,12 +3,7 @@ import pytest
 import string
 
 from uaclient import config
-from uaclient.status import (
-    format_tabular,
-    TxtColor,
-    colorize_commands,
-    UserFacingStatus,
-)
+from uaclient.status import format_tabular, TxtColor, colorize_commands
 
 
 @pytest.fixture(params=[True, False])
@@ -18,15 +13,13 @@ def status_dict_attached(request):
     # The following are required so we don't get an "unattached" error
     status["attached"] = True
     status["expires"] = "expires"
-    status["account"] = ""
-    status["contract"] = {
-        "name": "",
-        "tech_support_level": UserFacingStatus.INAPPLICABLE.value,
-    }
 
     if request.param:
         status["account"] = "account"
-        status["contract"]["name"] = "subscription"
+        status["subscription"] = "subscription"
+    else:
+        status["account"] = ""
+        status["subscription"] = ""
 
     return status
 
@@ -120,7 +113,7 @@ class TestFormatTabular:
         istty,
         status_dict_attached,
     ):
-        status_dict_attached["contract"]["tech_support_level"] = support_level
+        status_dict_attached["techSupportLevel"] = support_level
 
         m_isatty.return_value = istty
         tabular_output = format_tabular(status_dict_attached)
@@ -160,7 +153,7 @@ class TestFormatTabular:
     ):
         status_dict_attached["origin"] = origin
 
-        if status_dict_attached["contract"].get("name"):
+        if status_dict_attached["subscription"]:
             expected_headers = ("Subscription",) + expected_headers
         if status_dict_attached["account"]:
             expected_headers = ("Account",) + expected_headers


### PR DESCRIPTION
## Proposed Commit Message
status: do not modify internal status state

We have modified our internal status state to better reflect the contract structure we want to output in the json format. However,
by modifying the internal we end up affecting non-root users. That is because when a non-root user runs ua status, we get the status directly from the file saved on disk. If the user has not run any root commands after installing a new version of uaclient, that file on disk will be stale and will not be able to be used by the status formatting code. Because of that, we are bringing back the original internal status representation.

## Test Steps
Launch a container and verify that the contract info appears when running `ua status --format json` for an unattached and attached system

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
