### PR TITLE
tests: allow snapshot images to be ephemeral

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -736,7 +736,10 @@ def create_instance_with_uat_installed(
                 ppa_url=ppa, ppa_keyid=ppa_keyid
             )
     inst = context.config.cloud_manager.launch(
-        instance_name=name, series=series, user_data=user_data
+        instance_name=name,
+        series=series,
+        user_data=user_data,
+        ephemeral=context.config.ephemeral_instance,
     )
     instance_name = context.config.cloud_manager.get_instance_id(inst)
 

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@dd27b604137cc5a20fb54e233ecb6a028b3d6891
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@4fb989489541cbf20119ccf20eab1e3cb70f07c3
 
 
 # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
## Proposed Commit Message
tests: allow snapshot images to be ephemeral

We have recently allowed pycloudlib to make snapshot from ephemeral instances. We are nos updating uaclient
to also use ephemeral instances for the base images that will be snapshoted when running the tests

## Test Steps
Run any integration test with UACLIENT_BEHAVE_SNAPSHOT_STRATEGY=1 and verify that the base images are ephemeral

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
