### PR TITLE
config: remove config_path from config dict

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -83,9 +83,7 @@ def logging_sandbox():
 def FakeConfig(tmpdir):
     class _FakeConfig(UAConfig):
         def __init__(self, features_override=None) -> None:
-            super().__init__(
-                {"data_dir": tmpdir.strpath, "config_path": "config_path"}
-            )
+            super().__init__({"data_dir": tmpdir.strpath})
 
         @classmethod
         def for_attached_machine(

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -371,7 +371,7 @@ class TestActionStatus:
                 "created_at": "",
                 "external_account_ids": [],
             },
-            "config_path": "config_path",
+            "config_path": None,
             "config": {"data_dir": mock.ANY},
         }
 
@@ -492,7 +492,7 @@ class TestActionStatus:
                 "created_at": account_created_at,
                 "external_account_ids": [{"IDs": ["id1"], "Origin": "AWS"}],
             },
-            "config_path": "config_path",
+            "config_path": None,
             "config": {"data_dir": mock.ANY},
         }
 


### PR DESCRIPTION
## Proposed Commit Message
config: remove config_path from config dict

We are now removing the config_path entry from the config dict and pushing that logic into a dedicated function. We are using that to not clash with the write_cfg method which by default writes all content of the config dict into disk. Since the config_path is a variable that is being used only internally, we don't need it on disk.

## Test Steps
Run the modified unit tests and check that `config_path` is still working as expected when running any of the `ua status --format` commands

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
