### PR TITLE
Subst distro info

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,11 +23,6 @@ Build-Depends: bash-completion,
                libapt-pkg-dev,
                po-debconf,
                python3 (>= 3.4),
-# Bionic and Xenial each have older versions of distro-info that don't support the flag --supported-esm. Those
-# versions are 0.18 and 0.14build1, respectively. The first alternative here ensures we get the update on Bionic
-# (and all later releases come with a distro-info with a greater version than 0.18). The second alternative
-# ensures we get the update on Xenial.
-               distro-info (>= 0.18ubuntu0.18.04.1) | distro-info (= 0.14ubuntu0.2),
                python3-flake8,
                python3-mock,
                python3-pytest,

--- a/debian/control
+++ b/debian/control
@@ -39,9 +39,8 @@ Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
-         distro-info (>= 0.18ubuntu0.18.04.1) | distro-info (= 0.14ubuntu0.2),
          python3-pkg-resources,
-         ${extra:Depends},
+         ${extra:Depends}
 Description: management tools for Ubuntu Advantage
  Ubuntu Advantage is the professional package of tooling, technology
  and expertise from Canonical, helping organisations around the world

--- a/debian/rules
+++ b/debian/rules
@@ -6,16 +6,25 @@ FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
 include /etc/os-release
 # see https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1840091/comments/3
+
+# Bionic and Xenial each have older versions of distro-info that don't support
+# the flag --supported-esm. Those versions are 0.18 and 0.14build1,
+# respectively. So we set specific distro-info requirements for bionic and later
+# versus Xenial to make those contraints applicable on each series.
+DISTRO_INFO_DEPS="distro-info (>= 0.18ubuntu0.18.04.1),"
+
 ifeq (${VERSION_ID},"14.04")
-APT_PKG_DEPS="apt (>= 1.0.1ubuntu2.23), apt-transport-https (>= 1.0.1ubuntu2.23), apt-utils (>= 1.0.1ubuntu2.23), libapt-inst1.5 (>= 1.0.1ubuntu2.23), libapt-pkg4.12 (>= 1.0.1ubuntu2.23) "
+APT_PKG_DEPS="apt (>= 1.0.1ubuntu2.23), apt-transport-https (>= 1.0.1ubuntu2.23), apt-utils (>= 1.0.1ubuntu2.23), libapt-inst1.5 (>= 1.0.1ubuntu2.23), libapt-pkg4.12 (>= 1.0.1ubuntu2.23),"
+DISTRO_INFO_DEPS=""  # Don't set on trusty as we aren't releasing anymore
 else ifeq (${VERSION_ID},"16.04")
-APT_PKG_DEPS="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32)"
+APT_PKG_DEPS="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32),"
+DISTRO_INFO_DEPS="distro-info (>= 0.14ubuntu0.2),"
 else ifeq (${VERSION_ID},"18.04")
-APT_PKG_DEPS="apt (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
+APT_PKG_DEPS="apt (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11),"
 else ifeq (${VERSION_ID},"19.04")
-APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
+APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1),"
 else ifeq (${VERSION_ID},"19.10")
-APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
+APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1),"
 endif
 
 %:
@@ -39,7 +48,7 @@ endif
 endif
 
 override_dh_gencontrol:
-	echo extra:Depends=$(APT_PKG_DEPS) >> debian/ubuntu-advantage-tools.substvars
+	echo extra:Depends=$(APT_PKG_DEPS) $(DISTRO_INFO_DEPS) >> debian/ubuntu-advantage-tools.substvars
 	dh_gencontrol
 
 override_dh_systemd_enable:


### PR DESCRIPTION
## Proposed Commit Message

d/control|d/rules: use substvars for distro-info for Xenial deps

Xenial is specific and requires distro-info >= 0.14ubuntu0.2 but
Bionic and later should be >= 0.18ubuntu0.18.04.1.
Leave trusty unset because we haven't released support which
requires distro-info on trusty.

## Test Steps
```bash
sed -i 's/UNRELEASED/xenial/'
build-package
sbuild-it ../out/*dsc
dpkg-deb  -I ubuntu-advantage-tools_28.0_amd64.deb | grep distro-info

```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
