### PR TITLE
fix: make sure the latest value of machine-id is persisted

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -221,7 +221,10 @@ class UAContractClient(serviceclient.UAServiceClient):
         if not detach:
             self.cfg.write_cache("machine-token", response)
             util.get_machine_id.cache_clear()
-            self.cfg.write_cache("machine-id", data.get("machineId", ""))
+            self.cfg.write_cache(
+                "machine-id",
+                response.get("machineId", data.get("machineId", "")),
+            )
         return response
 
     def _get_platform_data(self, machine_id):


### PR DESCRIPTION
For now, there is still logic that depends on Machine ID being persisted separately.
If a new Machine ID is sent to us in the Machine Token, this should be the one we persist.