### PR TITLE
Allow timed jobs' intervals to be overriden by config (SC-308)

### DIFF
--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -20,6 +20,9 @@ Feature: Proxy configuration
         ua_config:
           http_proxy: http://<ci-proxy-ip>:3128
           https_proxy: http://<ci-proxy-ip>:3128
+          update_messaging_timer: 21600
+          update_status_timer: 43200
+          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I attach `contract_token` with sudo
@@ -38,6 +41,9 @@ Feature: Proxy configuration
         ua_config:
           apt_http_proxy: http://<ci-proxy-ip>:3128
           apt_https_proxy: http://<ci-proxy-ip>:3128
+          update_messaging_timer: 21600
+          update_status_timer: 43200
+          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         Then I verify that no files exist matching `/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy`
@@ -77,6 +83,9 @@ Feature: Proxy configuration
         ua_config:
             apt_http_proxy: "invalidurl"
             apt_https_proxy: "invalidurls"
+            update_messaging_timer: 21600
+            update_status_timer: 43200
+            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -87,6 +96,9 @@ Feature: Proxy configuration
         """
         ua_config:
             apt_https_proxy: "https://localhost:12345"
+            update_messaging_timer: 21600
+            update_status_timer: 43200
+            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -171,6 +183,9 @@ Feature: Proxy configuration
         ua_config:
             http_proxy: ""
             https_proxy: ""
+            update_messaging_timer: 21600
+            update_status_timer: 43200
+            gcp_auto_attach_timer: 1800
         """
         And I run `ua refresh config` with sudo
         Then I will see the following on stdout:
@@ -185,6 +200,9 @@ Feature: Proxy configuration
         ua_config:
             http_proxy: "invalidurl"
             https_proxy: "invalidurls"
+            update_messaging_timer: 21600
+            update_status_timer: 43200
+            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -195,6 +213,9 @@ Feature: Proxy configuration
         """
         ua_config:
             https_proxy: "https://localhost:12345"
+            update_messaging_timer: 21600
+            update_status_timer: 43200
+            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -227,6 +248,9 @@ Feature: Proxy configuration
         ua_config:
           http_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
           https_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
+          update_messaging_timer: 21600
+          update_status_timer: 43200
+          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I attach `contract_token` with sudo
@@ -245,6 +269,9 @@ Feature: Proxy configuration
         ua_config:
           apt_http_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
           apt_https_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
+          update_messaging_timer: 21600
+          update_status_timer: 43200
+          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `ua refresh config` with sudo
@@ -258,6 +285,9 @@ Feature: Proxy configuration
         """
         ua_config:
             apt_https_proxy: http://wronguser:wrongpassword@<ci-proxy-ip>:3128
+            update_messaging_timer: 21600
+            update_status_timer: 43200
+            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -557,6 +557,23 @@ def verify_package_is_installed_from_apt_source(context, package, apt_source):
     )
 
 
+@then("I verify that the timer interval for `{job}` is `{interval}`")
+def verify_timer_interval_for_job(context, job, interval):
+    when_i_run_command(
+        context, "cat /var/lib/ubuntu-advantage/jobs-status.json", "with sudo"
+    )
+    jobs_status = json.loads(context.process.stdout.strip())
+    last_run = datetime.datetime.strptime(
+        jobs_status[job]["last_run"], "%Y-%m-%dT%H:%M:%S.%f"
+    )
+    next_run = datetime.datetime.strptime(
+        jobs_status[job]["next_run"], "%Y-%m-%dT%H:%M:%S.%f"
+    )
+    run_diff = next_run - last_run
+
+    assert_that(run_diff.seconds, equal_to(int(interval)))
+
+
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
     if user_spec == "with sudo":

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -34,12 +34,16 @@ class TimedJob:
 
     def run(self, cfg: UAConfig):
         """Run a job in a failsafe manner, returning True on success.
+        Checks if the job is not disabled before running it.
 
         :param cfg: UAConfig instance
 
         :return: A bool True when successfully run. False if ignored
             or in error.
         """
+        if not self._should_run(cfg):
+            return False
+
         LOG.debug("Running job: %s", self.name)
         try:
             self._job_func(cfg)
@@ -60,6 +64,10 @@ class TimedJob:
             LOG.error(error_msg)
             return self._default_interval_seconds
         return configured_interval
+
+    def _should_run(self, cfg):
+        """Verify if the job has a valid (non-zero) interval."""
+        return self.run_interval_seconds(cfg) != 0
 
 
 UACLIENT_JOBS = [

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -1,13 +1,12 @@
 """
-Timer script used to run all jobs that need to be frequently run on the system
+Timer used to run all jobs that need to be frequently run on the system
 """
 
 import logging
 
 from datetime import datetime, timedelta
 
-import collections
-from typing import Any, Callable, Dict  # noqa: F401
+from typing import Callable
 
 from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
@@ -21,79 +20,80 @@ UPDATE_MESSAGING_INTERVAL = 21600  # 6 hours
 UPDATE_STATUS_INTERVAL = 43200  # 12 hours
 GCP_AUTO_ATTACH_INTERVAL = 1800  # 30 minutes
 
-# Store the default run_interval_seconds for each job in this dict.
-# OrderedDict is used to ensure each job is run sequentially in the order
-# listed as some jobs may depend on completion of the previous job.
-UACLIENT_JOBS = collections.OrderedDict(
-    [
-        (
-            "update_messaging",
-            {
-                "job_func": update_apt_and_motd_messages,
-                "run_interval_seconds": UPDATE_MESSAGING_INTERVAL,
-            },
-        ),
-        (
-            "update_status",
-            {
-                "job_func": update_status,
-                "run_interval_seconds": UPDATE_STATUS_INTERVAL,
-            },
-        ),
-        (
-            "gcp_auto_attach",
-            {
-                "job_func": gcp_auto_attach,
-                "run_interval_seconds": GCP_AUTO_ATTACH_INTERVAL,
-            },
-        ),
-    ]
-)  # type: Dict[str, Dict[str, Any]]
+
+class TimedJob:
+    def __init__(
+        self,
+        name: str,
+        job_func: Callable[[UAConfig], None],
+        default_interval_seconds: int,
+    ):
+        self.name = name
+        self._job_func = job_func
+        self._default_interval_seconds = default_interval_seconds
+
+    def run(self, cfg: UAConfig):
+        """Run a job in a failsafe manner, returning True on success.
+
+        :param cfg: UAConfig instance
+
+        :return: A bool True when successfully run. False if ignored
+            or in error.
+        """
+        LOG.debug("Running job: %s", self.name)
+        try:
+            self._job_func(cfg)
+        except Exception as e:
+            LOG.warning("Error executing job %s: %s", self.name, str(e))
+            return False
+
+        return True
+
+    def run_interval_seconds(self, cfg: UAConfig):
+        """Return the run_interval for the job based on config or defaults."""
+        configured_interval = getattr(cfg, "{}_timer".format(self.name), None)
+        if not isinstance(configured_interval, int) or configured_interval < 0:
+            error_msg = (
+                "Invalid value for {} interval found in config. "
+                "Default value will be used."
+            ).format(self.name)
+            LOG.error(error_msg)
+            return self._default_interval_seconds
+        return configured_interval
 
 
-def run_job(
-    job_name: str, job_func: "Callable[[UAConfig], None]", cfg: UAConfig
-) -> bool:
-    """Run a job in a failsafe manner, returning True on success.
-
-    :param job_name: Name of the job to run
-    :param job_func: Job callable to call
-    :param cfg: UAConfig instance
-
-    :return: A bool True when successfully run. False if ignored or in error.
-    """
-    LOG.debug("Running job: %s", job_name)
-    try:
-        job_func(cfg)
-    except Exception as e:
-        LOG.warning("Error executing job %s: %s", job_name, str(e))
-        return False
-
-    return True
+UACLIENT_JOBS = [
+    TimedJob(
+        "update_messaging",
+        update_apt_and_motd_messages,
+        UPDATE_MESSAGING_INTERVAL,
+    ),
+    TimedJob("update_status", update_status, UPDATE_STATUS_INTERVAL),
+    TimedJob("gcp_auto_attach", gcp_auto_attach, GCP_AUTO_ATTACH_INTERVAL),
+]
 
 
 def run_jobs(cfg: UAConfig, current_time: datetime):
-    """Run ordered UACLIENT_JOBS when next_run is before utcnow.
+    """Run jobs in order when next_run is before current_time.
 
-    Persist jobs-status with calculated next_run values to aid in timer state
-    introspection for jobs which ave not yet run.
+    Persist jobs-status with calculated next_run values to aid in timer
+    state introspection for jobs which have not yet run.
     """
     LOG.debug("Trigger UA Timer jobs")
     jobs_status = cfg.read_cache("jobs-status") or {}
-    for job_name, job_info in UACLIENT_JOBS.items():
-        if job_name in jobs_status:
+    for job in UACLIENT_JOBS:
+        if job.name in jobs_status:
             next_run = datetime.strptime(
-                jobs_status[job_name]["next_run"], "%Y-%m-%dT%H:%M:%S.%f"
+                jobs_status[job.name]["next_run"], "%Y-%m-%dT%H:%M:%S.%f"
             )
             if next_run > current_time:
                 continue  # Skip job as expected next_run hasn't yet passed
-        job_func = job_info["job_func"]  # type: Callable[[UAConfig], None]
-        if run_job(job_name=job_name, job_func=job_func, cfg=cfg):
+        if job.run(cfg):
             # Persist last_run and next_run UTC-based times on job success.
-            jobs_status[job_name] = {
+            jobs_status[job.name] = {
                 "last_run": current_time,
                 "next_run": current_time
-                + timedelta(seconds=job_info["run_interval_seconds"]),
+                + timedelta(seconds=job.run_interval_seconds(cfg)),
             }
     cfg.write_cache(key="jobs-status", content=jobs_status)
 

--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -9,3 +9,6 @@ ua_config:
   apt_https_proxy: null
   http_proxy: null
   https_proxy: null
+  update_messaging_timer: 21600
+  update_status_timer: 43200
+  gcp_auto_attach_timer: 1800

--- a/uaclient.conf
+++ b/uaclient.conf
@@ -12,3 +12,6 @@ ua_config:
   apt_https_proxy: null
   http_proxy: null
   https_proxy: null
+  update_messaging_timer: 21600
+  update_status_timer: 43200
+  gcp_auto_attach_timer: 1800

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -677,6 +677,20 @@ def action_config_set(args, cfg, **kwargs):
         }
         kwargs[set_key[4:]] = set_value
         setup_apt_proxy(**kwargs)
+    elif set_key in (
+        "update_messaging_timer",
+        "update_status_timer",
+        "gcp_auto_attach_timer",
+    ):
+        try:
+            set_value = int(set_value)
+            if set_value < 0:
+                raise ValueError("Invalid interval for {}".format(set_key))
+        except ValueError:
+            subparser.print_help()
+            raise exceptions.UserFacingError(
+                "\n<value> for interval must be a positive integer."
+            )
     setattr(cfg, set_key, set_value)
 
 

--- a/uaclient/tests/test_cli_config_show.py
+++ b/uaclient/tests/test_cli_config_show.py
@@ -92,10 +92,13 @@ class TestActionConfigShow:
         else:
             assert (
                 """\
-http_proxy       http://http_proxy
-https_proxy      http://https_proxy
-apt_http_proxy   http://apt_http_proxy
-apt_https_proxy  http://apt_https_proxy
+http_proxy              http://http_proxy
+https_proxy             http://https_proxy
+apt_http_proxy          http://apt_http_proxy
+apt_https_proxy         http://apt_https_proxy
+update_messaging_timer  None
+update_status_timer     None
+gcp_auto_attach_timer   None
 """
                 == out
             )

--- a/uaclient/tests/test_cli_config_unset.py
+++ b/uaclient/tests/test_cli_config_unset.py
@@ -13,7 +13,9 @@ Unset Ubuntu Advantage configuration setting
 
 positional arguments:
   key         configuration key to unset from Ubuntu Advantage services. One
-              of: http_proxy, https_proxy, apt_http_proxy, apt_https_proxy
+              of: http_proxy, https_proxy, apt_http_proxy, apt_https_proxy,
+              update_messaging_timer, update_status_timer,
+              gcp_auto_attach_timer
 
 Flags:
   -h, --help  show this help message and exit
@@ -31,12 +33,14 @@ class TestMainConfigUnSet:
             (
                 "junk",
                 "<key> must be one of: http_proxy, https_proxy,"
-                " apt_http_proxy, apt_https_proxy",
+                " apt_http_proxy, apt_https_proxy, update_messaging_timer, "
+                "update_status_timer, gcp_auto_attach_timer",
             ),
             (
                 "http_proxys",
                 "<key> must be one of: http_proxy, https_proxy,"
-                " apt_http_proxy, apt_https_proxy",
+                " apt_http_proxy, apt_https_proxy, update_messaging_timer, "
+                "update_status_timer, gcp_auto_attach_timer",
             ),
         ),
     )

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -51,11 +51,17 @@ class TestActionRefresh:
         "target, expect_unattached_error",
         [(None, True), ("contract", True), ("config", False)],
     )
+    @mock.patch("uaclient.config.UAConfig.write_cfg")
     def test_not_attached_errors(
-        self, getuid, target, expect_unattached_error, FakeConfig
+        self, _m_write_cfg, getuid, target, expect_unattached_error, FakeConfig
     ):
         """Check that an unattached machine emits message and exits 1"""
         cfg = FakeConfig()
+
+        cfg.update_messaging_timer = 0
+        cfg.update_status_timer = 0
+        cfg.gcp_auto_attach_timer = 0
+
         if expect_unattached_error:
             with pytest.raises(exceptions.UnattachedError):
                 action_refresh(mock.MagicMock(target=target), cfg)

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -260,6 +260,9 @@ UA_CFG_DICT = {
         "apt_https_proxy": None,
         "http_proxy": None,
         "https_proxy": None,
+        "update_messaging_timer": None,
+        "update_status_timer": None,
+        "gcp_auto_attach_timer": None,
     }
 }
 
@@ -1361,6 +1364,9 @@ class TestProcessConfig:
                     "apt_https_proxy": "apt_https",
                     "http_proxy": http_proxy,
                     "https_proxy": https_proxy,
+                    "update_messaging_timer": 21600,
+                    "update_status_timer": 43200,
+                    "gcp_auto_attach_timer": 1800,
                 }
             }
         )
@@ -1401,6 +1407,24 @@ class TestProcessConfig:
         out, err = capsys.readouterr()
         assert expected_out.strip() == out.strip()
         assert "" == err
+
+    def test_process_config_errors_for_wrong_timers(self):
+        cfg = UAConfig(
+            {
+                "ua_config": {
+                    "update_messaging_timer": "wrong",
+                    "update_status_timer": 43200,
+                    "gcp_auto_attach_timer": 1800,
+                }
+            }
+        )
+
+        with pytest.raises(
+            exceptions.UserFacingError,
+            match="Value for the update_messaging_timer interval must be "
+            "a positive integer. Default value will be used.",
+        ):
+            cfg.process_config()
 
 
 class TestParseConfig:


### PR DESCRIPTION
User can now set the desired run_interval for jobs in the `uaclient.conf` file, as in:
```
ua_config:
    <job_name>_timer: <run_interval_value>
```
It has the config for the messaging and status jobs.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
