### PR TITLE
jobs: add gcp auto-attach job (SC-333)

### DIFF
--- a/lib/timer.py
+++ b/lib/timer.py
@@ -13,11 +13,13 @@ from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 from uaclient.jobs.update_messaging import update_apt_and_motd_messages
 from uaclient.jobs.update_state import update_status
+from uaclient.jobs.gcp_auto_attach import gcp_auto_attach
 
 
 LOG = logging.getLogger(__name__)
 UPDATE_MESSAGING_INTERVAL = 21600  # 6 hours
 UPDATE_STATUS_INTERVAL = 43200  # 12 hours
+GCP_AUTO_ATTACH_INTERVAL = 1800  # 30 minutes
 
 # Store the default run_interval_seconds for each job in this dict.
 # OrderedDict is used to ensure each job is run sequentially in the order
@@ -36,6 +38,13 @@ UACLIENT_JOBS = collections.OrderedDict(
             {
                 "job_func": update_status,
                 "run_interval_seconds": UPDATE_STATUS_INTERVAL,
+            },
+        ),
+        (
+            "gcp_auto_attach",
+            {
+                "job_func": gcp_auto_attach,
+                "run_interval_seconds": GCP_AUTO_ATTACH_INTERVAL,
             },
         ),
     ]

--- a/uaclient/jobs/gcp_auto_attach.py
+++ b/uaclient/jobs/gcp_auto_attach.py
@@ -1,0 +1,36 @@
+"""
+Try to auto-attach in a GCP instance. This should only work
+if the instance has a new UA license attached to it
+"""
+
+from uaclient import config
+from uaclient import exceptions
+
+from uaclient.clouds.identity import get_cloud_type
+from uaclient.cli import action_auto_attach
+
+
+def gcp_auto_attach(cfg: config.UAConfig) -> None:
+    # If the instance is already attached we will not do anything.
+    # This implies that the user may have a new license attached to the
+    # instance, but we will not perfom the change through this job.
+    if cfg.is_attached:
+        return
+
+    # We will not do anything in a non-GCP cloud
+    cloud_id, _ = get_cloud_type()
+    if not cloud_id or cloud_id != "gce":
+        return
+
+    try:
+        # This function already uses the assert lock decorator,
+        # which means that we don't need to make create another
+        # lock only for the job
+        action_auto_attach(args=None, cfg=cfg)
+    except exceptions.NonAutoAttachImageError:
+        # If we get a NonAutoAttachImageError we now
+        # that the machine is not ready yet to perform an
+        # auto-attach operation (i.e. the license may not
+        # have been appended yet). If that happens, we will not
+        # error out.
+        return


### PR DESCRIPTION
## Proposed Commit Message
jobs: add gcp auto-attach job

Add gcp job that tries to run an auto-attach operation every 30 minutes. Before we try to run that command we verify that we are running on a GCP cloud and that we are not already attached. If we detect any of those scenarios, the job will not execute

## Test Steps
Launch a GCP PRO instance, then:

1) Run a detach command
2) Stop the systemd timer: `systemctl stop ua-timer.service`
3) Enable the systemd timer: `systemctl start ua-timer.service`
4) Wait a couple of minutes and verify that the instance is now attached to an UA subscription
5) Verify that the jobs status json file was created

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
