### PR TITLE
postinst: ignore configStatus when not present

### DIFF
--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -47,8 +47,10 @@ def patch_status_json_schema_0_1(status_file: str):
         "name": new_status.pop("subscription", ""),
         "id": new_status.pop("subscription-id", ""),
     }
-    new_status["execution_status"] = new_status.pop("configStatus")
-    new_status["execution_details"] = new_status.pop("configStatusDetails")
+    if "configStatus" in new_status:
+        new_status["execution_status"] = new_status.pop("configStatus")
+    if "configStatusDetails" in new_status:
+        new_status["execution_details"] = new_status.pop("configStatusDetails")
     try:
         status_content = json.dumps(
             new_status, cls=util.DatetimeAwareJSONEncoder

--- a/uaclient/tests/test_patch_status_json.py
+++ b/uaclient/tests/test_patch_status_json.py
@@ -103,6 +103,38 @@ ATTACHED_PATCHED_STATUS = {
     },
 }
 
+NO_CONFIG_UNPATCHED_STATUS = {
+    "_doc": "Content provided in json response is currently considered ...",
+    "attached": False,
+    "expires": "n/a",
+    "techSupportLevel": "n/a",
+    "services": [
+        {
+            "name": "cc-eal",
+            "available": "yes",
+            "description": "Common Criteria EAL2 Provisioning Packages",
+        }
+    ],
+    "origin": None,
+}
+
+NO_CONFIG_PATCHED_STATUS = {
+    "_schema_version": "0.1",
+    "origin": None,
+    "account": {"name": "", "id": ""},
+    "expires": "n/a",
+    "services": [
+        {
+            "available": "yes",
+            "name": "cc-eal",
+            "description": "Common Criteria EAL2 Provisioning Packages",
+        }
+    ],
+    "attached": False,
+    "contract": {"name": "", "id": "", "tech_support_level": "n/a"},
+    "_doc": "Content provided in json response is currently considered ...",
+}
+
 
 @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
 class TestPatchStatusJSONSchema0_1:
@@ -117,6 +149,11 @@ class TestPatchStatusJSONSchema0_1:
             (
                 ATTACHED_UNPATCHED_STATUS,
                 ATTACHED_PATCHED_STATUS,
+                ["Patching /var/lib/ubuntu-advantage/status.json schema"],
+            ),
+            (
+                NO_CONFIG_UNPATCHED_STATUS,
+                NO_CONFIG_PATCHED_STATUS,
                 ["Patching /var/lib/ubuntu-advantage/status.json schema"],
             ),
             (UNATTACHED_PATCHED_STATUS, UNATTACHED_PATCHED_STATUS, []),


### PR DESCRIPTION
Ignore potentially non-existing keys when patching the status JSON.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
