### PR TITLE
cli: catch errors when determining cloud type 

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -542,3 +542,48 @@ Feature: Enable command behaviour when attached to an UA staging subscription
            | release | fips-apt-source                                                        |
            | xenial  | https://esm.staging.ubuntu.com/fips-updates/ubuntu xenial-updates/main |
            | bionic  | https://esm.staging.ubuntu.com/fips-updates/ubuntu bionic-updates/main |
+
+    @series.xenial
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: FIPS enablement message when cloud init didn't run properly
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I delete the file `/run/cloud-init/instance-data.json`
+        And I attach `contract_token_staging` with sudo
+        And I run `ua disable livepatch` with sudo
+        And I run `ua enable fips --assume-yes` with sudo
+        Then stderr matches regexp:
+        """
+        Could not determine cloud, defaulting to generic FIPS package.
+        """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+        """
+        fips +yes                enabled
+        """
+
+        Examples: ubuntu release
+        | release |
+        | xenial  |
+        | bionic  |
+
+    @series.focal
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: FIPS enablement message when cloud init didn't run properly
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I delete the file `/run/cloud-init/instance-data.json`
+        And I attach `contract_token_staging` with sudo
+        And I run `ua enable fips --assume-yes` with sudo
+        Then stderr matches regexp:
+        """
+        Could not determine cloud, defaulting to generic FIPS package.
+        """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+        """
+        fips +yes                enabled
+        """
+
+        Examples: ubuntu release
+        | release |
+        | focal   |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -334,6 +334,13 @@ def when_i_create_file_with_content(context, file_path):
     when_i_run_command(context, cmd, "with sudo")
 
 
+@when("I delete the file `{file_path}`")
+def when_i_delete_file(context, file_path):
+    cmd = "rm -rf {}".format(file_path)
+    cmd = 'sh -c "{}"'.format(cmd)
+    when_i_run_command(context, cmd, "with sudo")
+
+
 @when("I reboot the `{series}` machine")
 def when_i_reboot_the_machine(context, series):
     context.instances["uaclient"].restart(wait=True)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -935,6 +935,8 @@ def apply_config_settings_override(override_key: str):
             )
 
             if value_override != UNSET_SETTINGS_OVERRIDE_KEY:
+                if override_key == "cloud_type":
+                    return (value_override, None)
                 return value_override
 
             return f()

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -173,7 +173,9 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
         # Use a lambda so we can mock util.is_container in tests
         cloud_titles = {"azure": "an Azure", "gce": "a GCP"}
-        cloud_id = get_cloud_type() or ""
+        cloud_id, _ = get_cloud_type()
+        if cloud_id is None:
+            cloud_id = ""
 
         series = util.get_platform_info().get("series", "")
         blocked_message = status.MESSAGE_FIPS_BLOCK_ON_CLOUD.format(
@@ -216,9 +218,11 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         if series != "bionic":
             return packages
 
-        cloud_match = re.match(
-            r"^(?P<cloud>(azure|aws)).*", get_cloud_type() or ""
-        )
+        cloud_id, _ = get_cloud_type()
+        if cloud_id is None:
+            cloud_id = ""
+
+        cloud_match = re.match(r"^(?P<cloud>(azure|aws)).*", cloud_id)
         cloud_id = cloud_match.group("cloud") if cloud_match else ""
 
         if cloud_id not in ("azure", "aws"):
@@ -362,7 +366,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
 
     @property
     def messaging(
-        self
+        self,
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
             "pre_enable": [
@@ -423,7 +427,7 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     @property
     def messaging(
-        self
+        self,
     ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
         return {
             "pre_enable": [

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 
@@ -5,7 +6,7 @@ from itertools import groupby
 
 from uaclient import apt
 from uaclient.entitlements import repo
-from uaclient.clouds.identity import get_cloud_type
+from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient import exceptions, status, util
 
 try:
@@ -411,6 +412,12 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         super().setup_apt_config()
 
     def _perform_enable(self) -> bool:
+        cloud_type, error = get_cloud_type()
+        if cloud_type is None and error == NoCloudTypeReason.CLOUD_ID_ERROR:
+            logging.warning(
+                "Could not determine cloud, "
+                "defaulting to generic FIPS package."
+            )
         if super()._perform_enable():
             self.cfg.remove_notice("", status.MESSAGE_FIPS_INSTALL_OUT_OF_DATE)
             return True

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -964,7 +964,7 @@ def prompt_for_affected_packages(
 
 def _inform_ubuntu_pro_existence_if_applicable() -> None:
     """Alert the user when running UA on cloud with PRO support."""
-    cloud_type = get_cloud_type()
+    cloud_type, _ = get_cloud_type()
     if cloud_type in PRO_CLOUDS:
         print(
             status.MESSAGE_SECURITY_USE_PRO_TMPL.format(

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -61,7 +61,7 @@ class TestGetContractTokenFromCloudIdentity:
         self, m_get_cloud_type, cloud_type, FakeConfig
     ):
         """Non-aws clouds will error."""
-        m_get_cloud_type.return_value = cloud_type
+        m_get_cloud_type.return_value = (cloud_type, None)
         with pytest.raises(NonAutoAttachImageError) as excinfo:
             _get_contract_token_from_cloud_identity(FakeConfig())
         assert status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -40,6 +40,7 @@ from uaclient.status import (
     ApplicabilityStatus,
     colorize_commands,
 )
+from uaclient.clouds.identity import NoCloudTypeReason
 from uaclient import exceptions
 from uaclient.util import UrlError
 
@@ -959,7 +960,7 @@ class TestPromptForAffectedPackages:
                 {},
                 {"curl": {"curl": "1.0"}},
                 {"unread-because-no-affected-pkgs": {}},
-                None,
+                (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 textwrap.dedent(
                     """\
                     No affected packages are installed.
@@ -973,7 +974,7 @@ class TestPromptForAffectedPackages:
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED)},
                 {"slsrc": {"sl": "2.1"}},
                 {"slsrc": {"sl": {"version": "2.1"}}},
-                None,
+                (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 textwrap.dedent(
                     """\
                     1 affected package is installed: slsrc
@@ -990,7 +991,7 @@ class TestPromptForAffectedPackages:
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED)},
                 {"slsrc": {"sl": "2.1"}},
                 {"slsrc": {"sl": {"version": "2.2"}}},
-                None,
+                (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 textwrap.dedent(
                     """\
                     1 affected package is installed: slsrc
@@ -1008,7 +1009,7 @@ class TestPromptForAffectedPackages:
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED)},
                 {"slsrc": {"sl": "2.0"}},
                 {"slsrc": {"sl": {"version": "2.1"}}},
-                None,
+                (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 textwrap.dedent(
                     """\
                     1 affected package is installed: slsrc
@@ -1036,7 +1037,7 @@ class TestPromptForAffectedPackages:
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_INFRA)},
                 {"slsrc": {"sl": "2.0"}},
                 {"slsrc": {"sl": {"version": "2.1"}}},
-                "azure",
+                ("azure", None),
                 textwrap.dedent(
                     """\
                     1 affected package is installed: slsrc
@@ -1057,7 +1058,7 @@ class TestPromptForAffectedPackages:
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_INFRA)},
                 {"slsrc": {"sl": "2.0"}},
                 {"slsrc": {"sl": {"version": "2.1"}}},
-                "aws",
+                ("aws", None),
                 textwrap.dedent(
                     """\
                     1 affected package is installed: slsrc
@@ -1086,7 +1087,7 @@ class TestPromptForAffectedPackages:
                     "slsrc": {"sl": {"version": "2.1"}},
                     "curl": {"curl": {"version": "2.1"}},
                 },
-                "gcp",
+                ("gcp", None),
                 textwrap.dedent(
                     """\
                     2 affected packages are installed: curl, slsrc
@@ -1157,7 +1158,7 @@ class TestPromptForAffectedPackages:
                     "pkg14": {"pkg14": {"version": "2.1"}},
                     "pkg15": {"pkg15": {"version": "2.1"}},
                 },
-                "gcp",
+                ("gcp", None),
                 textwrap.dedent(
                     """\
                     15 affected packages are installed: {}
@@ -1224,7 +1225,7 @@ class TestPromptForAffectedPackages:
                 },
                 {},
                 {},
-                "gcp",
+                ("gcp", None),
                 textwrap.dedent(
                     """\
                     9 affected packages are installed: {}
@@ -1290,7 +1291,7 @@ class TestPromptForAffectedPackages:
                         "longpackagename5": {"version": "2.1"}
                     },
                 },
-                "gcp",
+                ("gcp", None),
                 """\
 5 affected packages are installed: longpackagename1, longpackagename2,
     longpackagename3, longpackagename4, longpackagename5
@@ -1441,7 +1442,7 @@ A fix is available in Ubuntu standard updates.\n"""
         FakeConfig,
         capsys,
     ):
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_for_service.return_value = True
         m_check_subscription_expired.return_value = False
 
@@ -1589,7 +1590,7 @@ A fix is available in Ubuntu standard updates.\n"""
         import uaclient.security as sec
 
         m_should_reboot.return_value = should_reboot
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
 
         def fake_attach(args, cfg):
             cfg.for_attached_machine()
@@ -1679,7 +1680,7 @@ A fix is available in Ubuntu standard updates.\n"""
     ):
         import uaclient.security as sec
 
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_expired.return_value = False
         m_is_pocket_beta_service.return_value = False
 
@@ -1763,7 +1764,7 @@ A fix is available in Ubuntu standard updates.\n"""
     ):
         import uaclient.security as sec
 
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_expired.return_value = False
         m_is_pocket_beta_service.return_value = False
 
@@ -1855,7 +1856,7 @@ A fix is available in Ubuntu standard updates.\n"""
         FakeConfig,
         capsys,
     ):
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_for_service.return_value = True
         m_cli_attach.return_value = 0
         m_is_pocket_beta_service.return_value = False
@@ -1919,7 +1920,7 @@ A fix is available in Ubuntu standard updates.\n"""
         FakeConfig,
         capsys,
     ):
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
         m_is_pocket_beta_service.return_value = False
 
         cfg = FakeConfig()
@@ -1983,7 +1984,7 @@ A fix is available in Ubuntu standard updates.\n"""
         FakeConfig,
         capsys,
     ):
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
 
         cfg = FakeConfig()
         prompt_for_affected_packages(
@@ -2045,7 +2046,7 @@ A fix is available in Ubuntu standard updates.\n"""
         FakeConfig,
         capsys,
     ):
-        m_get_cloud_type.return_value = "cloud"
+        m_get_cloud_type.return_value = ("cloud", None)
 
         cfg = FakeConfig()
         prompt_for_affected_packages(


### PR DESCRIPTION
`get_cloud_type` now returns a tuple of (result, failure), and if it fails because of `cloud-id`, FIPS enablement has a warning about it.

Fixes: #1541 

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
