### PR TITLE
fix: do not fail if non-utf8 locale is being used (SC-368)

### DIFF
--- a/help_data.yaml
+++ b/help_data.yaml
@@ -53,7 +53,7 @@ fips:
       FIPS 140-2 is a set of publicly announced cryptographic standards
       developed by the National Institute of Standards and Technology
       applicable for FedRAMP, HIPAA, PCI and ISO compliance use cases.
-      Note that ‘fips’ does not provide security patching. For fips certified
+      Note that "fips" does not provide security patching. For fips certified
       modules with security patches please refer to fips-updates. The modules
       are certified on Intel x86_64 and IBM Z hardware platforms for Ubuntu
       18.04 and Intel x86_64, IBM Power8 and IBM Z hardware platforms for

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1135,15 +1135,7 @@ def action_status(args, cfg):
         print(ua_status.format_yaml_status(status))
     else:
         output = ua_status.format_tabular(status)
-        # Replace our Unicode dash with an ASCII dash if we aren't going to be
-        # writing to a utf-8 output; see
-        # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/859
-        if (
-            sys.stdout.encoding is None
-            or "UTF-8" not in sys.stdout.encoding.upper()
-        ):
-            output = output.replace("\u2014", "-")
-        print(output)
+        print(util.handle_unicode_characters(output))
     return 0
 
 

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -926,7 +926,7 @@ def prompt_for_affected_packages(
         # In case (2), then all_already_installed is also True
         if all_already_installed:
             # we didn't install any packages, so we're good
-            print(fix_message)
+            print(util.handle_unicode_characters(fix_message))
         elif util.should_reboot():
             # we successfully installed some packages, but
             # system reboot-required. This might be because
@@ -937,17 +937,23 @@ def prompt_for_affected_packages(
             print(reboot_msg)
             cfg.add_notice("", reboot_msg)
             print(
-                status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(
-                    issue=issue_id
+                util.handle_unicode_characters(
+                    status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(
+                        issue=issue_id
+                    )
                 )
             )
         else:
             # we successfully installed some packages, and the system
             # reboot-required flag is not set, so we're good
-            print(fix_message)
+            print(util.handle_unicode_characters(fix_message))
     else:
         print(
-            status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(issue=issue_id)
+            util.handle_unicode_characters(
+                status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(
+                    issue=issue_id
+                )
+            )
         )
 
 

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -941,13 +941,19 @@ class TestPromptForAffectedPackages:
         FakeConfig,
     ):
         with pytest.raises(exceptions.SecurityAPIMetadataError) as exc:
-            prompt_for_affected_packages(
-                cfg=FakeConfig(),
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=FakeConfig(),
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
         assert (
             "Error: USN-### metadata defines no fixed version for sl.\n"
             "1 package is still affected: slsrc\n"
@@ -1344,16 +1350,18 @@ A fix is available in Ubuntu standard updates.\n"""
         get_cloud_type.return_value = cloud_type
         m_user_facing_status.return_value = (UserFacingStatus.INACTIVE, "")
         cfg = FakeConfig()
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
         out, err = capsys.readouterr()
-        print(out)
-        print(expected)
         assert expected in out
 
     @pytest.mark.parametrize(
@@ -1458,13 +1466,17 @@ A fix is available in Ubuntu standard updates.\n"""
         m_action_attach.side_effect = fake_attach
 
         cfg = FakeConfig()
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1518,13 +1530,17 @@ A fix is available in Ubuntu standard updates.\n"""
         m_upgrade_packages.return_value = False
 
         cfg = FakeConfig()
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1620,13 +1636,19 @@ A fix is available in Ubuntu standard updates.\n"""
         with mock.patch.object(
             sec, "ENTITLEMENT_CLASS_BY_NAME", {"esm-infra": m_entitlement_cls}
         ):
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1708,13 +1730,19 @@ A fix is available in Ubuntu standard updates.\n"""
         with mock.patch.object(
             sec, "ENTITLEMENT_CLASS_BY_NAME", {"esm-infra": m_entitlement_cls}
         ):
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1792,13 +1820,19 @@ A fix is available in Ubuntu standard updates.\n"""
         with mock.patch.object(
             sec, "ENTITLEMENT_CLASS_BY_NAME", {"esm-infra": m_entitlement_cls}
         ):
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1874,13 +1908,18 @@ A fix is available in Ubuntu standard updates.\n"""
                 }
             }
         )
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
+
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1936,13 +1975,19 @@ A fix is available in Ubuntu standard updates.\n"""
                 }
             }
         )
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
+
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1992,13 +2037,17 @@ A fix is available in Ubuntu standard updates.\n"""
         m_get_cloud_type.return_value = ("cloud", None)
 
         cfg = FakeConfig()
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -2054,13 +2103,17 @@ A fix is available in Ubuntu standard updates.\n"""
         m_get_cloud_type.return_value = ("cloud", None)
 
         cfg = FakeConfig()
-        prompt_for_affected_packages(
-            cfg=cfg,
-            issue_id="USN-###",
-            affected_pkg_status=affected_pkg_status,
-            installed_packages=installed_packages,
-            usn_released_pkgs=usn_released_pkgs,
-        )
+        with mock.patch("uaclient.util.sys") as m_sys:
+            m_stdout = mock.MagicMock()
+            type(m_sys).stdout = m_stdout
+            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
+            prompt_for_affected_packages(
+                cfg=cfg,
+                issue_id="USN-###",
+                affected_pkg_status=affected_pkg_status,
+                installed_packages=installed_packages,
+                usn_released_pkgs=usn_released_pkgs,
+            )
         out, err = capsys.readouterr()
         assert expected in out
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -1070,3 +1070,27 @@ class TestValidateProxy:
             )
             in caplog_text()
         )
+
+
+class TestHandleUnicodeCharacters:
+    @pytest.mark.parametrize(
+        "encoding", ((None), ("utf-8"), ("UTF-8"), ("test"))
+    )
+    @pytest.mark.parametrize(
+        "message,modified_message",
+        (
+            (status.OKGREEN_CHECK + " test", "test"),
+            (status.FAIL_X + " fail", "fail"),
+            ("\u2014 blah", "- blah"),
+        ),
+    )
+    def test_handle_unicode_characters(
+        self, message, modified_message, encoding
+    ):
+        expected_message = message
+        if encoding is None or encoding.upper() != "UTF-8":
+            expected_message = modified_message
+
+        with mock.patch("sys.stdout") as m_stdout:
+            type(m_stdout).encoding = mock.PropertyMock(return_value=encoding)
+            assert expected_message == util.handle_unicode_characters(message)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -5,6 +5,7 @@ import os
 import re
 import socket
 import subprocess
+import sys
 import time
 import uuid
 from contextlib import contextmanager
@@ -841,3 +842,26 @@ def validate_proxy(
         raise exceptions.UserFacingError(
             status.MESSAGE_NOT_SETTING_PROXY_NOT_WORKING.format(proxy=proxy)
         )
+
+
+def handle_unicode_characters(message: str) -> str:
+    """
+    Verify if the system can output unicode characters and if not,
+    remove those characters from the message string.
+    """
+    if (
+        sys.stdout.encoding is None
+        or "UTF-8" not in sys.stdout.encoding.upper()
+    ):
+        # Replace our Unicode dash with an ASCII dash if we aren't going to be
+        # writing to a utf-8 output; see
+        # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/859
+        message = message.replace("\u2014", "-")
+
+        # Remove our unicode success/failure marks if we aren't going to be
+        # writing to a utf-8 output; see
+        # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/1463
+        message = message.replace(status.OKGREEN_CHECK + " ", "")
+        message = message.replace(status.FAIL_X + " ", "")
+
+    return message


### PR DESCRIPTION
## Proposed Commit Message
When running an ua fix command, we tell at the end if the issue is resolved or not. In that message, we have some unicode characters that are displayed. If the user is running on a system that doesn't support those characters, the printing that last message will fail. We are now redacting the code to not fail under this condition.

Fixes: #1463

## Test Steps
Run the new unittest provided in the system.
Another way to test is to launch an instance and change the locale to `ANSI_X3.4-1968`. Run an ua fix command and verify that it doesn't break on the message

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
