### PR TITLE
Systemd timer rename and API response overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,9 +413,9 @@ ua version
 # Make apt aware of the ESM source files
 sudo apt update
 # Generates ubuntu-advantage-tools messages that should be delivered to MOTD
-# This script is trigged by a systemd timer once a day. To test it, we need to
-# enforce that it was already executed.
-sudo systemctl start ua-messaging.service
+# This script is triggered by a systemd timer twice a day. To test it, we need
+# to enforce that it was already executed.
+sudo systemctl start ua-timer.service
 # Force updating MOTD messages related to update-notifier
 /usr/lib/update-notifier/update-motd-updates-available --force
 # Update MOTD and display the message

--- a/debian/rules
+++ b/debian/rules
@@ -54,11 +54,11 @@ override_dh_gencontrol:
 override_dh_systemd_enable:
 	dh_systemd_enable -pubuntu-advantage-pro ua-auto-attach.service
 	dh_systemd_enable -pubuntu-advantage-tools ua-reboot-cmds.service
-	dh_systemd_enable -pubuntu-advantage-tools ua-messaging.timer
-	dh_systemd_enable -pubuntu-advantage-tools ua-messaging.service
+	dh_systemd_enable -pubuntu-advantage-tools ua-timer.timer
+	dh_systemd_enable -pubuntu-advantage-tools ua-timer.service
 
 override_dh_systemd_start:
-	dh_systemd_start -pubuntu-advantage-tools ua-messaging.timer
+	dh_systemd_start -pubuntu-advantage-tools ua-timer.timer
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import collections
 from typing import Any, Callable, Dict  # noqa: F401
 
+from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 from uaclient.jobs.update_messaging import update_apt_and_motd_messages
 
@@ -55,6 +56,7 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
     Persist jobs-status with calculated next_run values to aid in timer state
     introspection for jobs which ave not yet run.
     """
+    LOG.debug("Trigger UA Timer jobs")
     jobs_status = cfg.read_cache("jobs-status") or {}
     for job_name, job_info in UACLIENT_JOBS.items():
         if job_name in jobs_status:
@@ -77,4 +79,5 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
 if __name__ == "__main__":
     cfg = UAConfig()
     current_time = datetime.utcnow()
+    setup_logging(logging.INFO, logging.DEBUG)
     run_jobs(cfg=cfg, current_time=current_time)

--- a/systemd/ua-timer.service
+++ b/systemd/ua-timer.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ubuntu Advantage APT and MOTD Messages
+Description=Ubuntu Advantage Timer for running repeated jobs
 After=network.target network-online.target systemd-networkd.service ua-auto-attach.service
 Wants=ua-auto-attach.service
 

--- a/systemd/ua-timer.timer
+++ b/systemd/ua-timer.timer
@@ -1,9 +1,10 @@
 [Unit]
-Description=Ubuntu Advantage update messaging
+Description=Ubuntu Advantage Timer for running repeated jobs
 
 [Timer]
-OnCalendar=*-*-* 3,15:00
+OnCalendar=hourly
 RandomizedDelaySec=1h
+FixdRandomDelay=true
 Persistent=true
 OnStartupSec=1min
 

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -16,7 +16,6 @@ except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
 
-from uaclient.cli import setup_logging
 from uaclient import config
 from uaclient import entitlements
 from uaclient import defaults
@@ -341,7 +340,6 @@ def update_apt_and_motd_messages(cfg: config.UAConfig) -> None:
 
     :param cfg: UAConfig instance for this environment.
     """
-    setup_logging(logging.INFO, logging.DEBUG)
     logging.debug("Updating UA messages for APT and MOTD.")
     msg_dir = os.path.join(cfg.data_dir, "messages")
     if not os.path.exists(msg_dir):

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -1,5 +1,6 @@
 import abc
 import json
+import os
 
 from urllib import error
 from urllib.parse import urlencode
@@ -9,16 +10,15 @@ from uaclient import config
 from uaclient import util
 from uaclient import version
 
-try:
-    from typing import Optional, Type  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict, Optional, Tuple, Type  # noqa
 
 
 class UAServiceClient(metaclass=abc.ABCMeta):
 
     url_timeout = None  # type: Optional[int]
+    # Cached serviceclient_url_responses if provided in uaclient.conf
+    # via features: {serviceclient_url_responses: /some/file.json}
+    _response_overlay = None  # type: Dict[str, Any]
 
     @property
     @abc.abstractmethod
@@ -54,6 +54,9 @@ class UAServiceClient(metaclass=abc.ABCMeta):
         if headers.get("content-type") == "application/json" and data:
             data = json.dumps(data).encode("utf-8")
         url = urljoin(getattr(self.cfg, self.cfg_url_base_attr), path)
+        fake_response, fake_headers = self._get_fake_responses(url)
+        if fake_response:
+            return fake_response, fake_headers  # URL faked by uaclient.conf
         if query_params:
             # filter out None values
             filtered_params = {
@@ -83,3 +86,69 @@ class UAServiceClient(metaclass=abc.ABCMeta):
                 e, code=getattr(e, "code", None), headers=headers, url=url
             )
         return response, headers
+
+    def _get_response_overlay(self, url: str):
+        """Return a list of fake response dicts for a given URL.
+
+        serviceclient_url_responses in uaclient.conf should be a path
+        to a json file which contains a dictionary keyed by full URL path.
+        Each value will be a list of dicts representing each faked response
+        for the given URL.
+
+            The response dict item will have a code: <HTTP_STATUS_CODE> and
+               response: "some string of content".
+            The JSON string below fakes the available_resources URL on the
+            contract server:
+            '{"https://contracts.canonical.com/v1/resources": \
+               [{"code": 200, "response": {"key": "val1", "key2": "val2"}}]}'
+
+        :return: List of dicts for each faked response matching the url, or
+           and empty list when no matching url found.
+        """
+        if self._response_overlay is not None:
+            # Cache it so we don't re-read config every readurl call
+            return self._response_overlay.get(url, [])
+        response_overlay_path = self.cfg.features.get(
+            "serviceclient_url_responses"
+        )
+        if not response_overlay_path:
+            self._response_overlay = {}
+        elif not os.path.exists(response_overlay_path):
+            self._response_overlay = {}
+        else:
+            self._response_overlay = json.loads(
+                util.load_file(response_overlay_path)
+            )
+        return self._response_overlay.get(url, [])
+
+    def _get_fake_responses(
+        self, url: str
+    ) -> "Tuple[Optional[Dict[str, Any]], Optional[Dict[str,str]]]":
+        """Return response and headers if faked for this URL in uaclient.conf.
+
+        :return: A tuple of response and header dicts if the URL has an overlay
+            response defined. Return (None, {}) otherwise.
+
+        :raises util.URLError: When faked response "code" is != 200.
+            URLError reason will be "response" value and any optional
+            "headers" provided.
+        """
+        responses = self._get_response_overlay(url)
+        if not responses:
+            return None, {}
+        if len(responses) == 1:
+            # When only one respose is defined, repeat it for all calls
+            response = responses[0]
+        else:
+            # When multiple responses defined pop the first one off the list.
+            response = responses.pop(0)
+        if response["code"] == 200:
+            return response["response"], response.get("headers", {})
+        # Must be an error
+        e = error.URLError(response["response"])
+        raise util.UrlError(
+            e,
+            code=response["code"],
+            headers=response.get("headers", {}),
+            url=url,
+        )

--- a/uaclient/tests/test_serviceclient.py
+++ b/uaclient/tests/test_serviceclient.py
@@ -2,6 +2,7 @@ import mock
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from io import BytesIO
+import json
 
 import pytest
 
@@ -22,7 +23,7 @@ class OurServiceClient(UAServiceClient):
 
     @property
     def cfg_url_base_attr(self):
-        return "url_attr"
+        return "contract_url"
 
 
 class TestRequestUrl:
@@ -42,11 +43,12 @@ class TestRequestUrl:
     )
     @mock.patch("uaclient.serviceclient.util.readurl")
     def test_httperror_handling(
-        self, m_readurl, fp, expected_exception, expected_attrs
+        self, m_readurl, fp, expected_exception, expected_attrs, FakeConfig
     ):
         m_readurl.side_effect = HTTPError(None, 619, None, None, fp)
-
-        client = OurServiceClient(cfg=mock.Mock(url_attr="http://example.com"))
+        cfg = FakeConfig()
+        cfg.cfg["contract_url"] = "http://example.com"
+        client = OurServiceClient(cfg=cfg)
         with pytest.raises(expected_exception) as excinfo:
             client.request_url("/")
 
@@ -54,10 +56,12 @@ class TestRequestUrl:
             assert expected_value == getattr(excinfo.value, attr)
 
     @mock.patch("uaclient.serviceclient.util.readurl")
-    def test_urlerror_handling(self, m_readurl):
+    def test_urlerror_handling(self, m_readurl, FakeConfig):
         m_readurl.side_effect = URLError(None)
 
-        client = OurServiceClient(cfg=mock.Mock(url_attr="http://example.com"))
+        cfg = FakeConfig()
+        cfg.cfg["contract_url"] = "http://example.com"
+        client = OurServiceClient(cfg=cfg)
         with pytest.raises(util.UrlError) as excinfo:
             client.request_url("/")
 
@@ -67,13 +71,16 @@ class TestRequestUrl:
         "m_kwargs", ({"a": 1, "b": "2", "c": "try me"}, {})
     )
     @mock.patch("uaclient.serviceclient.util.readurl")
-    def test_url_query_params_append_querystring(self, m_readurl, m_kwargs):
-
+    def test_url_query_params_append_querystring(
+        self, m_readurl, m_kwargs, FakeConfig
+    ):
         m_readurl.return_value = (m_kwargs, {})  # (response, resp_headers)
 
-        client = OurServiceClient(cfg=mock.Mock(url_attr="http://example.com"))
-        assert (m_kwargs, {}) == client.request_url("/", query_params=m_kwargs)
+        cfg = FakeConfig()
         url = "http://example.com/"
+        cfg.cfg["contract_url"] = url
+        client = OurServiceClient(cfg=cfg)
+        assert (m_kwargs, {}) == client.request_url("/", query_params=m_kwargs)
         if m_kwargs:
             url += "?" + urlencode(m_kwargs)
         assert [
@@ -85,3 +92,94 @@ class TestRequestUrl:
                 timeout=None,
             )
         ] == m_readurl.call_args_list
+
+
+URL_FAKES = {
+    "http://a": [{"code": 200, "response": {"key": "val", "key2": "val2"}}],
+    "http://anerror": [{"code": 404, "response": "nothing to see"}],
+    "http://multiresp": [
+        {"code": 200, "response": "resp1"},
+        {
+            "code": 200,
+            "response": "resp2",
+            "headers": {"content-type": "application/json"},
+        },
+    ],
+}
+
+
+class Test_GetResponseOverlay:
+    @pytest.mark.parametrize(
+        "url,expected",
+        (
+            ("http://a", URL_FAKES["http://a"]),
+            ("http://multiresp", URL_FAKES["http://multiresp"]),
+        ),
+    )
+    def test_overlay_returns_matching_url(
+        self, url, expected, FakeConfig, tmpdir
+    ):
+        overlay_path = tmpdir.join("overlay.json")
+        overlay_path.write(json.dumps(URL_FAKES))
+        cfg = FakeConfig()
+        cfg.override_features(
+            {"serviceclient_url_responses": overlay_path.strpath}
+        )
+        client = OurServiceClient(cfg=cfg)
+        assert expected == client._get_response_overlay(url)
+        # url overrides are cached and not re-read from disk
+        overlay_path.write(json.dumps({}))
+        assert expected == client._get_response_overlay(url)
+
+
+class Test_GetFakeResponses:
+    @pytest.mark.parametrize(
+        "url,overlay,responses",
+        (
+            # When URL has no fakes
+            ("http://a", {}, [(None, {})]),
+            # When URL has 1 fake, repeat that response for all calls
+            (
+                "http://a",
+                URL_FAKES,
+                [(URL_FAKES["http://a"][0]["response"], {})] * 2,
+            ),
+            # When URL has >1 fake, pop through that list and repeat last item
+            (
+                "http://multiresp",
+                URL_FAKES,
+                [(URL_FAKES["http://multiresp"][0]["response"], {})]
+                + [
+                    (
+                        URL_FAKES["http://multiresp"][1]["response"],
+                        URL_FAKES["http://multiresp"][1]["headers"],
+                    )
+                ]
+                * 2,
+            ),
+            # When URL fake is code != 200 raise URLError
+            (
+                "http://anerror",
+                URL_FAKES,
+                [(URLError(URL_FAKES["http://anerror"][0]["response"]), {})],
+            ),
+        ),
+    )
+    def test_overlay_returns_matching_url(
+        self, url, overlay, responses, FakeConfig, tmpdir
+    ):
+        overlay_path = tmpdir.join("overlay.json")
+        overlay_path.write(json.dumps(overlay))
+        cfg = FakeConfig()
+        cfg.override_features(
+            {"serviceclient_url_responses": overlay_path.strpath}
+        )
+        client = OurServiceClient(cfg=cfg)
+        for response, headers in responses:
+            if isinstance(response, Exception):
+                with pytest.raises(util.UrlError) as excinfo:
+                    client._get_fake_responses(url)
+                assert 404 == excinfo.value.code
+                assert "nothing to see" == str(excinfo.value)
+            else:
+                assert (response, headers) == client._get_fake_responses(url)


### PR DESCRIPTION
- Finalize ua-timer systemd renames
-  Add API response overlay functionality enabled by uaclient.conf features: serviceclient_url_responses

## Proposed Commit Message
- systemd: rename ua-messaging.service to ua-timer.service
-     testing: add overlay for any serviceclient API response
    
    To enable development testing of features that are not yet
    available on the contract server or security API endpoints,
    We can now provide API response overrides from a file on disk for any
    matched URL.
    
    uaclient.conf can add
    features:
      serviceclient_url_responses: <some_json_file>
    
    The represented some_json_file will contain a JSON dict keyed
    by full URL path.
    
    Each value for the URL key will be a list containing response dicts
    with a HTTP "code" key and a "response" key.
    Any servicelicent URL requests to URLs matching the
    serviceclient_url_responses will be return the faked responses
    
    Here are a few examples:
    - Fake available resources URL
    {
      "https://contracts.canonincal.com/v1/resouces": [
        {"code": 200, "response": {"resources": ["livepatch", "esm-apps"]}}
      ]
    }
    
    -Fake URLerror from available resources endpoint
    {
      "https://contracts.canonincal.com/v1/resouces": [
        {"code": 403, "response": "unauthorized to access endpoint"}
      ]
    }


## Test Steps
```bash
# Launch a test which will install this locally built deb in an instance
UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_DESTROY_INSTANCES=0 tox -e behave-lxd-18.04 features/unattached_commands.feature:22

# psuedo code get into the instance your test just launched to poke around
VM=`lxc ls -cn ubuntu --format=csv`
lxc exec $VM bash
systemctl  list-timers  # make sure ua-timer.timer is running
systemctl status ua-timer.service  # check trigger remaining times

cat > /root/overlay.json  <<EOF
    {
      "https://contracts.canonincal.com/v1/resouces": [
        {"code": 200, "response": {"resources": ["livepatch", "esm-apps"]}}
      ]
    }
EOF
echo "features:  {serviceclient_url_responses: /root/overlay.json}" >> /etc/ubuntu-advantage/uaclient.conf
python3 -c 'from uaclient.contract import get_available_resources; print(get_available_resources(UAConfig()))'
```
## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
