### PR TITLE
status: allow output to be in yaml format (SC-158)

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -49,7 +49,7 @@ DEFAULT_LOG_FORMAT = (
     "%(asctime)s - %(filename)s:(%(lineno)d) [%(levelname)s]: %(message)s"
 )
 
-STATUS_FORMATS = ["tabular", "json"]
+STATUS_FORMATS = ["tabular", "json", "yaml"]
 
 
 # Set a module-level callable here so we don't have to reinstantiate
@@ -889,6 +889,8 @@ def action_status(args, cfg):
         print("")
     if args and args.format == "json":
         print(ua_status.format_json_status(status))
+    elif args and args.format == "yaml":
+        print(ua_status.format_yaml_status(status))
     else:
         output = ua_status.format_tabular(status)
         # Replace our Unicode dash with an ASCII dash if we aren't going to be

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -40,7 +40,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         we will perform two actions:
 
         1. Upgrade the package to the FIPS version
-        2. Install the correspinding hmac version of that package.
+        2. Install the corresponding hmac version of that package
+           when available.
         """
         conditional_packages = [
             "strongswan",

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -655,9 +655,7 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     return "\n".join(content)
 
 
-def format_json_status(status: "Dict[str, Any]") -> str:
-    from uaclient.util import DatetimeAwareJSONEncoder
-
+def _format_status_output(status: "Dict[str, Any]") -> "Dict[str, Any]":
     status["environment_vars"] = [
         {"name": name, "value": value}
         for name, value in sorted(os.environ.items())
@@ -675,5 +673,18 @@ def format_json_status(status: "Dict[str, Any]") -> str:
 
     # We don't need the origin info in the json output
     status.pop("origin", "")
+    return status
 
-    return json.dumps(status, cls=DatetimeAwareJSONEncoder)
+
+def format_json_status(status: "Dict[str, Any]") -> str:
+    from uaclient.util import DatetimeAwareJSONEncoder
+
+    return json.dumps(
+        _format_status_output(status), cls=DatetimeAwareJSONEncoder
+    )
+
+
+def format_yaml_status(status: "Dict[str, Any]") -> str:
+    import yaml
+
+    return yaml.dump(_format_status_output(status), default_flow_style=False)


### PR DESCRIPTION
## Proposed Commit Message
status: allow output to be in yaml format

We are now allowing users to specify the yaml format when looking at the status output

## Test Steps
Launch a machine and test running `ua status --format yaml` on an unattached an attached uaclient

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
