### PR TITLE
Allow running tests with ephemeral instances (SC-266)

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -72,6 +72,7 @@ class Cloud:
         instance_name: "Optional[str]" = None,
         image_name: "Optional[str]" = None,
         user_data: "Optional[str]" = None,
+        ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Create an instance for on the cloud provider.
 
@@ -85,6 +86,8 @@ class Cloud:
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
+        :param ephemeral":
+            If instance should be ephemeral
 
         :returns:
             A cloud provider instance
@@ -116,6 +119,7 @@ class Cloud:
         instance_name: "Optional[str]" = None,
         image_name: "Optional[str]" = None,
         user_data: "Optional[str]" = None,
+        ephemeral: bool = False,
     ) -> pycloudlib.instance.BaseInstance:
         """Create and wait for cloud provider instance to be ready.
 
@@ -129,6 +133,8 @@ class Cloud:
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
+        :param ephemeral":
+            If instance should be ephemeral
 
         :returns:
             An cloud provider instance
@@ -138,6 +144,7 @@ class Cloud:
             instance_name=instance_name,
             image_name=image_name,
             user_data=user_data,
+            ephemeral=ephemeral,
         )
         print(
             "--- {} instance launched: {}. Waiting for ssh access".format(
@@ -346,6 +353,7 @@ class EC2(Cloud):
         instance_name: "Optional[str]" = None,
         image_name: "Optional[str]" = None,
         user_data: "Optional[str]" = None,
+        ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -359,6 +367,8 @@ class EC2(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
+        :param ephemeral":
+            If instance should be ephemeral
 
         :returns:
             An AWS cloud provider instance
@@ -503,6 +513,7 @@ class Azure(Cloud):
         instance_name: "Optional[str]" = None,
         image_name: "Optional[str]" = None,
         user_data: "Optional[str]" = None,
+        ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -516,6 +527,8 @@ class Azure(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
+        :param ephemeral":
+            If instance should be ephemeral
 
         :returns:
             An AWS cloud provider instance
@@ -606,6 +619,7 @@ class GCP(Cloud):
         instance_name: "Optional[str]" = None,
         image_name: "Optional[str]" = None,
         user_data: "Optional[str]" = None,
+        ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -619,6 +633,8 @@ class GCP(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
+        :param ephemeral":
+            If instance should be ephemeral
 
         :returns:
             An AWS cloud provider instance
@@ -634,6 +650,20 @@ class GCP(Cloud):
 class _LXD(Cloud):
     name = "_lxd"
 
+    def __init__(
+        self,
+        machine_type: str,
+        region: "Optional[str]" = None,
+        tag: "Optional[str]" = None,
+        timestamp_suffix: bool = True,
+    ) -> None:
+        super().__init__(
+            machine_type=machine_type,
+            region=region,
+            tag=tag,
+            timestamp_suffix=timestamp_suffix,
+        )
+
     @property
     def pycloudlib_cls(self):
         """Return the pycloudlib cls to be used as an api."""
@@ -645,6 +675,7 @@ class _LXD(Cloud):
         instance_name: "Optional[str]" = None,
         image_name: "Optional[str]" = None,
         user_data: "Optional[str]" = None,
+        ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -658,6 +689,8 @@ class _LXD(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
+        :param ephemeral":
+            If instance should be ephemeral
 
         :returns:
             An AWS cloud provider instance
@@ -674,7 +707,10 @@ class _LXD(Cloud):
         )
 
         inst = self.api.launch(
-            name=instance_name, image_id=image_name, user_data=user_data
+            name=instance_name,
+            image_id=image_name,
+            user_data=user_data,
+            ephemeral=ephemeral,
         )
         return inst
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -120,6 +120,7 @@ class UAClientBehaveConfig:
         "destroy_instances",
         "cache_source",
         "enable_proposed",
+        "ephemeral_instance",
     ]
     str_options = [
         "aws_access_key_id",
@@ -178,6 +179,7 @@ class UAClientBehaveConfig:
         destroy_instances: bool = True,
         cache_source: bool = True,
         enable_proposed: bool = False,
+        ephemeral_instance: bool = False,
         machine_type: str = "lxd.container",
         private_key_file: str = None,
         private_key_name: str = "uaclient-integration",
@@ -205,6 +207,7 @@ class UAClientBehaveConfig:
         self.build_pr = build_pr
         self.cache_source = cache_source
         self.enable_proposed = enable_proposed
+        self.ephemeral_instance = ephemeral_instance
         self.contract_token = contract_token
         self.contract_token_staging = contract_token_staging
         self.contract_token_staging_expired = contract_token_staging_expired

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -61,6 +61,7 @@ def given_a_machine(context, series):
             series=series,
             instance_name=instance_name,
             image_name=context.series_image_name[series],
+            ephemeral=context.config.ephemeral_instance,
         )
     }
 

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@88b25081a2e74262e445f3208dc45f841afacc56
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@dd27b604137cc5a20fb54e233ecb6a028b3d6891
 
 
 # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
## Proposed Commit Message
Allow running tests with ephemeral instances

We are now allowing running the integration tests with ephemeral instances. This will allow LXD to better handle deleting the instance, since we can now just stop the ephemeral instance and LXD will properly handle the deletion of the instance

## Test Steps
Run any integration test with `UACLIENT_BEHAVE_EPHEMERAL_INSTANCE=1` and verify that the instance created instance
is an ephemeral one

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
