### PR TITLE
status: update root level keys of json status (SC-150)

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -880,9 +880,9 @@ def action_status(args, cfg):
     show_beta = args.all if args else False
     status = cfg.status(show_beta=show_beta)
     active_value = ua_status.UserFacingConfigStatus.ACTIVE.value
-    config_active = bool(status["configStatus"] == active_value)
+    config_active = bool(status["execution_status"] == active_value)
     if args and args.wait and config_active:
-        while status["configStatus"] == active_value:
+        while status["execution_status"] == active_value:
             print(".", end="")
             time.sleep(1)
             status = cfg.status(show_beta=show_beta)

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -96,6 +96,7 @@ def FakeConfig(tmpdir):
                     "availableResources": [],
                     "machineToken": "not-null",
                     "machineTokenInfo": {
+                        "machineId": "test_machine_id",
                         "accountInfo": {
                             "id": "acct-1",
                             "name": account_name,
@@ -108,6 +109,8 @@ def FakeConfig(tmpdir):
                             "id": "cid",
                             "name": "test_contract",
                             "createdAt": "2020-05-08T19:02:26Z",
+                            "effectiveFrom": "2000-05-08T19:02:26Z",
+                            "effectiveTo": "2040-05-08T19:02:26Z",
                             "resourceEntitlements": [],
                             "products": ["free"],
                         },

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -658,9 +658,6 @@ def format_tabular(status: "Dict[str, Any]") -> str:
 def format_json_status(status: "Dict[str, Any]") -> str:
     from uaclient.util import DatetimeAwareJSONEncoder
 
-    if status["expires"] != UserFacingStatus.INAPPLICABLE.value:
-        status["expires"] = str(status["expires"])
-
     status["environment_vars"] = [
         {"name": name, "value": value}
         for name, value in sorted(os.environ.items())

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -25,6 +25,7 @@ BASIC_MACHINE_TOKEN = {
     "availableResources": [],
     "machineToken": "non-empty-token",
     "machineTokenInfo": {
+        "machineId": "test_machine_id",
         "contractInfo": {
             "name": "mycontract",
             "id": "contract-1",

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -8,7 +8,7 @@ import textwrap
 
 import pytest
 
-from uaclient import util
+from uaclient import util, version
 
 from uaclient.cli import action_status, main
 from uaclient import status
@@ -47,7 +47,7 @@ Enable services with: ua enable <service>
 
                 Account: test_account
            Subscription: test_contract
-            Valid until: n/a
+            Valid until: 2040-05-08 19:02:26+00:00
 Technical support level: n/a
 """
 
@@ -66,7 +66,7 @@ Enable services with: ua enable <service>
 
                 Account: test_account
            Subscription: test_contract
-            Valid until: n/a
+            Valid until: 2040-05-08 19:02:26+00:00
 Technical support level: n/a
 """
 
@@ -79,7 +79,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "cc-eal",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "yes",
     },
     {
@@ -88,7 +88,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "cis",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "yes",
     },
     {
@@ -97,7 +97,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "esm-apps",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "yes",
     },
     {
@@ -106,7 +106,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "esm-infra",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "yes",
     },
     {
@@ -115,7 +115,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "fips",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "no",
     },
     {
@@ -126,7 +126,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "fips-updates",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "yes",
     },
     {
@@ -135,7 +135,7 @@ SERVICES_JSON_ALL = [
         "entitled": "no",
         "name": "livepatch",
         "status": "—",
-        "statusDetails": "",
+        "status_details": "",
         "available": "yes",
     },
 ]
@@ -263,12 +263,14 @@ class TestActionStatus:
         assert 0 == action_status(mock.MagicMock(all=False), cfg)
         assert UNATTACHED_STATUS == capsys.readouterr()[0]
 
+    @mock.patch("uaclient.version.get_version", return_value="test_version")
     @mock.patch("uaclient.util.subp")
     @mock.patch(M_PATH + "time.sleep")
     def test_wait_blocks_until_lock_released(
         self,
         m_sleep,
         m_subp,
+        _m_get_version,
         m_getuid,
         m_get_avail_resources,
         _m_should_reboot,
@@ -335,10 +337,14 @@ class TestActionStatus:
                 "Content provided in json response is currently "
                 "considered Experimental and may change"
             ),
-            "configStatus": status.UserFacingConfigStatus.INACTIVE.value,
-            "configStatusDetails": status.MESSAGE_NO_ACTIVE_OPERATIONS,
+            "_schema_version": "0.1",
+            "version": version.get_version(features=cfg.features),
+            "execution_status": status.UserFacingConfigStatus.INACTIVE.value,
+            "execution_details": status.MESSAGE_NO_ACTIVE_OPERATIONS,
             "attached": False,
-            "expires": "n/a",
+            "machine_id": None,
+            "effective": None,
+            "expires": None,
             "notices": [],
             "services": [
                 {
@@ -431,10 +437,14 @@ class TestActionStatus:
                 "Content provided in json response is currently "
                 "considered Experimental and may change"
             ),
-            "configStatus": status.UserFacingConfigStatus.INACTIVE.value,
-            "configStatusDetails": status.MESSAGE_NO_ACTIVE_OPERATIONS,
+            "_schema_version": "0.1",
+            "version": version.get_version(features=cfg.features),
+            "execution_status": status.UserFacingConfigStatus.INACTIVE.value,
+            "execution_details": status.MESSAGE_NO_ACTIVE_OPERATIONS,
             "attached": True,
-            "expires": "n/a",
+            "machine_id": "test_machine_id",
+            "effective": "2000-05-08T19:02:26+00:00",
+            "expires": "2040-05-08T19:02:26+00:00",
             "notices": [],
             "services": filtered_services,
             "environment_vars": expected_environment,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->
```
status: update root level keys of json status

* changes expires to null when not present instead of "n/a"
* ensures expires is always iso format
* adds _schema_version
* adds version
* adds machine_id
* adds effective
* changes configStatus to execution_status
* changes configStatusDetails to execution_details
* changes services[].statusDetails to services[].status_details
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run `ua status --format=json` as {nonroot, root} {unattached, attached} and ensure changes described in commit message are applied appropriately.

@blackboxsw @lucasmoura some of these may be breaking changes. If they are then I can revert them for now. Do you know if desktop team (or anyone else) relies on the old camelCase keys or on the expires value "n/a"?

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
