### PR TITLE
behave: add unattached upgrade test and perform post-upgrade changes

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -165,6 +165,15 @@ def when_i_retry_run_command(context, command, user_spec, exit_codes):
     assert_that(context.process.returncode, equal_to(0))
 
 
+@when("I run `{command}` `{user_spec}` and stdin `{stdin}`")
+def when_i_run_command_with_stdin(
+    context, command, user_spec, stdin, instance_name="uaclient"
+):
+    when_i_run_command(
+        context=context, command=command, user_spec=user_spec, stdin=stdin
+    )
+
+
 @when("I run `{command}` {user_spec}")
 def when_i_run_command(
     context,

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -1,13 +1,12 @@
 @uses.config.contract_token
-Feature: Upgrade between releases when uaclient is attached
+Feature: Upgrade between releases when uaclient is unattached
 
     @series.focal
     @series.hirsute
     @upgrade
-    Scenario Outline: Attached upgrade across LTS releases
+    Scenario Outline: Unattached upgrade across LTS releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `apt-get dist-upgrade --assume-yes` with sudo
+        When I run `apt-get dist-upgrade --assume-yes` with sudo
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
         """
         [Sources]
@@ -28,26 +27,27 @@ Feature: Upgrade between releases when uaclient is attached
         When I run `ua status` with sudo
         Then stdout matches regexp:
         """
-        esm-infra     yes                n/a
+        SERVICE       AVAILABLE  DESCRIPTION
+        cis           no       +Center for Internet Security Audit Tools
+        esm-infra     no       +UA Infra: Extended Security Maintenance \(ESM\)
         """
-        When I run `ua detach --assume-yes` with sudo
+        When I attach `contract_token` with sudo
         Then stdout matches regexp:
-            """
-            This machine is now detached.
-            """
+        """
+        esm-infra     yes         +n/a
+        """
 
         Examples: ubuntu release
-        | release | next_release | devel_release   | stdin |
-        | focal   | groovy       |                 |       |
-        | hirsute | impish       | --devel-release |  y\n  |
+        | release  | next_release | devel_release   |
+        | focal    | groovy       |                 |
+        | hirsute  | impish       | --devel-release |
 
    @series.xenial
    @series.bionic
    @upgrade
-   Scenario Outline: Attached upgrade across LTS releases
+   Scenario Outline: Unattached upgrade across LTS releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `apt-get dist-upgrade --assume-yes` with sudo
+        When I run `apt-get dist-upgrade --assume-yes` with sudo
         # Some packages upgrade may require a reboot
         And I reboot the `<release>` machine
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
@@ -69,14 +69,21 @@ Feature: Upgrade between releases when uaclient is attached
         When I run `ua status` with sudo
         Then stdout matches regexp:
         """
-        esm-infra     yes                enabled
+        SERVICE       AVAILABLE  DESCRIPTION
+        cis           yes      +Center for Internet Security Audit Tools
+        esm-infra     yes      +UA Infra: Extended Security Maintenance \(ESM\)
+        """
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        esm-infra     yes            +enabled
         """
         When I run `ua disable esm-infra` with sudo
         And I run `ua status` with sudo
         Then stdout matches regexp:
-            """
-            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance \(ESM\)
-            """
+        """
+        esm-infra     yes            +disabled
+        """
 
         Examples: ubuntu release
         | release | next_release |

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands =
     behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
     behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" --tags="series.focal,series.all"
+    behave-upgrade-21.04: behave -v {posargs} --tags="upgrade" --tags="series.hirsute,series.all"
     behave-awsgeneric-16.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-awsgeneric-18.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
     behave-awsgeneric-20.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.focal,series.lts,series.all" --tags="~upgrade"


### PR DESCRIPTION
This an ask from SteveL related to SRU test verification procedure improvements for https://wiki.ubuntu.com/UbuntuAdvantageToolsUpdates

## Proposed Commit Message

Exercise ua with a destructive operation after upgrade to ensure
significant config-changing operations still succeed.


## Test Steps
```bash
UACLIENT_BEHAVE_CONTRACT_TOKEN=<your_token> tox -e tox -e behave-upgrade-16.04
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
