### PR TITLE
tests: always build packages using sbuild (SC-267)

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -5,7 +5,6 @@ import re
 import tempfile
 import textwrap
 import logging
-import subprocess
 import pycloudlib  # type: ignore
 
 try:
@@ -646,26 +645,6 @@ def build_debs_from_sbuild(context: Context, series: str) -> "List[str]":
         logging.info(
             "--- Could not find any debs to reuse. Building it locally"
         )
-        chroot_name = "{}-amd64".format(series)
-
-        try:
-            subprocess.check_output(["schroot", "-i", "-c", chroot_name])
-        except subprocess.CalledProcessError:
-            cmd = (
-                "sbuild-launchpad-chroot create"
-                '--architecture="amd64" --name={}-amd64"'.format(series),
-                '--series="{}"'.format(series),
-            )
-            msgs = (
-                "-- You need a {} chroot to proceed".format(series),
-                "-- Please run the following cmd as root:",
-                " ".join(cmd),
-                "-- If you don't have sbuild-launchpad-chroot please run:"
-                "apt-get install sbuild-launchpad-chroot",
-            )
-
-            logging.info("\n".join(msgs))
-            exit(-1)
 
         with emit_spinner_on_travis("Building debs from local source... "):
             deb_paths = build_debs(


### PR DESCRIPTION
## Proposed Commit Message
tests: always build packages on a LXD container
    
When running integration tests with BUILD_PR=1, we build the ua package using in the same instance type that we are going to run the test on. This is not ideal, since we run integrations tests on clouds and LXD vms. We are now building the packages through sbuild, which is a faster and more correct approach for building the packages to be used in the test

## Test Steps
Run either a vm or a cloud test with UACLIENT_BEHAVE_BUILD_PR=1 and verify that the package is built using sbuild.
To verify that run the tests with `--no-junit` and take a look at the logs to see references for the sbuild process running

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
