### PR TITLE
fix: get machine ID from inside of machineTokenInfo (SC-319)

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -221,14 +221,14 @@ class UAContractClient(serviceclient.UAServiceClient):
         if not detach:
             self.cfg.write_cache("machine-token", response)
             util.get_machine_id.cache_clear()
-            self.cfg.write_cache(
-                "machine-id",
-                response.get("machineId", data.get("machineId", "")),
+            machine_id = response.get("machinetTokenInfo", {}).get(
+                "machineId", data.get("machineId")
             )
+            self.cfg.write_cache("machine-id", machine_id)
         return response
 
     def _get_platform_data(self, machine_id):
-        """"Return a dict of platform-relateddata for contract requests"""
+        """Return a dict of platform-related data for contract requests"""
         if not machine_id:
             machine_id = util.get_machine_id(self.cfg)
         platform = util.get_platform_info()

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -495,11 +495,9 @@ class TestApplySeriesOverrides:
 
 class TestGetMachineId:
     def test_get_machine_id_from_config(self, FakeConfig):
-        cfg = FakeConfig.for_attached_machine(
-            machine_token={"machineId": "some-machine-id"}
-        )
+        cfg = FakeConfig.for_attached_machine()
         value = util.get_machine_id(cfg)
-        assert "some-machine-id" == value
+        assert "test_machine_id" == value
 
     def test_get_machine_id_from_etc_machine_id(self, FakeConfig, tmpdir):
         """Presence of /etc/machine-id is returned if it exists."""
@@ -575,8 +573,11 @@ class TestGetMachineId:
         self, FakeConfig, tmpdir, empty_value
     ):
         data_machine_id = tmpdir.join("machine-id")
-        cfg = FakeConfig.for_attached_machine()
-        # Cache it in cfg, so the load_file mock does not mess everything up
+        cfg = FakeConfig().for_attached_machine(
+            machine_token={"some": "thing"}
+        )
+        # Need to initialize the property with a noop,
+        # so load_file is not called after mocked
         cfg.machine_token
         with mock.patch("uaclient.util.os.path.exists") as m_exists:
             m_exists.return_value = True

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -300,7 +300,9 @@ def get_machine_id(cfg) -> str:
     # per Issue: #489
 
     if cfg.machine_token:
-        cfg_machine_id = cfg.machine_token.get("machineId")
+        cfg_machine_id = cfg.machine_token.get("machineTokenInfo", {}).get(
+            "machineId"
+        )
         if cfg_machine_id:
             return cfg_machine_id
 


### PR DESCRIPTION
CS is going to send us the machine ID inside of `machineTokenInfo`, and we should try to get it from there.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
