### PR TITLE
Fix 27.2 changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 ubuntu-advantage-tools (27.2~21.10.1) impish; urgency=medium
 
   * d/changelog:
-    - fix lintian typos in 24.4 and 27.0 changelog entries
+    - fix lintian typos in 27.0 changelog entry
   * d/control:
     - add comments to explain complex build-depends
     - add version requirement to distro-info (LP: #1932028)


### PR DESCRIPTION
## Proposed Commit Message
Remove 24.4 lintian entry on 27.2 changelog

It seems that release 24.4 changelog was not modified for release 27.2. Because of that, we are removing that entry from the changelog


