### PR TITLE
mypy: add packaging constraint

### DIFF
--- a/tools/constraints-mypy.txt
+++ b/tools/constraints-mypy.txt
@@ -1,3 +1,4 @@
 mypy
 pytest==6.1.2
 importlib-metadata==3.3.0
+packaging==20.9


### PR DESCRIPTION
## Proposed Commit Message
mypy: add packaging constraint

packaging was recently updated to a version that uses type hints. This is not supported on python 3.5, which is a version we are running mypy tests on. We are now freezing packaging to a version that doesn't break mypy checks for python 3.5

## Test Steps
Run mypy test without this change and see the python 3.5 error. Apply this change and confirm that the problem is fixed

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
