### PR TITLE
fips: do not block enable on conditional packages (SC-216)

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 import logging
 import os
 import re
@@ -63,7 +64,9 @@ class RepoEntitlement(base.UAEntitlement):
 
         if entitlement:
             directives = entitlement.get("directives", {})
-            additional_packages = directives.get("additionalPackages", [])
+            additional_packages = copy.copy(
+                directives.get("additionalPackages", [])
+            )
 
             packages = additional_packages
 
@@ -222,16 +225,22 @@ class RepoEntitlement(base.UAEntitlement):
         return True
 
     def install_packages(
-        self, package_list: "List[str]" = None, cleanup_on_failure: bool = True
+        self,
+        package_list: "List[str]" = None,
+        cleanup_on_failure: bool = True,
+        verbose: bool = True,
     ) -> None:
         """Install contract recommended packages for the entitlement.
 
         :param package_list: Optional package list to use instead of
             self.packages.
-        :param package_list: Optional package list to use instead of
-            self.packages.
+        :param cleanup_on_failure: Cleanup apt files if apt install fails.
+        :param verbose: If true, print messages to stdout
         """
-        print("Installing {title} packages".format(title=self.title))
+
+        if verbose:
+            print("Installing {title} packages".format(title=self.title))
+
         if self.apt_noninteractive:
             env = {"DEBIAN_FRONTEND": "noninteractive"}
             apt_options = [

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -301,6 +301,9 @@ MESSAGE_FIPS_REBOOT_REQUIRED = (
 MESSAGE_FIPS_DISABLE_REBOOT_REQUIRED = (
     "Disabling FIPS requires system reboot to complete operation."
 )
+MESSAGE_FIPS_PACKAGE_NOT_AVAILABLE = (
+    "{service} {pkg} package could not be installed"
+)
 NOTICE_FIPS_MANUAL_DISABLE_URL = """\
 FIPS kernel is running in a disabled state.
   To manually remove fips kernel: https://discourse.ubuntu.com/t/20738


### PR DESCRIPTION
## Proposed Commit Message
fips: do not block enable on conditional packages

When enabling fips we install FIPS version of some packages if they are already installed in the system. Currently, we
block enable if we can't install any of those conditional packages. Now, we are alerting the user about errors on installing those
packages, but we don't block the enable operation

## Test Steps
Run the new integration test added

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
