### PR TITLE
tests: only use -proposed for ua (SC-270)

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -44,7 +44,9 @@ runcmd:
 
 USERDATA_RUNCMD_ENABLE_PROPOSED = """
 runcmd:
-  - printf \"deb http://archive.ubuntu.com/ubuntu/ {series}-proposed restricted main multiverse universe\" > /etc/apt/sources.list.d/uaclient-proposed.list
+  - printf \"deb http://archive.ubuntu.com/ubuntu/ {series}-proposed main\" > /etc/apt/sources.list.d/uaclient-proposed.list
+  - "printf \\"Package: *\\nPin: release a={series}-proposed\\nPin-Priority: 400\\n\\" > /etc/apt/preferences.d/lower-proposed"
+  - "printf \\"Package: ubuntu-advantage-tools\\nPin: release a={series}-proposed\\nPin-Priority: 1001\\n\\" > /etc/apt/preferences.d/uaclient-proposed"
 """  # noqa: E501
 
 USERDATA_APT_SOURCE_PPA = """\


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->
```
tests: only use -proposed for ua
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

This is hard to test now that our latest release is in -updates. I suggest the following in a fresh xenial container:
1. Create the files that the new `printf` commands in this PR are creating
2. Change the specific package in `/etc/apt/preferences.d/uaclient-proposed` to `autopkgtest`
3. `apt update`
4. `apt install autopkgtest`
5. `apt policy autopkgtest`
    * Ensure that -proposed is pinned at 400 but this package is pinned at 1001. Make sure the version of autopkgtest from proposed is installed
6. `apt upgrade`
    * Ensure that nothing else is installed from -proposed

Also, still run `env UACLIENT_BEHAVE_ENABLE_PROPOSED=1 tox -e behave-vm-16.04 -- features/staging_commands.feature:479 --no-junit` and ensure it passes.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
