### PR TITLE
Log relevant env vars when running ua commands (SC-213)

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -29,6 +29,7 @@ from uaclient import status as ua_status
 from uaclient import util
 from uaclient import version
 from uaclient.clouds import identity
+from uaclient.defaults import CONFIG_FIELD_ENVVAR_ALLOWLIST
 
 NAME = "ua"
 
@@ -1325,6 +1326,19 @@ def main(sys_argv=None):
     logging.debug(
         util.redact_sensitive_logs("Executed with sys.argv: %r" % sys_argv)
     )
+    ua_environment = [
+        "{}={}".format(k, v)
+        for k, v in sorted(os.environ.items())
+        if k.lower() in CONFIG_FIELD_ENVVAR_ALLOWLIST
+        or k.startswith("UA_FEATURES")
+        or k == "UA_CONFIG_FILE"
+    ]
+    if ua_environment:
+        logging.debug(
+            util.redact_sensitive_logs(
+                "Executed with UA environment variables: %r" % ua_environment
+            )
+        )
     return args.action(args, cfg)
 
 

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -634,6 +634,22 @@ class TestMain:
 
         assert "['some', 'args']" in log
 
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.cli.get_parser")
+    @mock.patch.dict(
+        os.environ, {"NOT_UA_ENV": "YES", "UA_FEATURES_WOW": "XYZ"}
+    )
+    def test_environment_is_logged(
+        self, _m_get_parser, _m_setup_logging, logging_sandbox, caplog_text
+    ):
+        main(["some", "args"])
+
+        log = caplog_text()
+
+        assert "UA_FEATURES_WOW=XYZ" in log
+        assert "NOT_UA_ENV=YES" not in log
+
     def test_argparse_errors_well_formatted(self, capsys):
         parser = get_parser()
         with mock.patch("sys.argv", ["ua", "enable"]):


### PR DESCRIPTION
The variables are the same registered on the status JSON, as in **8f10bc5d761a5d3da1ab237db34937d20ddc45e8**

## Test Steps
- Run a command with the aforementioned environment variables
- Check `/var/log/ubuntu-advantage.log` - it should be there

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
