### PR TITLE
tests: do not prompt when installing uaclient

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -804,8 +804,19 @@ def _install_uat_in_container(
             inst.push_file(deb_file, "/tmp/" + deb_name)
 
         cmds.append(
-            ["sudo", "apt-get", "install", "-y", "--allow-downgrades"]
-            + deb_files
+            " ".join(
+                [
+                    "sudo",
+                    "DEBIAN_FRONTEND=noninteractive",
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "--allow-downgrades",
+                    '-o Dpkg::Options::="--force-confdef"',
+                    '-o Dpkg::Options::="--force-confold"',
+                ]
+                + deb_files
+            )
         )
     else:
         ua_pkg = ["ubuntu-advantage-tools"]
@@ -813,7 +824,19 @@ def _install_uat_in_container(
             ua_pkg.append("ubuntu-advantage-pro")
 
         cmds.append(
-            ["sudo", "apt-get", "install", "-y", "--allow-downgrades"] + ua_pkg
+            " ".join(
+                [
+                    "sudo",
+                    "DEBIAN_FRONTEND=noninteractive",
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "--allow-downgrades",
+                    '-o Dpkg::Options::="--force-confdef"',
+                    '-o Dpkg::Options::="--force-confold"',
+                ]
+                + ua_pkg
+            )
         )
 
     if "pro" in config.machine_type:


### PR DESCRIPTION
## Proposed Commit Message
tests: do not prompt when installing uaclient

We have recently changed uaclient.conf config file. On PRO test, we have custom config to block auto-attach. Because of that,
when we install the new uaclient package, we are prompted about config changes. We are now updating our install command to not prompt under those circumstances

## Test Steps
Run the azurepro-16.04 integration test without this change and confirm that uaclient is not properly installed. Add this change and verify that the test now succeeds as expected 

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
