### PR TITLE
azure: support Azure published images bump IMDS API version

### DIFF
--- a/uaclient/clouds/azure.py
+++ b/uaclient/clouds/azure.py
@@ -14,7 +14,7 @@ from uaclient import util
 
 IMDS_BASE_URL = "http://169.254.169.254/metadata/"
 
-API_VERSION = "2019-06-04"  # Needed to get subscription ID in attested data
+API_VERSION = "2020-09-01"  # Needed to get subscription ID in attested data
 IMDS_URLS = {
     "pkcs7": IMDS_BASE_URL + "attested/document?api-version=" + API_VERSION,
     "compute": IMDS_BASE_URL + "instance/compute?api-version=" + API_VERSION,

--- a/uaclient/clouds/tests/test_azure.py
+++ b/uaclient/clouds/tests/test_azure.py
@@ -34,8 +34,8 @@ class TestUAAutoAttachAzureInstance:
             "compute": {"computekey": "computeval"},
             "pkcs7": "attestedWOOT!===",
         } == instance.identity_doc
-        url1 = IMDS_BASE_URL + "instance/compute?api-version=2019-06-04"
-        url2 = IMDS_BASE_URL + "attested/document?api-version=2019-06-04"
+        url1 = IMDS_BASE_URL + "instance/compute?api-version=2020-09-01"
+        url2 = IMDS_BASE_URL + "attested/document?api-version=2020-09-01"
         assert [
             mock.call(url1, headers={"Metadata": "true"}),
             mock.call(url2, headers={"Metadata": "true"}),


### PR DESCRIPTION
# WIP: Do not land yet. Awaiting feedback from @patviafore-canonical on whether this is a viable approach. 
## Proposed Commit Message
```
    azure: support Azure published images bump IMDS API version
    
    Update the API_VERSION to 2020-09-01 to support grabbing both
    publisher and SKU information which helps discern whether
    an image is published by Microsoft itself versus one published
    by Canonical.
    
    Azure PRO based images will require an update to the IMDS APIcw
     version so the contract server can see whether the image is
    Canonical PRO or a Microsoft derivative image based on PRO.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
