### PR TITLE
tests: make lxd.container machine type explicit (SC-310)

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -26,6 +26,7 @@ Feature: UA is expected version
 
     @series.all
     @uses.config.check_version
+    @uses.config.machine_type.lxd.container
     @upgrade
     Scenario Outline: Check ua version
         Given a `<release>` machine with ubuntu-advantage-tools installed

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -2,6 +2,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
          Advantage subscription using an invalid token
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command failure on invalid token
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I verify that running `ua attach INVALID_TOKEN` `with sudo` exits `1`
@@ -23,6 +24,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
 
     @uses.config.contract_token_staging_expired
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command failure on expired token
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attempt to attach `contract_token_staging_expired` with sudo

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -3,6 +3,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         subscription using a valid token
 
     @series.hirsute
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached command in a non-lts ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -73,6 +73,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
               allow_beta: true
             """
         And I run `apt update` with sudo
+        And I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
         And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         And I run `apt install update-motd` with sudo, retrying exit [100]
         And I run `update-motd` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -2,6 +2,7 @@
 Feature: Command behaviour when attached to an UA subscription
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached refresh in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -35,6 +36,7 @@ Feature: Command behaviour when attached to an UA subscription
            | hirsute |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -58,6 +60,7 @@ Feature: Command behaviour when attached to an UA subscription
            | hirsute |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached disable of a service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -96,6 +99,7 @@ Feature: Command behaviour when attached to an UA subscription
            | xenial  |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached detach in an ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -137,6 +141,7 @@ Feature: Command behaviour when attached to an UA subscription
            | xenial  | yes      | yes    | yes | yes  | yes         |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -159,6 +164,7 @@ Feature: Command behaviour when attached to an UA subscription
            | hirsute |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached show version in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -179,6 +185,7 @@ Feature: Command behaviour when attached to an UA subscription
            | hirsute |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached status in a ubuntu machine with feature overrides
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/machine-token-overlay.json` with the following:
@@ -228,6 +235,7 @@ Feature: Command behaviour when attached to an UA subscription
            | hirsute |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached disable of different services in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -261,6 +269,7 @@ Feature: Command behaviour when attached to an UA subscription
            | xenial  |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Help command on an attached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -353,6 +362,7 @@ Feature: Command behaviour when attached to an UA subscription
            | hirsute | n/a          |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Enable command with invalid repositories in user machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -2,6 +2,7 @@
 Feature: Enable command behaviour when attached to an UA subscription
 
     @series.xenial
+    @uses.config.machine_type.lxd.container
     Scenario: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `xenial` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -18,6 +19,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -50,6 +52,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | hirsute | CC EAL2 is not available for Ubuntu 21.04 (Hirsute Hippo).     |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable of a service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -142,6 +145,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | hirsute |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -165,6 +169,7 @@ Feature: Enable command behaviour when attached to an UA subscription
            | xenial  |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable of cis service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -2,6 +2,7 @@
 Feature: Attached status
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached status in a ubuntu machine - formatted
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -16,6 +16,7 @@ Feature: UA Install and Uninstall related tests
 
     @series.lts
     @uses.config.contract_token
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Purge package after attaching it to a machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -2,6 +2,7 @@
 Feature: Proxy configuration
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when proxy is configured
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I launch a `focal` `proxy` machine
@@ -208,6 +209,7 @@ Feature: Proxy configuration
            | bionic  |
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when authenticated proxy is configured
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I launch a `focal` `proxy` machine

--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -2,6 +2,7 @@
 Feature: Enable command behaviour when attached to an UA staging subscription
 
     @series.lts
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable esm-apps on a machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -3,6 +3,7 @@ Feature: Upgrade between releases when uaclient is attached
 
     @series.focal
     @series.hirsute
+    @uses.config.machine_type.lxd.container
     @upgrade
     Scenario Outline: Attached upgrade across releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -43,6 +44,7 @@ Feature: Upgrade between releases when uaclient is attached
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.lxd.container
     @upgrade
     Scenario Outline: Attached upgrade across LTS releases
         Given a `<release>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -3,6 +3,7 @@ Feature: Upgrade between releases when uaclient is unattached
 
     @series.focal
     @series.hirsute
+    @uses.config.machine_type.lxd.container
     @upgrade
     Scenario Outline: Unattached upgrade across releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -42,6 +43,7 @@ Feature: Upgrade between releases when uaclient is unattached
 
    @series.xenial
    @series.bionic
+   @uses.config.machine_type.lxd.container
    @upgrade
    Scenario Outline: Unattached upgrade across LTS releases
         Given a `<release>` machine with ubuntu-advantage-tools installed

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,6 +1,7 @@
 Feature: Command behaviour when unattached
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I verify that running `ua auto-attach` `as non-root` exits `1`
@@ -23,6 +24,7 @@ Feature: Command behaviour when unattached
            | hirsute |
 
     @series.xenial
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Disabled unattached APT policy apt-hook for infra and apps
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt update` with sudo
@@ -97,6 +99,7 @@ Feature: Command behaviour when unattached
            | xenial  | https://esm.ubuntu.com/infra/ubuntu | https://esm.ubuntu.com/apps/ubuntu |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I verify that running `ua <command>` `as non-root` exits `1`
@@ -123,6 +126,7 @@ Feature: Command behaviour when unattached
            | hirsute | refresh |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached command known and unknown services in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I verify that running `ua <command> <service>` `as non-root` exits `1`
@@ -158,6 +162,7 @@ Feature: Command behaviour when unattached
            | hirsute | disable  | unknown   |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Help command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua help esm-infra` as non-root
@@ -198,6 +203,7 @@ Feature: Command behaviour when unattached
 
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Useful SSL failure message when there aren't any ca-certs
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt remove ca-certificates -y` with sudo
@@ -226,6 +232,7 @@ Feature: Command behaviour when unattached
 
 
     @series.focal
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
@@ -280,6 +287,7 @@ Feature: Command behaviour when unattached
            | focal   |
 
     @series.xenial
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt install -y libawl-php` with sudo
@@ -336,6 +344,7 @@ Feature: Command behaviour when unattached
            | xenial  |
 
     @series.bionic
+    @uses.config.machine_type.lxd.container
     Scenario: Fix command on an unattached machine
         Given a `bionic` machine with ubuntu-advantage-tools installed
         When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -62,6 +62,7 @@ Feature: Command behaviour when unattached
             features:
               allow_beta: true
             """
+        And I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
         And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         And I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,6 +1,7 @@
 Feature: Unattached status
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached status in a ubuntu machine - formatted
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua status --format json` as non-root
@@ -26,6 +27,7 @@ Feature: Unattached status
            | hirsute |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua status` as non-root

--- a/tox.ini
+++ b/tox.ini
@@ -47,13 +47,13 @@ commands =
     mypy: mypy --python-version 3.6 uaclient/ features/ lib/
     mypy-focal: mypy --python-version 3.7 uaclient/ features/ lib/
     black: black --check --diff uaclient/ features/ lib/ setup.py
-    behave-lxd-16.04: behave -v {posargs} --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-18.04: behave -v {posargs} --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-20.04: behave -v {posargs} --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-21.04: behave -v {posargs} --tags="series.hirsute,series.all" --tags="~upgrade"
-    behave-vm-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.xenial,series.all,series.lts"
-    behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.bionic,series.all,series.lts"
-    behave-vm-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.focal,series.all,series.lts"
+    behave-lxd-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-21.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.hirsute,series.all" --tags="~upgrade"
+    behave-vm-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.xenial,series.all,series.lts" --tags="~upgrade"
+    behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
+    behave-vm-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.focal,series.all,series.lts" --tags="~upgrade"
     behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
     behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" --tags="series.focal,series.all"


### PR DESCRIPTION
Current behave tests can be decorated to run on top of specific platforms. If no platform is specified, lxd.container is selected by default. However, documentation points to lxd.container as a machine type and it is there for some tests, but it is the same as defining no machine_type.

Besides being ambiguous and not consistent, this behavior can be misleading: by looking at the patterns, one can think that tests without a machine_type decorator are running on all platforms, which is not true.

This PR is a refactor to explicitly tell which tests should be executed in containers.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
