### PR TITLE
status: add config info in the status output

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -453,9 +453,7 @@ class UAConfig:
 
         return new_response
 
-    def _get_config_status(
-        self
-    ) -> "Dict[str, Union[str, List[Tuple[str,str]]]]":
+    def _get_config_status(self) -> "Dict[str, Any]":
         """Return a dict with execution_status, execution_details and notices.
 
             Values for execution_status will be one of UserFacingConfigStatus
@@ -488,6 +486,10 @@ class UAConfig:
             "execution_status": status_val,
             "execution_details": status_desc,
             "notices": notices,
+            "config_path": self.cfg.get("config_path"),
+            "config": {
+                k: v for k, v in self.cfg.items() if k != "config_path"
+            },
         }
 
     def _unattached_status(self) -> "Dict[str, Any]":
@@ -817,6 +819,7 @@ def parse_config(config_path=None):
     cfg.update(env_keys)
     cfg["log_level"] = cfg["log_level"].upper()
     cfg["data_dir"] = os.path.expanduser(cfg["data_dir"])
+    cfg["config_path"] = config_path
     for key in ("contract_url", "security_url"):
         if not util.is_service_url(cfg[key]):
             raise exceptions.UserFacingError(

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -83,7 +83,9 @@ def logging_sandbox():
 def FakeConfig(tmpdir):
     class _FakeConfig(UAConfig):
         def __init__(self, features_override=None) -> None:
-            super().__init__({"data_dir": tmpdir.strpath})
+            super().__init__(
+                {"data_dir": tmpdir.strpath, "config_path": "config_path"}
+            )
 
         @classmethod
         def for_attached_machine(

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -682,6 +682,7 @@ def _format_status_output(status: "Dict[str, Any]") -> "Dict[str, Any]":
 
     # We don't need the origin info in the json output
     status.pop("origin", "")
+
     return status
 
 

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -371,6 +371,8 @@ class TestActionStatus:
                 "created_at": "",
                 "external_account_ids": [],
             },
+            "config_path": "config_path",
+            "config": {"data_dir": mock.ANY},
         }
 
         if format_type == "json":
@@ -490,6 +492,8 @@ class TestActionStatus:
                 "created_at": account_created_at,
                 "external_account_ids": [{"IDs": ["id1"], "Origin": "AWS"}],
             },
+            "config_path": "config_path",
+            "config": {"data_dir": mock.ANY},
         }
 
         if format_type == "json":

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1082,6 +1082,8 @@ class TestStatus:
                 "execution_status": reboot_required,
                 "execution_details": details,
                 "notices": [],
+                "config_path": None,
+                "config": {"data_dir": mock.ANY},
             }
         )
 
@@ -1294,6 +1296,7 @@ class TestParseConfig:
             "data_dir": "/var/lib/ubuntu-advantage",
             "log_file": "/var/log/ubuntu-advantage.log",
             "log_level": "INFO",
+            "config_path": "/etc/ubuntu-advantage/uaclient.conf",
         }
         assert expected_default_config == config
 


### PR DESCRIPTION
## Proposed Commit Message
status: add config info in the status output

We are now adding config info in the status output. This will be reflected whenener the user runs ua status with the --format flag

## Test Steps
Launch a machine and check if the output of `ua status --format json` has the config keys. Also, check if changing the path to load the config file from will reflect in ua status

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
