### PR TITLE
postinst: do not run cloud-id if cloud-init did not run

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
 ubuntu-advantage-tools (28.0) UNRELEASED; urgency=medium
 
+  [ Chad Smith ]
   * Open 28.0 for active development
+
+  [ Michael Hudson-Doyle ]
+  * Do not fail in postinst if cloud-init did not run. (LP: #1936833)
 
  -- Chad Smith <chad.smith@canonical.com>  Wed, 19 May 2021 16:35:25 -0600
 

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -291,7 +291,7 @@ notify_wrong_fips_metapackage_on_cloud() {
     fips_metapkg="ubuntu-fips"
 
     cloud_id=""
-    if command -v "cloud-id" > /dev/null ; then
+    if command -v "cloud-id" > /dev/null && [ -f /run/cloud-init/instance-data.json ] ; then
       cloud_id=$(cloud-id)
     fi
 


### PR DESCRIPTION
cloud-id will only do anyting useful if cloud-init ran and fails
otherwise (e.g. in a chroot while building an image) so do not run it at
all if /run/cloud-init/instance-data.json is not present.

LP: #1936833
