### PR TITLE
Remove changelog entry already reflected on 27.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,5 @@
 ubuntu-advantage-tools (27.2~21.10.1) impish; urgency=medium
 
-  * d/changelog:
-    - fix lintian typos in 27.0 changelog entry
   * d/control:
     - add comments to explain complex build-depends
     - add version requirement to distro-info (LP: #1932028)


### PR DESCRIPTION
We have a changelog entry for fixing lintian errors on the release 27.0 changelog. However, this was already reflected on 27.1. We are now removing that changelog entry from 27.2

