### PR TITLE
non-root patch status.json file to avoid tracebacks (SC- 190)

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -265,6 +265,19 @@ mark_reboot_cmds_as_needed() {
     add_notice "$msg_name"
 }
 
+patch_status_json_0_1_for_non_root() {
+    # UA client 27.2 broke status.json schema backward-compatibility for
+    # non-root users apply a patch to allow non-root user to run `ua status`
+    # without Tracebacks
+    if dpkg --compare-versions "$PREVIOUS_PKG_VER" gt-nl "27.2"; then
+        return
+    fi
+    if [ ! -e "/var/lib/ubuntu-advantage/status.json" ]; then
+        return
+    fi
+    /usr/lib/ubuntu-advantage/patch_status_json.py || true
+}
+
 notify_wrong_fips_metapackage_on_cloud() {
 
     # On xenial, we don't have FIPS optimized kernels on the clouds.
@@ -320,7 +333,7 @@ case "$1" in
               rm -f $SYSTEMD_HELPER_ENABLED_WANTS_LINK
           fi
       fi
-
+      patch_status_json_0_1_for_non_root
       # UA service PPAs support all ubuntu releases, no need to
       # specialize apt config filenames per ubuntu release.
       redact_ubuntu_release_from_ua_apt_filenames $APT_SRC_DIR

--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""
+Patch status.json file to avoid tracebacks for non-root from `ua status`
+
+Between 27.1 and 27.2 status.json broke schema key backward-compatibility.
+
+Running `ua status` as non-root users does not generate a new status.json with
+the updated status.json schema so the logic which renders ua status
+information will traceback on KeyErrors.
+
+Since we haven't introduced official schema versioning in UA client yet,
+this patch is a stop-gap until official schema version handling is
+delivered.
+"""
+
+import copy
+import json
+import logging
+
+from uaclient.cli import setup_logging
+from uaclient import util
+
+
+def patch_status_json_schema_0_1(status_file: str):
+    """Patch incompatible status.json file schema to align with version 0.1."""
+    setup_logging(logging.INFO, logging.DEBUG)
+    content = util.load_file(status_file)
+    try:
+        status = json.loads(content, cls=util.DatetimeAwareJSONDecoder)
+    except ValueError as e:
+        logging.debug(
+            "Unable to patch /var/lib/ubuntu-advantage/status.json: {}".format(
+                str(e)
+            )
+        )
+        return
+    new_status = copy.deepcopy(status)
+    if float(status.get("_schema_version", 0)) >= 0.1:
+        return  # Already have version 0.1 from daily PPA
+    logging.debug("Patching /var/lib/ubuntu-advantage/status.json schema")
+    new_status["_schema_version"] = "0.1"
+    new_status["account"] = {
+        "name": new_status.pop("account", ""),
+        "id": new_status.pop("account-id", ""),
+    }
+    new_status["contract"] = {
+        "tech_support_level": new_status.pop("techSupportLevel", "n/a"),
+        "name": new_status.pop("subscription", ""),
+        "id": new_status.pop("subscription-id", ""),
+    }
+    new_status["execution_status"] = new_status.pop("configStatus")
+    new_status["execution_details"] = new_status.pop("configStatusDetails")
+    try:
+        status_content = json.dumps(
+            new_status, cls=util.DatetimeAwareJSONEncoder
+        )
+    except ValueError as e:
+        logging.debug(
+            "Unable to patch /var/lib/ubuntu-advantage/status.json: {}".format(
+                str(e)
+            )
+        )
+    util.write_file(status_file, status_content)
+
+
+if __name__ == "__main__":
+    patch_status_json_schema_0_1(
+        status_file="/var/lib/ubuntu-advantage/status.json"
+    )

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1452,6 +1452,8 @@ class TestParseConfig:
         warn_logs = caplog_text()
         for warning in warnings:
             assert warning in warn_logs
+        if not warnings:
+            assert "Ignoring invalid uaclient.conf key" not in warn_logs
         assert expected == cfg
 
     @pytest.mark.parametrize(

--- a/uaclient/tests/test_patch_status_json.py
+++ b/uaclient/tests/test_patch_status_json.py
@@ -1,0 +1,139 @@
+import logging
+import pytest
+
+import json
+
+from lib.patch_status_json import patch_status_json_schema_0_1
+
+UNATTACHED_UNPATCHED_STATUS = {
+    "_doc": "Content provided in json response is currently considered ...",
+    "attached": False,
+    "expires": "n/a",
+    "techSupportLevel": "n/a",
+    "notices": [],
+    "services": [
+        {
+            "name": "cc-eal",
+            "available": "yes",
+            "description": "Common Criteria EAL2 Provisioning Packages",
+        }
+    ],
+    "origin": None,
+    "configStatusDetails": "No Ubuntu Advantage operations are running",
+    "configStatus": "inactive",
+}
+
+# Note that (UN)ATTACHED_PATCHED_STATUS is only a capture of expected minimal
+# schema transformation performed by patch_status function to allow ua status
+# to work without errors for non-root user. It is not expected to be a full
+# representation of schema which will be written once a root user runs any
+# ua command which will rewrite the full latest schema to status.json.
+UNATTACHED_PATCHED_STATUS = {
+    "execution_details": "No Ubuntu Advantage operations are running",
+    "_schema_version": "0.1",
+    "origin": None,
+    "account": {"name": "", "id": ""},
+    "expires": "n/a",
+    "notices": [],
+    "services": [
+        {
+            "available": "yes",
+            "name": "cc-eal",
+            "description": "Common Criteria EAL2 Provisioning Packages",
+        }
+    ],
+    "attached": False,
+    "execution_status": "inactive",
+    "contract": {"name": "", "id": "", "tech_support_level": "n/a"},
+    "_doc": "Content provided in json response is currently considered ...",
+}
+
+ATTACHED_UNPATCHED_STATUS = {
+    "_doc": "Content provided in json response is currently considered ...",
+    "configStatusDetails": "Operation in progress: ua attach (pid:33140)",
+    "configStatus": "active",
+    "subscription": "chad.smith@canonical.com",
+    "subscription-id": "cAKuvrqHend2ZHxUYTyJqXhULJ-4r2lpCzd1HLC_lrJg",
+    "services": [
+        {
+            "entitled": "yes",
+            "description": "Common Criteria EAL2 Provisioning Packages",
+            "description_override": None,
+            "name": "cc-eal",
+            "statusDetails": "CC EAL2 is not configured",
+            "status": "disabled",
+        }
+    ],
+    "notices": [["Operation in progress: ua attach"]],
+    "attached": True,
+    "account-id": "aAHQlZdfWiafnWvjDZCZDqZzDUComc8WF7IJnoG6GAmA",
+    "account": "chad.smith@canonical.com",
+    "techSupportLevel": "n/a",
+    "expires": "9999-12-31T00:00:00",
+    "origin": "free",
+}
+
+ATTACHED_PATCHED_STATUS = {
+    "_doc": "Content provided in json response is currently considered ...",
+    "origin": "free",
+    "execution_details": "Operation in progress: ua attach (pid:33140)",
+    "execution_status": "active",
+    "expires": "9999-12-31T00:00:00+00:00",
+    "contract": {
+        "tech_support_level": "n/a",
+        "name": "chad.smith@canonical.com",
+        "id": "cAKuvrqHend2ZHxUYTyJqXhULJ-4r2lpCzd1HLC_lrJg",
+    },
+    "services": [
+        {
+            "description_override": None,
+            "entitled": "yes",
+            "description": "Common Criteria EAL2 Provisioning Packages",
+            "status": "disabled",
+            "statusDetails": "CC EAL2 is not configured",
+            "name": "cc-eal",
+        }
+    ],
+    "_schema_version": "0.1",
+    "attached": True,
+    "notices": [["Operation in progress: ua attach"]],
+    "account": {
+        "name": "chad.smith@canonical.com",
+        "id": "aAHQlZdfWiafnWvjDZCZDqZzDUComc8WF7IJnoG6GAmA",
+    },
+}
+
+
+@pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+class TestPatchStatusJSONSchema0_1:
+    @pytest.mark.parametrize(
+        "orig_status,expected_status,expected_logs",
+        (
+            (
+                UNATTACHED_UNPATCHED_STATUS,
+                UNATTACHED_PATCHED_STATUS,
+                ["Patching /var/lib/ubuntu-advantage/status.json schema"],
+            ),
+            (
+                ATTACHED_UNPATCHED_STATUS,
+                ATTACHED_PATCHED_STATUS,
+                ["Patching /var/lib/ubuntu-advantage/status.json schema"],
+            ),
+            (UNATTACHED_PATCHED_STATUS, UNATTACHED_PATCHED_STATUS, []),
+        ),
+    )
+    def test_unattached_noops(
+        self, orig_status, expected_status, expected_logs, tmpdir, caplog_text
+    ):
+        status_file = tmpdir.join("status.json")
+        status_file.write(json.dumps(orig_status))
+        patch_status_json_schema_0_1(status_file=status_file.strpath)
+        assert expected_status == json.loads(status_file.read())
+        debug_logs = caplog_text()
+        for log in expected_logs:
+            assert log in debug_logs
+        if not expected_logs:
+            assert (
+                "Patching /var/lib/ubuntu-advantage/status.json"
+                not in debug_logs
+            )


### PR DESCRIPTION
There were a couple key renames and drops in in `/var/lib/ubuntu-advantage/statu.json` which would break non-root users runnning `ua status` after upgrade because non-root tries to read the old status.json cache which is only updated once a root user runs any UA subcommand.

Add postinst script to fix status.json for non-root users for the 27.2 release  of ubuntu-advantage-tools. It will only be triggered if /var/lib/ubuntu-advantage/status.json exists and we are upgrading from a ua-tools version prior to 27.2.


Also perform a drive-by bug fix: ua status on 27.2 emits warning messages about the config_path key added in an unrelated PR.
change write_cfg to avoid persiting "config_path" to uaclient.conf and move config_path additions below valid key checks in parse_config

## Proposed Commit Message
- 
    postinst: add status.json patch script run during postinst
    
    Between 27.1 and 27.2 ua client renamed a number of keys in
    /var/lib/ubuntu-advantage/status.json.
    
    This breaks status.json schema compatibility and results in a
    Traceback for non-root users running `ua status` because non-root
    sources the stale cached status.json with the old schema whereas
    root users would re-write status.json during any ua operation.
    
    Introduce a status schema patch file, which will be called during
    package upgrade in postinst which will adapt the status.json cache
    to the new keys so non-root users don't see errors from ua status.
    
    Official status.json chema compatibility will be introduced after
    27.2 release.

- config: do not warn on config_path key in parse_config
    
    Also do not persist config_path in UAConfig.write_cfg

## Test Steps
```bash
sed -i 's/UNRELEASED/bionic/' debian/changelog
git commit -am 'build for bionic'
build-package
sbuild-it ../out/ubuntu-advantage-tools_28.0.dsc
lxc launch ubuntu-daily:bionic dev-b
lxc file push ubuntu-advantage-tools_28.0_amd64.deb dev-b/
lxc exec dev-b bash
su - ubuntu
ua version # confirm current released version 27.1
sudo ua status # to persist version 27.1 status.json file

ua status  # expect ua status failure as non-root
# upgrade to your 28.0 deb
sudo dpkg -i /ubuntu-advantage-tools_28.0_amd64.deb
ua status  # expect success as non-root after postinst ran
grep -i patch /var/log/ubuntu-advantage.log # to see schema patch messages
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
