### PR TITLE
Information about proxy authentication (SC-238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ configuration is required to properly enable that service.
 Any interactions with the Contract server API are defined as UAContractClient
 class methods in [uaclient/contract.py](uaclient/contract.py).
 
+### Using a proxy
+The UA Client can be configured to use an http/https proxy as needed for network requests.
+In addition, the UA Client will automatically set up proxies for all programs required for
+enabling Ubuntu Advantage services. This includes APT, Snaps, and Livepatch.
+
+The proxy can be set to the config file under `ua config`. HTTP/HTTPS proxies are
+set using `http_proxy` and `https_proxy`, respectively. APT proxies are defined
+separately, using `apt_http_proxy` and `apt_https_proxy`. The proxy is identified
+by a string formatted as:
+
+`<protocol>://[<username>:<password>@]<fqdn>:<port>`
+
 ## Directory layout
 The following describes the intent of UA client related directories:
 

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -206,3 +206,116 @@ Feature: Proxy configuration
            | release |
            | xenial  |
            | bionic  |
+
+    @series.lts
+    Scenario Outline: Attach command when authenticated proxy is configured
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I launch a `focal` `proxy` machine
+        And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
+        And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
+        And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
+            """
+            dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+            """
+        And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        ua_config:
+          http_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
+          https_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
+        """
+        And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        And I attach `contract_token` with sudo
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT contracts.canonical.com.*
+        """
+        When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        ua_config:
+          apt_http_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
+          apt_https_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
+        """
+        And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        And I run `ua refresh config` with sudo
+        And I run `apt update` with sudo
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*GET.*ubuntu.com/ubuntu/dists.*
+        """
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        ua_config:
+            apt_https_proxy: http://wronguser:wrongpassword@<ci-proxy-ip>:3128
+        """
+        And I verify that running `ua refresh config` `with sudo` exits `1`
+        Then stderr matches regexp:
+        """
+        "http://wronguser:wrongpassword@.*:3128" is not working. Not setting as proxy.
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+
+    @series.xenial
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attach command when authenticated proxy is configured
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I launch a `focal` `proxy` machine
+        And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
+        And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
+        And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
+            """
+            dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+            """
+        And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
+        And I run `ua config set http_proxy=http://someuser:somepassword@<ci-proxy-ip>:3128` with sudo
+        And I run `ua config set https_proxy=http://someuser:somepassword@<ci-proxy-ip>:3128` with sudo
+        And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        And I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        Setting snap proxy
+        """
+        Then stdout matches regexp:
+        """
+        Setting Livepatch proxy
+        """
+        When I run `canonical-livepatch config check-interval=0` with sudo
+        And I run `canonical-livepatch refresh` with sudo
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT contracts.canonical.com.*
+        """
+        When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT api.snapcraft.io:443.*
+        """
+        When I run `sleep 120` as non-root
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT livepatch.canonical.com:443.*
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -138,6 +138,16 @@ If set, ua will configure apt to use the specified https proxy by writing a apt
 config file to /etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy
 
 .P
+If needed, authentication to the proxy server can be performed by setting
+username and password in the URL itself, as in:
+.PP
+.nf
+.fam C
+  http_proxy: http://<username>:<password>@<fqdn>:<port>
+.fam T
+.fi
+
+.P
 Additionally, some configuration options can be overridden in the environment
 by setting an environment variable prefaced by \fBUA_<option_name>\fP. Both
 uppercase and lowercase environment variables are allowed. The configuration


### PR DESCRIPTION
Add information to the manpage on how to authenticate to proxy servers if needed, and add an integration test to ensure this authentication is working.

Fixes: #1727

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
