### PR TITLE
Integration tests upgrade unattached (SC-265)

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -165,6 +165,15 @@ def when_i_retry_run_command(context, command, user_spec, exit_codes):
     assert_that(context.process.returncode, equal_to(0))
 
 
+@when("I run `{command}` `{user_spec}` and stdin `{stdin}`")
+def when_i_run_command_with_stdin(
+    context, command, user_spec, stdin, instance_name="uaclient"
+):
+    when_i_run_command(
+        context=context, command=command, user_spec=user_spec, stdin=stdin
+    )
+
+
 @when("I run `{command}` {user_spec}")
 def when_i_run_command(
     context,

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -37,9 +37,9 @@ Feature: Upgrade between releases when uaclient is attached
             """
 
         Examples: ubuntu release
-        | release | next_release | devel_release   | stdin |
-        | focal   | groovy       |                 |       |
-        | hirsute | impish       | --devel-release |  y\n  |
+        | release | next_release | devel_release   |
+        | focal   | groovy       |                 |
+        | hirsute | impish       | --devel-release |
 
    @series.xenial
    @series.bionic

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -27,8 +27,6 @@ Feature: Upgrade between releases when uaclient is unattached
         When I run `ua status` with sudo
         Then stdout matches regexp:
         """
-        SERVICE       AVAILABLE  DESCRIPTION
-        cis           no       +Center for Internet Security Audit Tools
         esm-infra     no       +UA Infra: Extended Security Maintenance \(ESM\)
         """
         When I attach `contract_token` with sudo

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -1,13 +1,12 @@
 @uses.config.contract_token
-Feature: Upgrade between releases when uaclient is attached
+Feature: Upgrade between releases when uaclient is unattached
 
     @series.focal
     @series.hirsute
     @upgrade
-    Scenario Outline: Attached upgrade across LTS releases
+    Scenario Outline: Unattached upgrade across LTS releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `apt-get dist-upgrade --assume-yes` with sudo
+        When I run `apt-get dist-upgrade --assume-yes` with sudo
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
         """
         [Sources]
@@ -28,26 +27,27 @@ Feature: Upgrade between releases when uaclient is attached
         When I run `ua status` with sudo
         Then stdout matches regexp:
         """
-        esm-infra     yes                n/a
+        SERVICE       AVAILABLE  DESCRIPTION
+        cis           no       +Center for Internet Security Audit Tools
+        esm-infra     no       +UA Infra: Extended Security Maintenance \(ESM\)
         """
-        When I run `ua detach --assume-yes` with sudo
+        When I attach `contract_token` with sudo
         Then stdout matches regexp:
-            """
-            This machine is now detached.
-            """
+        """
+        esm-infra     yes         +n/a
+        """
 
         Examples: ubuntu release
-        | release | next_release | devel_release   | stdin |
-        | focal   | groovy       |                 |       |
-        | hirsute | impish       | --devel-release |  y\n  |
+        | release  | next_release | devel_release   |
+        | focal    | groovy       |                 |
+        | hirsute  | impish       | --devel-release |
 
    @series.xenial
    @series.bionic
    @upgrade
-   Scenario Outline: Attached upgrade across LTS releases
+   Scenario Outline: Unattached upgrade across LTS releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `apt-get dist-upgrade --assume-yes` with sudo
+        When I run `apt-get dist-upgrade --assume-yes` with sudo
         # Some packages upgrade may require a reboot
         And I reboot the `<release>` machine
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
@@ -69,14 +69,21 @@ Feature: Upgrade between releases when uaclient is attached
         When I run `ua status` with sudo
         Then stdout matches regexp:
         """
-        esm-infra     yes                enabled
+        SERVICE       AVAILABLE  DESCRIPTION
+        cis           yes      +Center for Internet Security Audit Tools
+        esm-infra     yes      +UA Infra: Extended Security Maintenance \(ESM\)
+        """
+        When I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        esm-infra     yes            +enabled
         """
         When I run `ua disable esm-infra` with sudo
         And I run `ua status` with sudo
         Then stdout matches regexp:
-            """
-            esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance \(ESM\)
-            """
+        """
+        esm-infra     yes            +disabled
+        """
 
         Examples: ubuntu release
         | release | next_release |

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands =
     behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
     behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" --tags="series.focal,series.all"
+    behave-upgrade-21.04: behave -v {posargs} --tags="upgrade" --tags="series.hirsute,series.all"
     behave-awsgeneric-16.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-awsgeneric-18.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
     behave-awsgeneric-20.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.focal,series.lts,series.all" --tags="~upgrade"


### PR DESCRIPTION
This PR is based on #1738, only dropping the cis check on the integration test were we upgrade from focal into groovy