### PR TITLE
Remve apt-hook entry from release 27.2 changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,7 +6,6 @@ ubuntu-advantage-tools (27.2~21.10.1) impish; urgency=medium
   * d/tools.postinst:
     - run status.json schema patch script to avoid non-root status errors
   * New upstream release 27.2:
-    - apt-hook: fix invalid 20apt-esm-hook.conf syntax (LP: #1930741)
     - attach: print contract server reason for 403 (GH: #1630)
     - cli: add ua config set, unset and show subcommands
     - config:


### PR DESCRIPTION
The 20apt-esm-hook.conf fix was already covered in the past release. We don't need that entry again for 27.2

