### PR TITLE
tests: logging to determine what takes up time

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -108,7 +108,7 @@ class Cloud:
                 % (result.stdout, result.stderr)
             )
 
-        print("--- cloud-init succeeded")
+        logging.info("--- cloud-init succeeded")
 
     def launch(
         self,
@@ -139,7 +139,7 @@ class Cloud:
             image_name=image_name,
             user_data=user_data,
         )
-        print(
+        logging.info(
             "--- {} instance launched: {}. Waiting for ssh access".format(
                 self.name, inst.name
             )
@@ -150,7 +150,7 @@ class Cloud:
                 inst.wait()
                 break
             except Exception as e:
-                print("--- Retrying instance.wait on {}".format(str(e)))
+                logging.info("--- Retrying instance.wait on {}".format(str(e)))
 
         self._check_cloudinit_status(inst)
         return inst
@@ -327,7 +327,7 @@ class EC2(Cloud):
                 self.api.delete_key(self.key_name)
 
             private_key_path = "ec2-{}.pem".format(self.key_name)
-            print(
+            logging.info(
                 "--- Creating local keyfile {} for EC2".format(
                     private_key_path
                 )
@@ -366,13 +366,15 @@ class EC2(Cloud):
         if not image_name:
             image_name = self.locate_image_name(series)
 
-        print("--- Launching AWS image {}({})".format(image_name, series))
+        logging.info(
+            "--- Launching AWS image {}({})".format(image_name, series)
+        )
         vpc = self.api.get_or_create_vpc(name="uaclient-integration")
 
         try:
             inst = self.api.launch(image_name, user_data=user_data, vpc=vpc)
         except Exception as e:
-            print(str(e))
+            logging.error(str(e))
             raise
 
         return inst
@@ -476,7 +478,7 @@ class Azure(Cloud):
         if not private_key_path:
             private_key_path = "azure-priv-{}.pem".format(self.key_name)
             pub_key_path = "azure-pub-{}.txt".format(self.key_name)
-            print(
+            logging.info(
                 "--- Creating local keyfile {} for Azure".format(
                     private_key_path
                 )
@@ -523,7 +525,9 @@ class Azure(Cloud):
         if not image_name:
             image_name = self.locate_image_name(series)
 
-        print("--- Launching Azure image {}({})".format(image_name, series))
+        logging.info(
+            "--- Launching Azure image {}({})".format(image_name, series)
+        )
         inst = self.api.launch(image_id=image_name, user_data=user_data)
         return inst
 
@@ -626,7 +630,9 @@ class GCP(Cloud):
         if not image_name:
             image_name = self.locate_image_name(series)
 
-        print("--- Launching GCP image {}({})".format(image_name, series))
+        logging.info(
+            "--- Launching GCP image {}({})".format(image_name, series)
+        )
         inst = self.api.launch(image_id=image_name, user_data=user_data)
         return inst
 
@@ -667,7 +673,7 @@ class _LXD(Cloud):
 
         image_type = self.name.title().replace("-", " ")
 
-        print(
+        logging.info(
             "--- Launching {} image {}({})".format(
                 image_type, image_name, series
             )

--- a/features/environment.py
+++ b/features/environment.py
@@ -554,7 +554,9 @@ def after_step(context, step):
                 artifact_file = os.path.join(
                     artifacts_dir, os.path.basename(log_file)
                 )
-                print("-- pull instance:{} {}".format(log_file, artifact_file))
+                logging.info(
+                    "-- pull instance:{} {}".format(log_file, artifact_file)
+                )
                 try:
                     result = context.instances["uaclient"].execute(
                         ["cat", log_file], use_sudo=True
@@ -575,11 +577,13 @@ def after_step(context, step):
 
 def after_all(context):
     if context.config.ppa == "":
-        print(" No custom images to delete. UACLIENT_BEHAVE_PPA is unset.")
+        logging.info(
+            " No custom images to delete. UACLIENT_BEHAVE_PPA is unset."
+        )
     elif context.config.image_clean:
         for key, image in context.series_image_name.items():
             if key == context.series_reuse_image:
-                print(
+                logging.info(
                     " Not deleting this image: ",
                     context.series_image_name[key],
                 )
@@ -602,7 +606,7 @@ def _capture_container_as_image(
     :param cloud_api: Optional pycloud BaseCloud api for applicable
         machine_types.
     """
-    print(
+    logging.info(
         "--- Creating  base image snapshot from vm {}".format(container_name)
     )
     inst = cloud_api.get_instance(container_name)
@@ -621,7 +625,7 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
     deb_paths = []
 
     if context.config.debs_path:
-        print(
+        logging.info(
             "--- Checking if debs can be reused in {}".format(
                 context.config.debs_path
             )
@@ -635,10 +639,12 @@ def build_debs_from_dev_instance(context: Context, series: str) -> "List[str]":
             ]
 
     if len(deb_paths):
-        print("--- Reusing debs: {}".format(", ".join(deb_paths)))
+        logging.info("--- Reusing debs: {}".format(", ".join(deb_paths)))
     else:
-        print("--- Could not find any debs to reuse. Building it locally")
-        print(
+        logging.info(
+            "--- Could not find any debs to reuse. Building it locally"
+        )
+        logging.info(
             "--- Launching vm to build ubuntu-advantage*debs from local source"
         )
         build_container_name = (
@@ -687,7 +693,7 @@ def create_uat_image(context: Context, series: str) -> None:
     """
 
     if series in context.reuse_container:
-        print(
+        logging.info(
             "\n Reusing the existing container: ",
             context.reuse_container[series],
         )
@@ -695,7 +701,7 @@ def create_uat_image(context: Context, series: str) -> None:
     ppa = context.config.ppa
     if ppa == "":
         image_name = context.config.cloud_manager.locate_image_name(series)
-        print(
+        logging.info(
             "--- Unset UACLIENT_BEHAVE_PPA. Using ubuntu-advantage-tools "
             + "from image: {}".format(image_name)
         )
@@ -707,7 +713,7 @@ def create_uat_image(context: Context, series: str) -> None:
     if context.config.build_pr:
         deb_paths = build_debs_from_dev_instance(context, series)
 
-    print(
+    logging.info(
         "--- Launching VM to create a base image with updated ubuntu-advantage"
     )
 
@@ -857,10 +863,10 @@ def _install_uat_in_container(
     for cmd in cmds:  # type: ignore
         result = instance.execute(cmd)
         if result.failed:
-            print(
+            logging.info(
                 "--- Failed {}: out {} err {}".format(
                     cmd, result.stdout, result.stderr
                 )
             )
         elif "version" in cmd:
-            print("--- " + result)
+            logging.info("--- " + result)

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -70,7 +70,7 @@ def given_a_machine(context, series):
 
     def cleanup_instance() -> None:
         if not context.config.destroy_instances:
-            print(
+            logging.info(
                 "--- Leaving instance running: {}".format(
                     context.instances["uaclient"].name
                 )
@@ -79,17 +79,16 @@ def given_a_machine(context, series):
             try:
                 context.instances["uaclient"].delete(wait=False)
             except RuntimeError as e:
-                print(
+                logging.error(
                     "Failed to delete instance: {}\n{}".format(
                         context.instances["uaclient"].name, str(e)
                     )
                 )
 
     context.add_cleanup(cleanup_instance)
-    logging.warning(
+    logging.info(
         "--- instance ip: {}".format(context.instances["uaclient"].ip)
     )
-    print("--- instance ip: {}".format(context.instances["uaclient"].ip))
 
 
 @when("I launch a `{series}` `{instance_name}` machine")
@@ -106,7 +105,7 @@ def launch_machine(context, series, instance_name):
         try:
             context.instances[instance_name].delete(wait=False)
         except RuntimeError as e:
-            print(
+            logging.error(
                 "Failed to delete instance: {}\n{}".format(
                     context.instances[instance_name].name, str(e)
                 )
@@ -156,7 +155,7 @@ def when_i_retry_run_command(context, command, user_spec, exit_codes):
                 "Exhausted retries waiting for exit codes: %s", exit_codes
             )
             break
-        print(
+        logging.info(
             "--- Retrying on exit {exit_code}: {command}".format(
                 exit_code=context.process.returncode, command=command
             )
@@ -199,9 +198,9 @@ def when_i_run_command(
     )
 
     if verify_return and result.return_code != 0:
-        print("Error executing command: {}".format(command))
-        print("stdout: {}".format(result.stdout))
-        print("stderr: {}".format(result.stderr))
+        logging.error("Error executing command: {}".format(command))
+        logging.error("stdout: {}".format(result.stdout))
+        logging.error("stderr: {}".format(result.stderr))
 
     if verify_return:
         assert_that(process.returncode, equal_to(0))
@@ -289,7 +288,7 @@ def when_i_attach_staging_token(
             except IndexError:  # no more timeouts
                 logging.warning("Exhausted retries waiting for exit code: 0")
                 break
-            print(
+            logging.info(
                 "--- Retrying on exit {exit_code}: {cmd}".format(
                     exit_code=context.process.returncode, cmd=cmd
                 )

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ log_format = %(filename)-25s %(lineno)4d %(levelname)-8s %(message)s
 
 [behave]
 logging_level=info
+logging_format=%(asctime)s:%(levelname)s:%(name)s:%(message)s
 log_capture=no
 stdout_capture=no
 stderr_capture=no


### PR DESCRIPTION
This adds a timestamps the logs of our integration tests and replaces many `print` calls with `logging.info` calls. The goal is to be able to identify the points in our tests that are taking up the most time.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

> tests: logging with timestamps

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
To see the output try running the following:

```
env UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_CHECK_VERSION=28.0 tox -e behave-vm-20.04 -- features/_version.feature --no-junit --logging-level DEBUG
```

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
