### PR TITLE
tests: add script to run integration tests (SC-197)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ gcp-pub-*
 gcp-priv-*
 lxd-*-uaclient-ci-*
 build-from-source.sh
+test-results*
+
+# credentials - don't commit credentials
+tools/ua-test-credentials.yaml
 
 # apt-hook build artifacts
 apt-hook/hook

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -1,0 +1,195 @@
+import os
+import subprocess
+import tarfile
+import time
+from datetime import datetime
+from sys import stdout
+
+import click
+import yaml
+
+PLATFORMS = (
+    "azuregeneric",
+    "azurepro",
+    "awsgeneric",
+    "awspro",
+    "gcpgeneric",
+    "gcppro",
+    "vm",
+    "lxd",
+    "upgrade",
+)
+
+SERIES_TO_VERSION = {
+    "xenial": "16.04",
+    "bionic": "18.04",
+    "focal": "20.04",
+    "hirsute": "21.04",
+}
+
+TOKEN_TO_ENVVAR = {
+    "prod": "UACLIENT_BEHAVE_CONTRACT_TOKEN",
+    "staging": "UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING",
+    "expired": "UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED",
+}
+
+
+def is_compatible(platform, series):
+    if platform in ("lxd", "upgrade"):
+        return True
+    elif series not in ("hirsute",):
+        return True
+    return False
+
+
+def build_commands(
+    platform, series, proposed, check_version, token, credentials_path, wip
+):
+    with open(credentials_path) as f:
+        credentials = yaml.safe_load(f)
+    commands = []
+    for p in platform:
+        for s in series:
+            # Not all tests can run in all platforms
+            if is_compatible(p, s):
+                series_version = SERIES_TO_VERSION[s]
+                env = os.environ.copy()
+
+                # Add check_version variable
+                if check_version:
+                    env["UACLIENT_BEHAVE_CHECK_VERSION"] = "{}~{}.1".format(
+                        check_version, series_version
+                    )
+
+                # If not told to run from proposed, run from local changes
+                if proposed:
+                    env["UACLIENT_BEHAVE_ENABLE_PROPOSED"] = "1"
+                else:
+                    env["UACLIENT_BEHAVE_BUILD_PR"] = "1"
+
+                # Inject tokens from credentials
+                for t in token:
+                    envvar = TOKEN_TO_ENVVAR[t]
+                    env[envvar] = credentials["token"].get(envvar)
+
+                # Inject cloud-specific variables from credentials
+                for cloud in ("azure", "aws", "gcp"):
+                    if cloud in p:
+                        for envvar in credentials[cloud]:
+                            env[envvar] = credentials[cloud].get(envvar)
+
+                # Until we don't get sbuild to run just once per run,
+                env["UACLIENT_BEHAVE_SNAPSHOT_STRATEGY"] = "1"
+
+                # Tox command itself
+                command = "tox -e behave-{}-{}".format(
+                    p, series_version
+                ).split()
+
+                # Wip
+                if wip:
+                    command.extend("-- -w".split())
+
+                commands.append((command, env))
+
+    return commands
+
+
+@click.command()
+@click.option(
+    "-p",
+    "--platform",
+    type=click.Choice(PLATFORMS),
+    default=PLATFORMS,
+    multiple=True,
+    help="Platform to run the tests on (requires credentials file for the clouds)",
+)
+@click.option(
+    "-s",
+    "--series",
+    type=click.Choice(SERIES_TO_VERSION.keys()),
+    default=SERIES_TO_VERSION.keys(),
+    multiple=True,
+    help="Series to run the tests on",
+)
+@click.option(
+    "--token",
+    "-t",
+    type=click.Choice(TOKEN_TO_ENVVAR.keys()),
+    default=TOKEN_TO_ENVVAR.keys(),
+    multiple=True,
+    help="Tokens to use for the tests (require tokens in the credentials file)",
+)
+@click.option(
+    "--proposed",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Run tests based on existing packages in the Proposed pocket",
+)
+@click.option(
+    "--check-version",
+    type=str,
+    help="Check for a specific version in the tests",
+)
+@click.option(
+    "--credentials-path",
+    "-c",
+    type=click.Path(dir_okay=False),
+    default="tools/ua-test-credentials.yaml",
+    help="Path to the file containing the credentials to run the test",
+)
+@click.option(
+    "-w",
+    "--wip",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Run only tests with the @wip decorator",
+)
+def run_tests(
+    platform, series, proposed, check_version, token, credentials_path, wip
+):
+    commands = build_commands(
+        platform, series, proposed, check_version, token, credentials_path, wip
+    )
+    current_datetime = datetime.now().strftime(format="%b-%d-%H%M")
+    output_dir = "test-results/{}".format(current_datetime)
+    os.makedirs(output_dir, exist_ok=True)
+    error = False
+    processes = []
+    for command, env in commands:
+        print("Running {}".format(command))
+        with open(
+            "{}/{}.txt".format(output_dir, command[2]), "wb"
+        ) as result_file:
+            process = subprocess.Popen(
+                command, env=env, stdout=result_file, stderr=stdout
+            )
+            processes.append(process)
+
+    while processes:
+        for process in processes:
+            result = process.poll()
+            if result is not None:
+                if result == 0:
+                    print("{} finished sucessfully".format(process.args))
+                else:
+                    print("Failing tests for {}".format(process.args))
+                    result_filename = "{}.txt".format(process.args[2])
+                    os.rename(
+                        "{}/{}".format(output_dir, result_filename),
+                        "{}/failed-{}".format(output_dir, result_filename),
+                    )
+                    error = True
+                processes.remove(process)
+        time.sleep(5)
+
+    if proposed and not error:
+        filename = "test-results-{}.tar.gz".format(current_datetime)
+        with tarfile.open(filename, "w:gz") as results:
+            results.add(output_dir, arcname="test-results/")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -88,7 +88,7 @@ def build_commands(
 
                 # Wip
                 if wip:
-                    command.extend("-- -w".split())
+                    command.extend(["--tags='wip'", "--stop"])
 
                 commands.append((command, env))
 

--- a/tools/ua-test-credentials.example.yaml
+++ b/tools/ua-test-credentials.example.yaml
@@ -1,0 +1,20 @@
+---
+
+token:
+    UACLIENT_BEHAVE_CONTRACT_TOKEN: <token for testing>
+    UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING: <staging token for testing>
+    UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED: <expired staging token for testing>
+
+azure:
+    UACLIENT_BEHAVE_AZ_CLIENT_ID: <azure credentials>
+    UACLIENT_BEHAVE_AZ_CLIENT_SECRET: <azure credentials>
+    UACLIENT_BEHAVE_AZ_SUBSCRIPTION_ID: <azure credentials>
+    UACLIENT_BEHAVE_AZ_TENANT_ID: <azure credentials>
+
+aws:
+    UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID: <aws credentials>
+    UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY: <aws credentials>
+
+gcp:
+    UACLIENT_BEHAVE_GCP_CREDENTIALS_PATH: <gcp credentials>
+    UACLIENT_BEHAVE_GCP_PROJECT: <gcp credentials>


### PR DESCRIPTION
A CLI script to run the integration tests, organizing the credentials, storing the results (`stdin` and `stderr`).
If testing from Proposed, check that all tests pass and create a tarball with the results.
There is an example file with the yaml structure.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
