### PR TITLE
postinst: ignore any cloud-id error on postinst (SC-280)

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -290,10 +290,7 @@ notify_wrong_fips_metapackage_on_cloud() {
 
     fips_metapkg="ubuntu-fips"
 
-    cloud_id=""
-    if command -v "cloud-id" > /dev/null && [ -f /run/cloud-init/instance-data.json ] ; then
-      cloud_id=$(cloud-id)
-    fi
+    cloud_id=$(cloud-id 2>/dev/null) || cloud_id=""
 
     # If the package is not installed, we don't want the postinst script to fail
     fips_installed=$(dpkg-query -W --showformat='${db:Status-Status}\n' $fips_metapkg 2>/dev/null || true)

--- a/features/postinst.feature
+++ b/features/postinst.feature
@@ -1,0 +1,15 @@
+Feature: UA post-install script checks
+
+    @series.all
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Do not fail on postinst when cloud-id returns error
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I delete the file `/run/cloud-init/instance-data.json`
+        Then I verify that running `dpkg-reconfigure ubuntu-advantage-tools` `with sudo` exits `0`
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | hirsute |


### PR DESCRIPTION
Cloud ID is used during postinst to warn users about potentially wrong FIPS packages on Azure or AWS.
If `cloud-id` fails on top of those, then there would be worse problems with the instance.
If `cloud-id` fails anywhere else, the message is unnecessary.

Thus, we can completely ignore `cloud-id` fails here, and make sure we don't fail.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
