### PR TITLE
test: update contract response to a dict

### DIFF
--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -60,7 +60,7 @@ class TestUAContractClient:
         """
         get_platform_info.return_value = {"arch": "arch", "kernel": "kernel"}
         get_machine_id.return_value = "machineId"
-        request_url.return_value = ("newtoken", {})
+        request_url.return_value = ({"machineToken": "newtoken"}, {})
         cfg = FakeConfig.for_attached_machine()
         client = UAContractClient(cfg)
         kwargs = {"machine_token": "mToken", "contract_id": "cId"}
@@ -68,7 +68,9 @@ class TestUAContractClient:
             kwargs["detach"] = detach
         client._request_machine_token_update(**kwargs)
         if not detach:  # Then we have written the updated cache
-            assert "newtoken" == cfg.read_cache("machine-token")
+            assert {"machineToken": "newtoken"} == cfg.read_cache(
+                "machine-token"
+            )
         params = {
             "headers": {
                 "user-agent": "UA-Client/{}".format(get_version()),


### PR DESCRIPTION
## Proposed Commit Message
test: update contract response to a dict

We now try to get the machine id info from the contract response first. On our test, the mocked response was a string. We are now updating it to be a dict to fix that issue


## Test Steps
Run the modified test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
