### PR TITLE
tests: drop fips contract overlays for focal on staging (SC-217)

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -284,46 +284,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
-        And I create the file `/home/ubuntu/machine-token-overlay.json` with the following:
-        """
-        {
-           "availableResources": [
-               {
-                 "available": true,
-                 "name": "fips"
-               }
-            ],
-            "machineTokenInfo": {
-                "contractInfo": {
-                   "resourceEntitlements": [
-                      {
-                        "type": "fips",
-                        "entitled": true,
-                        "affordances": {
-                          "series": [
-                            "xenial",
-                            "bionic",
-                            "focal"
-                          ]
-                         },
-                        "directives": {
-                          "suites": [
-                            "xenial",
-                            "bionic",
-                            "focal"
-                          ]
-                        }
-                     }
-                   ]
-                }
-            }
-        }
-        """
-        And I append the following on uaclient config:
-        """
-        features:
-          machine_token_overlay: "/home/ubuntu/machine-token-overlay.json"
-        """
         When I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
@@ -384,46 +344,6 @@ Feature: Enable command behaviour when attached to an UA staging subscription
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
-        And I create the file `/home/ubuntu/machine-token-overlay.json` with the following:
-        """
-        {
-           "availableResources": [
-               {
-                 "available": true,
-                 "name": "fips-updates"
-               }
-            ],
-            "machineTokenInfo": {
-                "contractInfo": {
-                   "resourceEntitlements": [
-                      {
-                        "type": "fips-updates",
-                        "entitled": true,
-                        "affordances": {
-                          "series": [
-                            "xenial",
-                            "bionic",
-                            "focal"
-                          ]
-                         },
-                        "directives": {
-                          "suites": [
-                            "xenial-updates",
-                            "bionic-updates",
-                            "focal-updates"
-                          ]
-                        }
-                     }
-                   ]
-                }
-            }
-        }
-        """
-        And I append the following on uaclient config:
-        """
-        features:
-          machine_token_overlay: "/home/ubuntu/machine-token-overlay.json"
-        """
         When I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """


### PR DESCRIPTION
Remove FIPS contract overlays for focal on staging, as they are not needed anymore.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
