### PR TITLE
tests: don't run apt update on userdata

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -45,7 +45,6 @@ runcmd:
 USERDATA_RUNCMD_ENABLE_PROPOSED = """
 runcmd:
   - printf \"deb http://archive.ubuntu.com/ubuntu/ {series}-proposed restricted main multiverse universe\" > /etc/apt/sources.list.d/uaclient-proposed.list
-  - apt-get update
 """  # noqa: E501
 
 USERDATA_APT_SOURCE_PPA = """\
@@ -823,6 +822,7 @@ def _install_uat_in_container(
         if "pro" in machine_type:
             ua_pkg.append("ubuntu-advantage-pro")
 
+        cmds.append(["sudo", "apt-get", "update"])
         cmds.append(
             " ".join(
                 [


### PR DESCRIPTION
## Proposed Commit Message
tests: don't run apt update on userdata

When installing ua directly from proposed, we create an userdata that create the proposed source file and runs apt update. This can cause race conditions on the start up process of an instance, since another apt command might be running. To try to avoid that, we are now running the apt update command only when we really need it

## Test Steps
Run the gcp generic xenial test without this change and verify that it fails because of a cloud-init error. Apply that change and confirm that the test works as expected

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
