### PR TITLE
Remove trusty typing import logic and sort imports with isort (SC-367)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
     rev: 19.3b0  # Also stored in dev-requirements.txt; update both together!
     hooks:
     - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0  # Also stored in dev-requirements.txt; update both together!
+    hooks:
+    - id: isort

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
             steps {
                 sh '''
                 set +x
-                tox -e black
+                tox -e black -e isort
                 '''
             }
         }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-# The black version is also in .pre-commit-config.yaml; make sure to update
-# both together
+# The black and isort versions are also in .pre-commit-config.yaml; make sure
+# to update both together
 black==19.3b0
+isort==5.8.0
 pre-commit

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -5,11 +5,7 @@ import pycloudlib  # type: ignore
 import time
 import yaml
 
-try:
-    from typing import Tuple, List, Optional  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Tuple, List, Optional
 
 
 class Cloud:

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -24,13 +24,13 @@ class Cloud:
 
     name = ""
     pro_ids_path = ""
-    env_vars: "Tuple[str, ...]" = ()
+    env_vars: Tuple[str, ...] = ()
 
     def __init__(
         self,
         machine_type: str,
-        region: "Optional[str]" = None,
-        tag: "Optional[str]" = None,
+        region: Optional[str] = None,
+        tag: Optional[str] = None,
         timestamp_suffix: bool = True,
     ) -> None:
         if tag:
@@ -65,9 +65,9 @@ class Cloud:
     def _create_instance(
         self,
         series: str,
-        instance_name: "Optional[str]" = None,
-        image_name: "Optional[str]" = None,
-        user_data: "Optional[str]" = None,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
         ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Create an instance for on the cloud provider.
@@ -112,9 +112,9 @@ class Cloud:
     def launch(
         self,
         series: str,
-        instance_name: "Optional[str]" = None,
-        image_name: "Optional[str]" = None,
-        user_data: "Optional[str]" = None,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
         ephemeral: bool = False,
     ) -> pycloudlib.instance.BaseInstance:
         """Create and wait for cloud provider instance to be ready.
@@ -171,7 +171,7 @@ class Cloud:
         """
         return instance.id
 
-    def format_missing_env_vars(self, missing_env_vars: "List") -> "List[str]":
+    def format_missing_env_vars(self, missing_env_vars: List) -> List[str]:
         """Format missing env vars to be displayed in log.
 
         :returns:
@@ -179,7 +179,7 @@ class Cloud:
         """
         return [" - {}\n".format(env_var) for env_var in missing_env_vars]
 
-    def missing_env_vars(self) -> "List[str]":
+    def missing_env_vars(self) -> List[str]:
         """Return a list of env variables necessary for this cloud provider.
 
         :returns:
@@ -219,8 +219,8 @@ class Cloud:
 
     def manage_ssh_key(
         self,
-        private_key_path: "Optional[str]" = None,
-        key_name: "Optional[str]" = None,
+        private_key_path: Optional[str] = None,
+        key_name: Optional[str] = None,
     ) -> None:
         """Create and manage ssh key pairs to be used in the cloud provider.
 
@@ -268,19 +268,16 @@ class EC2(Cloud):
     """
 
     name = "aws"
-    env_vars: "Tuple[str, ...]" = (
-        "aws_access_key_id",
-        "aws_secret_access_key",
-    )
+    env_vars: Tuple[str, ...] = ("aws_access_key_id", "aws_secret_access_key")
     pro_ids_path = "features/aws-ids.yaml"
 
     def __init__(
         self,
-        aws_access_key_id: "Optional[str]",
-        aws_secret_access_key: "Optional[str]",
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[str],
         machine_type: str,
-        region: "Optional[str]" = "us-east-2",
-        tag: "Optional[str]" = None,
+        region: Optional[str] = "us-east-2",
+        tag: Optional[str] = None,
         timestamp_suffix: bool = True,
     ) -> None:
         self.aws_access_key_id = aws_access_key_id
@@ -311,8 +308,8 @@ class EC2(Cloud):
 
     def manage_ssh_key(
         self,
-        private_key_path: "Optional[str]" = None,
-        key_name: "Optional[str]" = None,
+        private_key_path: Optional[str] = None,
+        key_name: Optional[str] = None,
     ) -> None:
         """Create and manage ssh key pairs to be used in the cloud provider.
 
@@ -346,9 +343,9 @@ class EC2(Cloud):
     def _create_instance(
         self,
         series: str,
-        instance_name: "Optional[str]" = None,
-        image_name: "Optional[str]" = None,
-        user_data: "Optional[str]" = None,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
         ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
@@ -409,7 +406,7 @@ class Azure(Cloud):
     """
 
     name = "Azure"
-    env_vars: "Tuple[str, ...]" = (
+    env_vars: Tuple[str, ...] = (
         "az_client_id",
         "az_client_secret",
         "az_tenant_id",
@@ -420,13 +417,13 @@ class Azure(Cloud):
     def __init__(
         self,
         machine_type: str,
-        region: "Optional[str]" = "centralus",
-        tag: "Optional[str]" = None,
+        region: Optional[str] = "centralus",
+        tag: Optional[str] = None,
         timestamp_suffix: bool = True,
-        az_client_id: "Optional[str]" = None,
-        az_client_secret: "Optional[str]" = None,
-        az_tenant_id: "Optional[str]" = None,
-        az_subscription_id: "Optional[str]" = None,
+        az_client_id: Optional[str] = None,
+        az_client_secret: Optional[str] = None,
+        az_tenant_id: Optional[str] = None,
+        az_subscription_id: Optional[str] = None,
     ) -> None:
         self.az_client_id = az_client_id
         self.az_client_secret = az_client_secret
@@ -472,8 +469,8 @@ class Azure(Cloud):
 
     def manage_ssh_key(
         self,
-        private_key_path: "Optional[str]" = None,
-        key_name: "Optional[str]" = None,
+        private_key_path: Optional[str] = None,
+        key_name: Optional[str] = None,
     ) -> None:
         """Create and manage ssh key pairs to be used in the cloud provider.
 
@@ -508,9 +505,9 @@ class Azure(Cloud):
     def _create_instance(
         self,
         series: str,
-        instance_name: "Optional[str]" = None,
-        image_name: "Optional[str]" = None,
-        user_data: "Optional[str]" = None,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
         ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
@@ -562,17 +559,17 @@ class GCP(Cloud):
         of the provided tag.
     """
 
-    env_vars: "Tuple[str, ...]" = ("gcp_credentials_path", "gcp_project")
+    env_vars: Tuple[str, ...] = ("gcp_credentials_path", "gcp_project")
 
     def __init__(
         self,
         machine_type: str,
-        region: "Optional[str]" = "us-west2",
-        tag: "Optional[str]" = None,
+        region: Optional[str] = "us-west2",
+        tag: Optional[str] = None,
         timestamp_suffix: bool = True,
-        zone: "Optional[str]" = "a",
-        gcp_credentials_path: "Optional[str]" = None,
-        gcp_project: "Optional[str]" = None,
+        zone: Optional[str] = "a",
+        gcp_credentials_path: Optional[str] = None,
+        gcp_project: Optional[str] = None,
     ) -> None:
         self.gcp_credentials_path = gcp_credentials_path
         self.gcp_project = gcp_project
@@ -616,9 +613,9 @@ class GCP(Cloud):
     def _create_instance(
         self,
         series: str,
-        instance_name: "Optional[str]" = None,
-        image_name: "Optional[str]" = None,
-        user_data: "Optional[str]" = None,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
         ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
@@ -655,8 +652,8 @@ class _LXD(Cloud):
     def __init__(
         self,
         machine_type: str,
-        region: "Optional[str]" = None,
-        tag: "Optional[str]" = None,
+        region: Optional[str] = None,
+        tag: Optional[str] = None,
         timestamp_suffix: bool = True,
     ) -> None:
         super().__init__(
@@ -674,9 +671,9 @@ class _LXD(Cloud):
     def _create_instance(
         self,
         series: str,
-        instance_name: "Optional[str]" = None,
-        image_name: "Optional[str]" = None,
-        user_data: "Optional[str]" = None,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
         ephemeral: bool = False,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -1,11 +1,11 @@
 import json
-import os
 import logging
-import pycloudlib  # type: ignore
+import os
 import time
-import yaml
+from typing import List, Optional, Tuple
 
-from typing import Tuple, List, Optional
+import pycloudlib  # type: ignore
+import yaml
 
 
 class Cloud:

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,21 +1,18 @@
 import datetime
-import os
 import itertools
+import logging
+import os
 import re
 import tempfile
 import textwrap
-import logging
+from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
+
 import pycloudlib  # type: ignore
-
-from typing import Dict, Optional, Union, List, Tuple, Any  # noqa: F401
-
 from behave.model import Feature, Scenario
-
 from behave.runner import Context
 
 import features.cloud as cloud
-
-from features.util import emit_spinner_on_travis, lxc_get_property, build_debs
+from features.util import build_debs, emit_spinner_on_travis, lxc_get_property
 
 ALL_SUPPORTED_SERIES = ["bionic", "focal", "xenial"]
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -7,11 +7,7 @@ import textwrap
 import logging
 import pycloudlib  # type: ignore
 
-try:
-    from typing import Dict, Optional, Union, List, Tuple, Any  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Dict, Optional, Union, List, Tuple, Any  # noqa: F401
 
 from behave.model import Feature, Scenario
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -190,7 +190,7 @@ class UAClientBehaveConfig:
         ppa_keyid: str = DAILY_PPA_KEYID,
         userdata_file: str = None,
         check_version: str = None,
-        cmdline_tags: "List" = []
+        cmdline_tags: List = []
     ) -> None:
         # First, store the values we've detected
         self.aws_access_key_id = aws_access_key_id
@@ -404,7 +404,7 @@ def before_all(context: Context) -> None:
         )
 
 
-def _should_skip_tags(context: Context, tags: "List") -> str:
+def _should_skip_tags(context: Context, tags: List) -> str:
     """Return a reason if a feature or scenario should be skipped"""
     machine_type = getattr(context.config, "machine_type", "")
     machine_types = []
@@ -592,9 +592,7 @@ def after_all(context):
 
 
 def capture_container_as_image(
-    container_name: str,
-    image_name: str,
-    cloud_api: "pycloudlib.cloud.BaseCloud",
+    container_name: str, image_name: str, cloud_api: pycloudlib.cloud.BaseCloud
 ) -> str:
     """Capture a container as an image.
 
@@ -613,7 +611,7 @@ def capture_container_as_image(
     return cloud_api.snapshot(instance=inst)
 
 
-def build_debs_from_sbuild(context: Context, series: str) -> "List[str]":
+def build_debs_from_sbuild(context: Context, series: str) -> List[str]:
     """Create a chroot and build the package using sbuild
 
 
@@ -749,7 +747,7 @@ def _install_uat_in_container(
     series: str,
     config: UAClientBehaveConfig,
     machine_type: str,
-    deb_paths: "Optional[List[str]]" = None,
+    deb_paths: Optional[List[str]] = None,
 ) -> None:
     """Install ubuntu-advantage-tools into the specified container
 
@@ -760,7 +758,7 @@ def _install_uat_in_container(
     :param config: UAClientBehaveConfig
     :param deb_paths: Optional paths to local deb files we need to install
     """
-    cmds: "List[Any]" = [["systemctl", "is-system-running", "--wait"]]
+    cmds: List[Any] = [["systemctl", "is-system-running", "--wait"]]
 
     if deb_paths is None:
         deb_paths = []

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -2,29 +2,27 @@ import datetime
 import json
 import logging
 import os
-import subprocess
 import re
 import shlex
+import subprocess
 import time
-import yaml
 
+import yaml
 from behave import given, then, when
 from hamcrest import (
     assert_that,
+    contains_string,
     equal_to,
     matches_regexp,
     not_,
-    contains_string,
 )
 
 from features.environment import (
-    create_instance_with_uat_installed,
     capture_container_as_image,
+    create_instance_with_uat_installed,
 )
 from features.util import SLOW_CMDS, emit_spinner_on_travis, nullcontext
-
 from uaclient.defaults import DEFAULT_CONFIG_FILE, DEFAULT_MACHINE_TOKEN_PATH
-
 
 CONTAINER_PREFIX = "ubuntu-behave-test"
 IMAGE_BUILD_PREFIX = "ubuntu-behave-image-build"

--- a/features/util.py
+++ b/features/util.py
@@ -1,15 +1,15 @@
-from contextlib import contextmanager
-import os
 import logging
 import multiprocessing
+import os
+import shutil
 import subprocess
 import tempfile
-import shutil
 import textwrap
 import time
-import yaml
+from contextlib import contextmanager
 from typing import List
 
+import yaml
 
 LXC_PROPERTY_MAP = {
     "image": {"series": "properties.release", "machine_type": "Type"},

--- a/features/util.py
+++ b/features/util.py
@@ -86,7 +86,7 @@ def lxc_get_property(name: str, property_name: str, image: bool = False):
 
 def build_debs(
     series: str, output_deb_dir: str, cache_source: bool
-) -> "List[str]":
+) -> List[str]:
     """
     Build the package through sbuild and store the debs into
     output_deb_dir

--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -18,8 +18,8 @@ import copy
 import json
 import logging
 
-from uaclient.cli import setup_logging
 from uaclient import util
+from uaclient.cli import setup_logging
 
 
 def patch_status_json_schema_0_1(status_file: str):

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -20,10 +20,9 @@ import sys
 import time
 
 from uaclient import config, contract, entitlements, status
-from uaclient.exceptions import UserFacingError, LockHeldError
-
-from uaclient.util import subp, ProcessExecutionError, UrlError
-from uaclient.cli import setup_logging, assert_lock_file
+from uaclient.cli import assert_lock_file, setup_logging
+from uaclient.exceptions import LockHeldError, UserFacingError
+from uaclient.util import ProcessExecutionError, UrlError, subp
 
 # Retry sleep backoff algorithm if lock is held.
 # Lock may be held by auto-attach on systems with ubuntu-advantage-pro.

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -3,17 +3,14 @@ Timer used to run all jobs that need to be frequently run on the system
 """
 
 import logging
-
 from datetime import datetime, timedelta
-
 from typing import Callable
 
 from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
+from uaclient.jobs.gcp_auto_attach import gcp_auto_attach
 from uaclient.jobs.update_messaging import update_apt_and_motd_messages
 from uaclient.jobs.update_state import update_status
-from uaclient.jobs.gcp_auto_attach import gcp_auto_attach
-
 
 LOG = logging.getLogger(__name__)
 UPDATE_MESSAGING_INTERVAL = 21600  # 6 hours

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -20,9 +20,9 @@ This script will detect differences like that and update the Xenial system
 to reflect them.
 """
 
-import time
 import logging
 import sys
+import time
 
 from uaclient.cli import setup_logging
 from uaclient.config import UAConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.black]
 line-length = 79
 target_version = ['py34', 'py35', 'py36', 'py37']
+
+[tool.isort]
+profile = "black"
+line_length = 79

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # This file is part of ubuntu-advantage-client.  See LICENSE file for license.
 
 import glob
+
 import setuptools
 
 from uaclient import defaults, util, version

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic}, mypy, black
+envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic}, mypy, black, isort
 
 [testenv:flake8-trusty]
 pip_version = 9.0.2
@@ -25,6 +25,7 @@ deps =
     mypy: -rtypes-requirements.txt
     mypy: -ctools/constraints-mypy.txt
     black: -rdev-requirements.txt
+    isort: -rdev-requirements.txt
     behave: -rintegration-requirements.txt
 passenv =
     UACLIENT_BEHAVE_*
@@ -47,6 +48,7 @@ commands =
     mypy: mypy --python-version 3.6 uaclient/ features/ lib/
     mypy-focal: mypy --python-version 3.7 uaclient/ features/ lib/
     black: black --check --diff uaclient/ features/ lib/ setup.py
+    isort: isort --check --diff uaclient/ features/ lib/ setup.py
     behave-lxd-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-lxd-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
     behave-lxd-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.focal,series.lts,series.all" --tags="~upgrade"

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -4,13 +4,9 @@ import os
 import re
 import subprocess
 import tempfile
-
-from uaclient import exceptions
-from uaclient import gpg
-from uaclient import status
-from uaclient import util
-
 from typing import Dict, List, Optional
+
+from uaclient import exceptions, gpg, status, util
 
 APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
 APT_AUTH_COMMENT = "  # ubuntu-advantage-tools"

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -10,11 +10,7 @@ from uaclient import gpg
 from uaclient import status
 from uaclient import util
 
-try:
-    from typing import Dict, List, Optional  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Dict, List, Optional
 
 APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
 APT_AUTH_COMMENT = "  # ubuntu-advantage-tools"

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -125,7 +125,7 @@ def _parse_apt_update_for_invalid_apt_config(apt_error: str) -> str:
 
 
 def run_apt_command(
-    cmd: "List[str]", error_msg: str, env: "Optional[Dict[str, str]]" = {}
+    cmd: List[str], error_msg: str, env: Optional[Dict[str, str]] = {}
 ) -> str:
     """Run an apt command, retrying upon failure APT_RETRIES times.
 
@@ -160,7 +160,7 @@ def add_auth_apt_repo(
     repo_filename: str,
     repo_url: str,
     credentials: str,
-    suites: "List[str]",
+    suites: List[str],
     keyring_file: str,
 ) -> None:
     """Add an authenticated apt repo and credentials to the system.
@@ -383,7 +383,7 @@ def clean_apt_files(*, _entitlements=None):
             os.unlink(pref_file)
 
 
-def get_installed_packages() -> "List[str]":
+def get_installed_packages() -> List[str]:
     out, _ = util.subp(["dpkg-query", "-W", "--showformat=${Package}\\n"])
     return out.splitlines()
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -56,8 +56,8 @@ class UAArgumentParser(argparse.ArgumentParser):
         epilog=None,
         formatter_class=argparse.HelpFormatter,
         base_desc: str = None,
-        non_beta_services_desc: "List[str]" = None,
-        beta_services_desc: "List[str]" = None,
+        non_beta_services_desc: List[str] = None,
+        beta_services_desc: List[str] = None,
     ):
         super().__init__(
             prog=prog,
@@ -545,7 +545,7 @@ def _perform_disable(entitlement_name, cfg, *, assume_yes):
     return ret
 
 
-def get_valid_entitlement_names(names: "List[str]"):
+def get_valid_entitlement_names(names: List[str]):
     """Return a list of valid entitlement names.
 
     :param names: List of entitlements to validate

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -3,7 +3,6 @@
 """Client to manage Ubuntu Advantage services on a machine."""
 
 import argparse
-from functools import wraps
 import json
 import logging
 import os
@@ -12,18 +11,12 @@ import re
 import sys
 import textwrap
 import time
-
+from functools import wraps
 from typing import List
 
-
-from uaclient import config
-from uaclient import contract
-from uaclient import entitlements
-from uaclient import exceptions
-from uaclient import security
+from uaclient import config, contract, entitlements, exceptions, security
 from uaclient import status as ua_status
-from uaclient import util
-from uaclient import version
+from uaclient import util, version
 from uaclient.clouds import identity
 from uaclient.defaults import CONFIG_FIELD_ENVVAR_ALLOWLIST
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -13,11 +13,7 @@ import sys
 import textwrap
 import time
 
-try:
-    from typing import List  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import List
 
 
 from uaclient import config

--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -1,10 +1,6 @@
 import abc
 
-try:
-    from typing import Any, Dict  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict
 
 
 class AutoAttachCloudInstance(metaclass=abc.ABCMeta):

--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -1,5 +1,4 @@
 import abc
-
 from typing import Any, Dict
 
 

--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 class AutoAttachCloudInstance(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
-    def identity_doc(self) -> "Dict[str, Any]":
+    def identity_doc(self) -> Dict[str, Any]:
         """Return the identity document representing this cloud instance"""
         pass
 

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -1,10 +1,8 @@
+from typing import Any, Dict
 from urllib.error import HTTPError
 
-from typing import Any, Dict
-
-from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util
-
+from uaclient.clouds import AutoAttachCloudInstance
 
 IMDS_V2_TOKEN_URL = "http://169.254.169.254/latest/api/token"
 IMDS_URL = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -1,10 +1,6 @@
 from urllib.error import HTTPError
 
-try:
-    from typing import Any, Dict  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict
 
 from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -23,7 +23,7 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
-    def identity_doc(self) -> "Dict[str, Any]":
+    def identity_doc(self) -> Dict[str, Any]:
         headers = self._get_imds_v2_token_headers()
         response, _headers = util.readurl(IMDS_URL, headers=headers)
         return {"pkcs7": response}

--- a/uaclient/clouds/azure.py
+++ b/uaclient/clouds/azure.py
@@ -1,12 +1,9 @@
 import os
-
+from typing import Any, Dict
 from urllib.error import HTTPError
 
-from typing import Any, Dict
-
-from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util
-
+from uaclient.clouds import AutoAttachCloudInstance
 
 IMDS_BASE_URL = "http://169.254.169.254/metadata/"
 

--- a/uaclient/clouds/azure.py
+++ b/uaclient/clouds/azure.py
@@ -24,7 +24,7 @@ class UAAutoAttachAzureInstance(AutoAttachCloudInstance):
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
-    def identity_doc(self) -> "Dict[str, Any]":
+    def identity_doc(self) -> Dict[str, Any]:
         responses = {}
         for key, url in sorted(IMDS_URLS.items()):
             url_response, _headers = util.readurl(

--- a/uaclient/clouds/azure.py
+++ b/uaclient/clouds/azure.py
@@ -2,11 +2,7 @@ import os
 
 from urllib.error import HTTPError
 
-try:
-    from typing import Any, Dict  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict
 
 from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util

--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -21,7 +21,7 @@ class UAAutoAttachGCPInstance(AutoAttachCloudInstance):
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
-    def identity_doc(self) -> "Dict[str, Any]":
+    def identity_doc(self) -> Dict[str, Any]:
         url_response, _headers = util.readurl(
             TOKEN_URL, headers={"Metadata-Flavor": "Google"}
         )

--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -1,12 +1,9 @@
 import os
-
+from typing import Any, Dict
 from urllib.error import HTTPError
 
-from typing import Any, Dict
-
-from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util
-
+from uaclient.clouds import AutoAttachCloudInstance
 
 TOKEN_URL = (
     "http://metadata/computeMetadata/v1/instance/service-accounts/"

--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -2,11 +2,7 @@ import os
 
 from urllib.error import HTTPError
 
-try:
-    from typing import Any, Dict  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict
 
 from uaclient.clouds import AutoAttachCloudInstance
 from uaclient import util

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -8,11 +8,7 @@ from uaclient import status
 from uaclient import util
 from uaclient.config import apply_config_settings_override
 
-try:
-    from typing import Dict, Optional, Tuple, Type  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Dict, Optional, Tuple, Type  # noqa F401
 
 
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -1,15 +1,9 @@
 import logging
-
 from enum import Enum
-
-from uaclient import exceptions
-from uaclient import clouds
-from uaclient import status
-from uaclient import util
-from uaclient.config import apply_config_settings_override
-
 from typing import Dict, Optional, Tuple, Type  # noqa F401
 
+from uaclient import clouds, exceptions, status, util
+from uaclient.config import apply_config_settings_override
 
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
 DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws", "gce": "gcp"}
@@ -56,9 +50,7 @@ def get_cloud_type() -> "Tuple[Optional[str], Optional[NoCloudTypeReason]]":
 
 
 def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
-    from uaclient.clouds import aws
-    from uaclient.clouds import azure
-    from uaclient.clouds import gcp
+    from uaclient.clouds import aws, azure, gcp
 
     cloud_instance_map = {
         "aws": aws.UAAutoAttachAWSInstance,

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Dict, Optional, Tuple, Type  # noqa F401
+from typing import Dict, Optional, Tuple, Type  # noqa: F401
 
 from uaclient import clouds, exceptions, status, util
 from uaclient.config import apply_config_settings_override
@@ -24,7 +24,7 @@ class NoCloudTypeReason(Enum):
     CLOUD_ID_ERROR = 1
 
 
-def get_instance_id() -> "Optional[str]":
+def get_instance_id() -> Optional[str]:
     """Query cloud instance-id from cmdline."""
     try:
         # Present in cloud-init on >= Xenial
@@ -37,7 +37,7 @@ def get_instance_id() -> "Optional[str]":
 
 
 @apply_config_settings_override("cloud_type")
-def get_cloud_type() -> "Tuple[Optional[str], Optional[NoCloudTypeReason]]":
+def get_cloud_type() -> Tuple[Optional[str], Optional[NoCloudTypeReason]]:
     if util.which("cloud-id"):
         # Present in cloud-init on >= Xenial
         try:

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -1,8 +1,8 @@
 import logging
-import mock
 from io import BytesIO
 from urllib.error import HTTPError
 
+import mock
 import pytest
 
 from uaclient.clouds.aws import (

--- a/uaclient/clouds/tests/test_azure.py
+++ b/uaclient/clouds/tests/test_azure.py
@@ -1,8 +1,8 @@
 import logging
-import mock
 from io import BytesIO
 from urllib.error import HTTPError
 
+import mock
 import pytest
 
 from uaclient.clouds.azure import IMDS_BASE_URL, UAAutoAttachAzureInstance

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -1,8 +1,8 @@
 import logging
-import mock
 from io import BytesIO
 from urllib.error import HTTPError
 
+import mock
 import pytest
 
 from uaclient.clouds.gcp import TOKEN_URL, UAAutoAttachGCPInstance

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -1,16 +1,14 @@
 import mock
-
 import pytest
 
+from uaclient import exceptions, status
 from uaclient.clouds.identity import (
     NoCloudTypeReason,
     cloud_instance_factory,
-    get_instance_id,
     get_cloud_type,
+    get_instance_id,
 )
 from uaclient.util import ProcessExecutionError
-from uaclient import exceptions
-from uaclient import status
 
 M_PATH = "uaclient.clouds.identity."
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -18,20 +18,7 @@ from uaclient.defaults import (
     BASE_SECURITY_URL,
 )
 
-try:
-    from typing import (  # noqa: F401
-        Any,
-        cast,
-        Dict,
-        List,
-        Optional,
-        Tuple,
-        Union,
-    )
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    def cast(_, x):  # type: ignore
-        return x
+from typing import Any, cast, Dict, Optional, Tuple
 
 
 DEFAULT_STATUS = {

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -1,25 +1,24 @@
 import copy
-from datetime import datetime
-from functools import wraps
 import json
 import logging
 import os
 import re
 import sys
+from collections import OrderedDict, namedtuple
+from datetime import datetime
+from functools import wraps
+from typing import Any, Dict, Optional, Tuple, cast
+
 import yaml
-from collections import namedtuple, OrderedDict
 
 from uaclient import apt, exceptions, snap, status, util, version
 from uaclient.defaults import (
+    BASE_CONTRACT_URL,
+    BASE_SECURITY_URL,
     CONFIG_DEFAULTS,
     CONFIG_FIELD_ENVVAR_ALLOWLIST,
     DEFAULT_CONFIG_FILE,
-    BASE_CONTRACT_URL,
-    BASE_SECURITY_URL,
 )
-
-from typing import Any, cast, Dict, Optional, Tuple
-
 
 DEFAULT_STATUS = {
     "_doc": "Content provided in json response is currently considered"

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -106,9 +106,7 @@ class UAConfig:
     _machine_token = None  # caching to avoid repetitive file reading
     _contract_expiry_datetime = None
 
-    def __init__(
-        self, cfg: "Dict[str, Any]" = None, series: str = None
-    ) -> None:
+    def __init__(self, cfg: Dict[str, Any] = None, series: str = None) -> None:
         """"""
         if cfg:
             self.cfg_path = None
@@ -136,7 +134,7 @@ class UAConfig:
         return self.cfg.get("security_url", BASE_SECURITY_URL)
 
     @property
-    def http_proxy(self) -> "Optional[str]":
+    def http_proxy(self) -> Optional[str]:
         return self.cfg.get("ua_config", {}).get("http_proxy")
 
     @http_proxy.setter
@@ -147,7 +145,7 @@ class UAConfig:
         self.write_cfg()
 
     @property
-    def https_proxy(self) -> "Optional[str]":
+    def https_proxy(self) -> Optional[str]:
         return self.cfg.get("ua_config", {}).get("https_proxy")
 
     @https_proxy.setter
@@ -158,7 +156,7 @@ class UAConfig:
         self.write_cfg()
 
     @property
-    def apt_http_proxy(self) -> "Optional[str]":
+    def apt_http_proxy(self) -> Optional[str]:
         return self.cfg.get("ua_config", {}).get("apt_http_proxy")
 
     @apt_http_proxy.setter
@@ -169,7 +167,7 @@ class UAConfig:
         self.write_cfg()
 
     @property
-    def apt_https_proxy(self) -> "Optional[str]":
+    def apt_https_proxy(self) -> Optional[str]:
         return self.cfg.get("ua_config", {}).get("apt_https_proxy")
 
     @apt_https_proxy.setter
@@ -180,7 +178,7 @@ class UAConfig:
         self.write_cfg()
 
     @property
-    def update_status_timer(self) -> "Optional[int]":
+    def update_status_timer(self) -> Optional[int]:
         return self.cfg.get("ua_config", {}).get("update_status_timer")
 
     @update_status_timer.setter
@@ -191,7 +189,7 @@ class UAConfig:
         self.write_cfg()
 
     @property
-    def update_messaging_timer(self) -> "Optional[int]":
+    def update_messaging_timer(self) -> Optional[int]:
         return self.cfg.get("ua_config", {}).get("update_messaging_timer")
 
     @update_messaging_timer.setter
@@ -202,7 +200,7 @@ class UAConfig:
         self.write_cfg()
 
     @property
-    def gcp_auto_attach_timer(self) -> "Optional[int]":
+    def gcp_auto_attach_timer(self) -> Optional[int]:
         return self.cfg.get("ua_config", {}).get("gcp_auto_attach_timer")
 
     @gcp_auto_attach_timer.setter
@@ -212,7 +210,7 @@ class UAConfig:
         self.cfg["ua_config"]["gcp_auto_attach_timer"] = value
         self.write_cfg()
 
-    def check_lock_info(self) -> "Tuple[int, str]":
+    def check_lock_info(self) -> Tuple[int, str]:
         """Return lock info if config lock file is present the lock is active.
 
         If process claiming the lock is no longer present, remove the lock file
@@ -328,7 +326,7 @@ class UAConfig:
         return self._entitlements
 
     @property
-    def contract_expiry_datetime(self) -> "datetime":
+    def contract_expiry_datetime(self) -> datetime:
         """Return a datetime of the attached contract expiration."""
         if not self._contract_expiry_datetime:
             self._contract_expiry_datetime = self.machine_token[
@@ -414,7 +412,7 @@ class UAConfig:
                 )
             )
 
-    def data_path(self, key: "Optional[str]" = None) -> str:
+    def data_path(self, key: Optional[str] = None) -> str:
         """Return the file path in the data directory represented by the key"""
         data_dir = self.cfg["data_dir"]
         if not key:
@@ -456,7 +454,7 @@ class UAConfig:
         for path_key in self.data_paths.keys():
             self.delete_cache_key(path_key)
 
-    def read_cache(self, key: str, silent: bool = False) -> "Optional[Any]":
+    def read_cache(self, key: str, silent: bool = False) -> Optional[Any]:
         cache_path = self.data_path(key)
         try:
             content = util.load_file(cache_path)
@@ -469,7 +467,7 @@ class UAConfig:
         except ValueError:
             return content
 
-    def write_cache(self, key: str, content: "Any") -> None:
+    def write_cache(self, key: str, content: Any) -> None:
         filepath = self.data_path(key)
         data_dir = os.path.dirname(filepath)
         if not os.path.exists(data_dir):
@@ -493,7 +491,7 @@ class UAConfig:
                 mode = 0o644
         util.write_file(filepath, content, mode=mode)
 
-    def _remove_beta_resources(self, response) -> "Dict[str, Any]":
+    def _remove_beta_resources(self, response) -> Dict[str, Any]:
         """Remove beta services from response dict"""
         from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
@@ -526,7 +524,7 @@ class UAConfig:
 
         return new_response
 
-    def _get_config_status(self) -> "Dict[str, Any]":
+    def _get_config_status(self) -> Dict[str, Any]:
         """Return a dict with execution_status, execution_details and notices.
 
         Values for execution_status will be one of UserFacingConfigStatus
@@ -563,7 +561,7 @@ class UAConfig:
             "config": self.cfg,
         }
 
-    def _unattached_status(self) -> "Dict[str, Any]":
+    def _unattached_status(self) -> Dict[str, Any]:
         """Return unattached status as a dict."""
         from uaclient.contract import get_available_resources
         from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
@@ -598,7 +596,7 @@ class UAConfig:
 
     def _attached_service_status(
         self, ent, inapplicable_resources
-    ) -> "Dict[str, Optional[str]]":
+    ) -> Dict[str, Optional[str]]:
         details = ""
         description_override = None
         contract_status = ent.contract_status()
@@ -623,7 +621,7 @@ class UAConfig:
             else "no",
         }
 
-    def _attached_status(self) -> "Dict[str, Any]":
+    def _attached_status(self) -> Dict[str, Any]:
         """Return configuration of attached status as a dictionary."""
         from uaclient.contract import get_available_resources
         from uaclient.entitlements import ENTITLEMENT_CLASSES
@@ -684,7 +682,7 @@ class UAConfig:
                 response["contract"]["tech_support_level"] = supportLevel
         return response
 
-    def status(self, show_beta=False) -> "Dict[str, Any]":
+    def status(self, show_beta=False) -> Dict[str, Any]:
         """Return status as a dict, using a cache for non-root users
 
         When unattached, get available resources from the contract service

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -6,11 +6,7 @@ import pytest
 
 from uaclient.config import UAConfig
 
-try:
-    from typing import Any, Dict, Optional  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict
 
 
 @pytest.fixture

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -1,12 +1,11 @@
 import io
 import logging
-import mock
+from typing import Any, Dict
 
+import mock
 import pytest
 
 from uaclient.config import UAConfig
-
-from typing import Any, Dict
 
 
 @pytest.fixture

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -84,7 +84,7 @@ def FakeConfig(tmpdir):
         def for_attached_machine(
             cls,
             account_name: str = "test_account",
-            machine_token: "Dict[str, Any]" = None,
+            machine_token: Dict[str, Any] = None,
         ):
             if not machine_token:
                 machine_token = {

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -1,12 +1,7 @@
 import logging
-
-from uaclient import clouds
-from uaclient import exceptions
-from uaclient import status
-from uaclient import serviceclient
-from uaclient import util
-
 from typing import Any, Dict, List, Optional
+
+from uaclient import clouds, exceptions, serviceclient, status, util
 
 API_V1_CONTEXT_MACHINE_TOKEN = "/v1/context/machines/token"
 API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE = (

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -6,11 +6,7 @@ from uaclient import status
 from uaclient import serviceclient
 from uaclient import util
 
-try:
-    from typing import Any, Dict, List, Optional  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict, List, Optional
 
 API_V1_CONTEXT_MACHINE_TOKEN = "/v1/context/machines/token"
 API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE = (

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -80,7 +80,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         util.get_machine_id.cache_clear()
         return machine_token
 
-    def request_resources(self) -> "Dict[str, Any]":
+    def request_resources(self) -> Dict[str, Any]:
         """Requests list of entitlements available to this machine type."""
         platform = util.get_platform_info()
         query_params = {
@@ -115,8 +115,8 @@ class UAContractClient(serviceclient.UAServiceClient):
         self,
         machine_token: str,
         resource: str,
-        machine_id: "Optional[str]" = None,
-    ) -> "Dict[str, Any]":
+        machine_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Requests machine access context for a given resource
 
         @param machine_token: The authentication token needed to talk to
@@ -144,7 +144,7 @@ class UAContractClient(serviceclient.UAServiceClient):
 
     def request_machine_token_update(
         self, machine_token: str, contract_id: str, machine_id: str = None
-    ) -> "Dict":
+    ) -> Dict:
         """Update existing machine-token for an attached machine."""
         return self._request_machine_token_update(
             machine_token=machine_token,
@@ -155,7 +155,7 @@ class UAContractClient(serviceclient.UAServiceClient):
 
     def detach_machine_from_contract(
         self, machine_token: str, contract_id: str, machine_id: str = None
-    ) -> "Dict":
+    ) -> Dict:
         """Report the attached machine should be detached from the contract."""
         curr_machine_id = self._get_platform_data(machine_id=None).get(
             "machineId", ""
@@ -181,7 +181,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         contract_id: str,
         machine_id: str = None,
         detach: bool = False,
-    ) -> "Dict":
+    ) -> Dict:
         """Request machine token refresh from contract server.
 
         @param machine_token: The machine token needed to talk to
@@ -228,8 +228,8 @@ class UAContractClient(serviceclient.UAServiceClient):
 
 
 def process_entitlements_delta(
-    past_entitlements: "Dict[str, Any]",
-    new_entitlements: "Dict[str, Any]",
+    past_entitlements: Dict[str, Any],
+    new_entitlements: Dict[str, Any],
     allow_enable: bool,
     series_overrides: bool = True,
 ) -> None:
@@ -279,11 +279,11 @@ def process_entitlements_delta(
 
 
 def process_entitlement_delta(
-    orig_access: "Dict[str, Any]",
-    new_access: "Dict[str, Any]",
+    orig_access: Dict[str, Any],
+    new_access: Dict[str, Any],
     allow_enable: bool = False,
     series_overrides: bool = True,
-) -> "Dict":
+) -> Dict:
     """Process a entitlement access dictionary deltas if they exist.
 
     :param orig_access: Dict with original entitlement access details before
@@ -359,7 +359,7 @@ def _create_attach_forbidden_message(e: ContractAPIError) -> str:
 
 
 def request_updated_contract(
-    cfg, contract_token: "Optional[str]" = None, allow_enable=False
+    cfg, contract_token: Optional[str] = None, allow_enable=False
 ):
     """Request contract refresh from ua-contracts service.
 
@@ -413,7 +413,7 @@ def request_updated_contract(
     )
 
 
-def get_available_resources(cfg) -> "List[Dict]":
+def get_available_resources(cfg) -> List[Dict]:
     """Query available resources from the contrct server for this machine."""
     client = UAContractClient(cfg)
     resources = client.request_resources()

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -1,16 +1,14 @@
-from uaclient.entitlements.base import UAEntitlement  # noqa: F401
-from uaclient.entitlements.cis import CISEntitlement
-from uaclient.entitlements.cc import CommonCriteriaEntitlement
-from uaclient.entitlements.esm import ESMAppsEntitlement, ESMInfraEntitlement
-from uaclient.entitlements import fips
-from uaclient.entitlements.livepatch import LivepatchEntitlement
-from uaclient.entitlements.ros import ROSESMEntitlement
+from typing import Dict, List, Type, cast  # noqa: F401
 
 from uaclient.config import UAConfig
+from uaclient.entitlements import fips
+from uaclient.entitlements.base import UAEntitlement  # noqa: F401
+from uaclient.entitlements.cc import CommonCriteriaEntitlement
+from uaclient.entitlements.cis import CISEntitlement
+from uaclient.entitlements.esm import ESMAppsEntitlement, ESMInfraEntitlement
+from uaclient.entitlements.livepatch import LivepatchEntitlement
+from uaclient.entitlements.ros import ROSESMEntitlement
 from uaclient.util import is_config_value_true
-
-from typing import cast, Dict, List, Type  # noqa: F401
-
 
 ENTITLEMENT_CLASSES = [
     CommonCriteriaEntitlement,

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -9,12 +9,7 @@ from uaclient.entitlements.ros import ROSESMEntitlement
 from uaclient.config import UAConfig
 from uaclient.util import is_config_value_true
 
-try:
-    from typing import cast, Dict, List, Type, Optional  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    def cast(_, x):  # type: ignore
-        return x
+from typing import cast, Dict, List, Type  # noqa: F401
 
 
 ENTITLEMENT_CLASSES = [

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -27,7 +27,7 @@ ENTITLEMENT_CLASS_BY_NAME = dict(
 )  # type: Dict[str, Type[UAEntitlement]]
 
 
-def valid_services(allow_beta: bool = False) -> "List[str]":
+def valid_services(allow_beta: bool = False) -> List[str]:
     """Return a list of valid (non-beta) services.
 
     @param allow_beta: if we should allow beta services to be marked as valid

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -24,8 +24,8 @@ from uaclient.status import (
     MESSAGE_DEPENDENT_SERVICE_STOPS_DISABLE,
 )
 from uaclient.defaults import DEFAULT_HELP_FILE
+from uaclient.types import StaticAffordance
 
-StaticAffordance = Tuple[str, Callable[[], Any], bool]
 
 RE_KERNEL_UNAME = (
     r"(?P<major>[\d]+)[.-](?P<minor>[\d]+)[.-](?P<patch>[\d]+\-[\d]+)"

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -43,10 +43,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     _help_info = None  # type: str
 
     # List of services that are incompatible with this service
-    _incompatible_services = ()  # type: "Tuple[str, ...]"
+    _incompatible_services = ()  # type: Tuple[str, ...]
 
     # List of services that must be active before enabling this service
-    _required_services = ()  # type: "Tuple[str, ...]"
+    _required_services = ()  # type: Tuple[str, ...]
 
     # List of services that depend on this service
     _dependent_services = ()  # type: Tuple[str, ...]
@@ -87,11 +87,11 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # If any static_affordance does not match expected_results fail with
     # <failure_message>. Overridden in livepatch and fips
     @property
-    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+    def static_affordances(self) -> Tuple[StaticAffordance, ...]:
         return ()
 
     @property
-    def incompatible_services(self) -> "Tuple[str, ...]":
+    def incompatible_services(self) -> Tuple[str, ...]:
         """
         Return a list of packages that aren't compatible with the entitlement.
         When we are enabling the entitlement we can directly ask the user
@@ -101,7 +101,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         return self._incompatible_services
 
     @property
-    def required_services(self) -> "Tuple[str, ...]":
+    def required_services(self) -> Tuple[str, ...]:
         """
         Return a list of packages that must be active before enabling this
         service. When we are enabling the entitlement we can directly ask
@@ -111,7 +111,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         return self._required_services
 
     @property
-    def dependent_services(self) -> "Tuple[str, ...]":
+    def dependent_services(self) -> Tuple[str, ...]:
         """
         Return a list of packages that depend on this service.
         We will use that list during disable operations, where
@@ -124,14 +124,12 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # Any custom messages to emit to the console or callables which are
     # handled at pre_enable, pre_disable, pre_install or post_enable stages
     @property
-    def messaging(
-        self,
-    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+    def messaging(self,) -> Dict[str, List[Union[str, Tuple[Callable, Dict]]]]:
         return {}
 
     def __init__(
         self,
-        cfg: "Optional[config.UAConfig]" = None,
+        cfg: Optional[config.UAConfig] = None,
         assume_yes: bool = False,
         allow_beta: bool = False,
     ) -> None:
@@ -234,7 +232,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             return False
         return True
 
-    def can_enable(self) -> "Tuple[bool, Optional[CanEnableFailure]]":
+    def can_enable(self) -> Tuple[bool, Optional[CanEnableFailure]]:
         """
         Report whether or not enabling is possible for the entitlement.
 
@@ -449,7 +447,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         return True
 
-    def applicability_status(self) -> "Tuple[ApplicabilityStatus, str]":
+    def applicability_status(self) -> Tuple[ApplicabilityStatus, str]:
         """Check all contract affordances to vet current platform
 
         Affordances are a list of support constraints for the entitlement.
@@ -649,7 +647,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             return False
         return True
 
-    def _check_application_status_on_cache(self) -> "status.ApplicationStatus":
+    def _check_application_status_on_cache(self) -> status.ApplicationStatus:
         """Check on the state of application on the status cache."""
         status_cache = self.cfg.read_cache("status-cache")
 
@@ -671,8 +669,8 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
     def process_contract_deltas(
         self,
-        orig_access: "Dict[str, Any]",
-        deltas: "Dict[str, Any]",
+        orig_access: Dict[str, Any],
+        deltas: Dict[str, Any],
         allow_enable: bool = False,
     ) -> bool:
         """Process any contract access deltas for this entitlement.
@@ -759,7 +757,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         return False
 
-    def user_facing_status(self) -> "Tuple[UserFacingStatus, str]":
+    def user_facing_status(self) -> Tuple[UserFacingStatus, str]:
         """Return (user-facing status, details) for entitlement"""
         applicability, details = self.applicability_status()
         if applicability != ApplicabilityStatus.APPLICABLE:
@@ -784,7 +782,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         return user_facing_status, explanation
 
     @abc.abstractmethod
-    def application_status(self) -> "Tuple[status.ApplicationStatus, str]":
+    def application_status(self) -> Tuple[status.ApplicationStatus, str]:
         """
         The current status of application of this entitlement
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -7,21 +7,7 @@ import yaml
 
 from uaclient.util import is_config_value_true
 
-try:
-    from typing import (  # noqa: F401
-        Any,
-        Callable,
-        Dict,
-        List,
-        Optional,
-        Tuple,
-        Union,
-    )
-
-    StaticAffordance = Tuple[str, Callable[[], Any], bool]
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from uaclient import config
 from uaclient import contract
@@ -38,6 +24,8 @@ from uaclient.status import (
     MESSAGE_DEPENDENT_SERVICE_STOPS_DISABLE,
 )
 from uaclient.defaults import DEFAULT_HELP_FILE
+
+StaticAffordance = Tuple[str, Callable[[], Any], bool]
 
 RE_KERNEL_UNAME = (
     r"(?P<major>[\d]+)[.-](?P<minor>[\d]+)[.-](?P<patch>[\d]+\-[\d]+)"

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -1,31 +1,26 @@
-import os
 import abc
-from datetime import datetime
 import logging
+import os
 import re
-import yaml
-
-from uaclient.util import is_config_value_true
-
+from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from uaclient import config
-from uaclient import contract
-from uaclient import status
-from uaclient import util
+import yaml
+
+from uaclient import config, contract, status, util
+from uaclient.defaults import DEFAULT_HELP_FILE
 from uaclient.status import (
-    ApplicabilityStatus,
-    ContractStatus,
-    UserFacingStatus,
-    CanEnableFailure,
-    CanEnableFailureReason,
+    MESSAGE_DEPENDENT_SERVICE_STOPS_DISABLE,
     MESSAGE_INCOMPATIBLE_SERVICE_STOPS_ENABLE,
     MESSAGE_REQUIRED_SERVICE_STOPS_ENABLE,
-    MESSAGE_DEPENDENT_SERVICE_STOPS_DISABLE,
+    ApplicabilityStatus,
+    CanEnableFailure,
+    CanEnableFailureReason,
+    ContractStatus,
+    UserFacingStatus,
 )
-from uaclient.defaults import DEFAULT_HELP_FILE
 from uaclient.types import StaticAffordance
-
+from uaclient.util import is_config_value_true
 
 RE_KERNEL_UNAME = (
     r"(?P<major>[\d]+)[.-](?P<minor>[\d]+)[.-](?P<patch>[\d]+\-[\d]+)"

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -1,6 +1,6 @@
-from uaclient.entitlements import repo
-
 from typing import Callable, Dict, List, Tuple, Union
+
+from uaclient.entitlements import repo
 
 CC_README = "/usr/share/doc/ubuntu-commoncriteria/README"
 

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -15,9 +15,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     is_beta = True
 
     @property
-    def messaging(
-        self
-    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+    def messaging(self) -> Dict[str, List[Union[str, Tuple[Callable, Dict]]]]:
         return {
             "pre_install": [
                 "(This will download more than 500MB of packages, so may take"

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -1,10 +1,6 @@
 from uaclient.entitlements import repo
 
-try:
-    from typing import Callable, Dict, List, Tuple, Union  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Callable, Dict, List, Tuple, Union
 
 CC_README = "/usr/share/doc/ubuntu-commoncriteria/README"
 

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -15,9 +15,7 @@ class CISEntitlement(repo.RepoEntitlement):
     apt_noninteractive = True
 
     @property
-    def messaging(
-        self,
-    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+    def messaging(self,) -> Dict[str, List[Union[str, Tuple[Callable, Dict]]]]:
         return {
             "post_enable": [
                 "Visit {} to learn how to use CIS".format(CIS_DOCS_URL)

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -1,10 +1,6 @@
 from uaclient.entitlements import repo
 
-try:
-    from typing import Callable, Dict, List, Tuple, Union  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Callable, Dict, List, Tuple, Union
 
 CIS_DOCS_URL = "https://security-certs.docs.ubuntu.com/en/cis"
 

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -1,6 +1,6 @@
-from uaclient.entitlements import repo
-
 from typing import Callable, Dict, List, Tuple, Union
+
+from uaclient.entitlements import repo
 
 CIS_DOCS_URL = "https://security-certs.docs.ubuntu.com/en/cis"
 

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -31,7 +31,7 @@ class ESMAppsEntitlement(ESMBaseEntitlement):
     is_beta = True
 
     @property
-    def repo_pin_priority(self) -> "Optional[str]":
+    def repo_pin_priority(self) -> Optional[str]:
         """All LTS with the exception of Trusty should pin esm-apps."""
         series = util.get_platform_info()["series"]
         if series == "trusty":
@@ -62,7 +62,7 @@ class ESMInfraEntitlement(ESMBaseEntitlement):
     repo_key_file = "ubuntu-advantage-esm-infra-trusty.gpg"
 
     @property
-    def repo_pin_priority(self) -> "Optional[str]":
+    def repo_pin_priority(self) -> Optional[str]:
         """Once a release goes into EOL it is entitled to ESM Infra."""
         if util.is_active_esm(util.get_platform_info()["series"]):
             return "never"

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -1,8 +1,8 @@
 from typing import Optional, Tuple  # noqa: F401
 
-from uaclient.entitlements import repo
 from uaclient import util
 from uaclient.config import update_ua_messages
+from uaclient.entitlements import repo
 
 
 class ESMBaseEntitlement(repo.RepoEntitlement):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,16 +1,13 @@
 import logging
 import os
 import re
-
 from itertools import groupby
-
-from uaclient import apt
-from uaclient.entitlements import repo
-from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
-from uaclient import exceptions, status, util
-from uaclient.types import StaticAffordance
-
 from typing import Callable, Dict, List, Tuple, Union
+
+from uaclient import apt, exceptions, status, util
+from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
+from uaclient.entitlements import repo
+from uaclient.types import StaticAffordance
 
 
 class FIPSCommonEntitlement(repo.RepoEntitlement):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -57,7 +57,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     def install_packages(
         self,
-        package_list: "List[str]" = None,
+        package_list: List[str] = None,
         cleanup_on_failure: bool = True,
         verbose: bool = True,
     ) -> None:
@@ -163,7 +163,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         return True
 
     @property
-    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+    def static_affordances(self) -> Tuple[StaticAffordance, ...]:
         # Use a lambda so we can mock util.is_container in tests
         cloud_titles = {"azure": "an Azure", "gce": "a GCP"}
         cloud_id, _ = get_cloud_type()
@@ -188,8 +188,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         )
 
     def _replace_metapackage_on_cloud_instance(
-        self, packages: "List[str]"
-    ) -> "List[str]":
+        self, packages: List[str]
+    ) -> List[str]:
         """
         Identify correct metapackage to be used if in a cloud instance.
 
@@ -228,11 +228,11 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         ]
 
     @property
-    def packages(self) -> "List[str]":
+    def packages(self) -> List[str]:
         packages = super().packages
         return self._replace_metapackage_on_cloud_instance(packages)
 
-    def application_status(self) -> "Tuple[status.ApplicationStatus, str]":
+    def application_status(self) -> Tuple[status.ApplicationStatus, str]:
         super_status, super_msg = super().application_status()
 
         if os.path.exists(self.FIPS_PROC_FILE):
@@ -324,7 +324,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     ]
 
     @property
-    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+    def static_affordances(self) -> Tuple[StaticAffordance, ...]:
         static_affordances = super().static_affordances
 
         fips_update = FIPSUpdatesEntitlement(self.cfg)
@@ -358,9 +358,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         )
 
     @property
-    def messaging(
-        self,
-    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+    def messaging(self,) -> Dict[str, List[Union[str, Tuple[Callable, Dict]]]]:
         return {
             "pre_enable": [
                 (
@@ -425,9 +423,7 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
     description = "NIST-certified core packages with priority security updates"
 
     @property
-    def messaging(
-        self,
-    ) -> "Dict[str, List[Union[str, Tuple[Callable, Dict]]]]":
+    def messaging(self,) -> Dict[str, List[Union[str, Tuple[Callable, Dict]]]]:
         return {
             "pre_enable": [
                 (

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -9,13 +9,9 @@ from uaclient.entitlements import repo
 from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient import exceptions, status, util
 
-try:
-    from typing import Any, Callable, Dict, List, Set, Tuple, Union  # noqa
+from typing import Any, Callable, Dict, List, Tuple, Union
 
-    StaticAffordance = Tuple[str, Callable[[], Any], bool]
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+StaticAffordance = Tuple[str, Callable[[], Any], bool]
 
 
 class FIPSCommonEntitlement(repo.RepoEntitlement):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -8,10 +8,9 @@ from uaclient import apt
 from uaclient.entitlements import repo
 from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient import exceptions, status, util
+from uaclient.types import StaticAffordance
 
-from typing import Any, Callable, Dict, List, Tuple, Union
-
-StaticAffordance = Tuple[str, Callable[[], Any], bool]
+from typing import Callable, Dict, List, Tuple, Union
 
 
 class FIPSCommonEntitlement(repo.RepoEntitlement):

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -18,7 +18,7 @@ ERROR_MSG_MAP = {
 
 
 def unconfigure_livepatch_proxy(
-    protocol_type: str, retry_sleeps: "Optional[List[float]]" = None
+    protocol_type: str, retry_sleeps: Optional[List[float]] = None
 ) -> None:
     """
     Unset livepatch configuration settings for http and https proxies.
@@ -38,9 +38,9 @@ def unconfigure_livepatch_proxy(
 
 
 def configure_livepatch_proxy(
-    http_proxy: "Optional[str]" = None,
-    https_proxy: "Optional[str]" = None,
-    retry_sleeps: "Optional[List[float]]" = None,
+    http_proxy: Optional[str] = None,
+    https_proxy: Optional[str] = None,
+    retry_sleeps: Optional[List[float]] = None,
 ) -> None:
     """
     Configure livepatch to use http and https proxies.
@@ -103,7 +103,7 @@ class LivepatchEntitlement(base.UAEntitlement):
     description = "Canonical Livepatch service"
 
     @property
-    def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
+    def static_affordances(self) -> Tuple[StaticAffordance, ...]:
         # Use a lambda so we can mock util.is_container in tests
         from uaclient.entitlements.fips import (
             FIPSEntitlement,
@@ -279,7 +279,7 @@ class LivepatchEntitlement(base.UAEntitlement):
         util.subp(["/snap/bin/canonical-livepatch", "disable"], capture=True)
         return True
 
-    def application_status(self) -> "Tuple[ApplicationStatus, str]":
+    def application_status(self) -> Tuple[ApplicationStatus, str]:
         status = (ApplicationStatus.ENABLED, "")
 
         if not util.which("/snap/bin/canonical-livepatch"):
@@ -301,8 +301,8 @@ class LivepatchEntitlement(base.UAEntitlement):
 
     def process_contract_deltas(
         self,
-        orig_access: "Dict[str, Any]",
-        deltas: "Dict[str, Any]",
+        orig_access: Dict[str, Any],
+        deltas: Dict[str, Any],
         allow_enable: bool = False,
     ) -> bool:
         """Process any contract access deltas for this entitlement.

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -1,13 +1,11 @@
 import logging
 import re
+from typing import Any, Dict, List, Optional, Tuple
 
+from uaclient import apt, exceptions, snap, status, util
 from uaclient.entitlements import base
-from uaclient import apt, exceptions, snap, status
-from uaclient import util
 from uaclient.status import ApplicationStatus
 from uaclient.types import StaticAffordance
-
-from typing import Any, Dict, Tuple, List, Optional
 
 LIVEPATCH_RETRIES = [0.5, 1.0]
 HTTP_PROXY_OPTION = "http-proxy"
@@ -107,8 +105,10 @@ class LivepatchEntitlement(base.UAEntitlement):
     @property
     def static_affordances(self) -> "Tuple[StaticAffordance, ...]":
         # Use a lambda so we can mock util.is_container in tests
-        from uaclient.entitlements.fips import FIPSEntitlement
-        from uaclient.entitlements.fips import FIPSUpdatesEntitlement
+        from uaclient.entitlements.fips import (
+            FIPSEntitlement,
+            FIPSUpdatesEntitlement,
+        )
 
         fips_ent = FIPSEntitlement(self.cfg)
         fips_update_ent = FIPSUpdatesEntitlement(self.cfg)

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -5,14 +5,13 @@ from uaclient.entitlements import base
 from uaclient import apt, exceptions, snap, status
 from uaclient import util
 from uaclient.status import ApplicationStatus
+from uaclient.types import StaticAffordance
 
-from typing import Any, Callable, Dict, Tuple, List, Optional
+from typing import Any, Dict, Tuple, List, Optional
 
 LIVEPATCH_RETRIES = [0.5, 1.0]
 HTTP_PROXY_OPTION = "http-proxy"
 HTTPS_PROXY_OPTION = "https-proxy"
-
-StaticAffordance = Tuple[str, Callable[[], Any], bool]
 
 ERROR_MSG_MAP = {
     "Unknown Auth-Token": "Invalid Auth-Token provided to livepatch.",

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -6,17 +6,13 @@ from uaclient import apt, exceptions, snap, status
 from uaclient import util
 from uaclient.status import ApplicationStatus
 
+from typing import Any, Callable, Dict, Tuple, List, Optional
+
 LIVEPATCH_RETRIES = [0.5, 1.0]
 HTTP_PROXY_OPTION = "http-proxy"
 HTTPS_PROXY_OPTION = "https-proxy"
 
-try:
-    from typing import Any, Callable, Dict, Tuple, List, Optional  # noqa: F401
-
-    StaticAffordance = Tuple[str, Callable[[], Any], bool]
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+StaticAffordance = Tuple[str, Callable[[], Any], bool]
 
 ERROR_MSG_MAP = {
     "Unknown Auth-Token": "Invalid Auth-Token provided to livepatch.",

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -3,16 +3,10 @@ import copy
 import logging
 import os
 import re
-
-from uaclient import contract
-
 from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
-from uaclient import apt
-from uaclient import exceptions
+from uaclient import apt, contract, exceptions, status, util
 from uaclient.entitlements import base
-from uaclient import status
-from uaclient import util
 from uaclient.status import ApplicationStatus
 
 APT_DISABLED_PIN = "-32768"

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -6,21 +6,7 @@ import re
 
 from uaclient import contract
 
-try:
-    from typing import (  # noqa: F401
-        Any,
-        Callable,
-        Dict,
-        List,
-        Optional,
-        Sequence,
-        Tuple,
-        Union,
-    )
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
-
+from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
 from uaclient import apt
 from uaclient import exceptions

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -25,7 +25,7 @@ class RepoEntitlement(base.UAEntitlement):
 
     # Optional repo pin priority in subclass
     @property
-    def repo_pin_priority(self) -> "Union[int, str, None]":
+    def repo_pin_priority(self) -> Union[int, str, None]:
         return None
 
     # disable_apt_auth_only (ESM) to only remove apt auth files on disable
@@ -34,7 +34,7 @@ class RepoEntitlement(base.UAEntitlement):
         return False  # Set True on ESM to only remove apt auth
 
     @property
-    def packages(self) -> "List[str]":
+    def packages(self) -> List[str]:
         """debs to install on enablement"""
         packages = []
 
@@ -83,7 +83,7 @@ class RepoEntitlement(base.UAEntitlement):
         """Clean up the entitlement without checks or messaging"""
         self.remove_apt_config(silent=silent)
 
-    def application_status(self) -> "Tuple[ApplicationStatus, str]":
+    def application_status(self) -> Tuple[ApplicationStatus, str]:
         entitlement_cfg = self.cfg.entitlements.get(self.name, {})
         directives = entitlement_cfg.get("entitlement", {}).get(
             "directives", {}
@@ -124,8 +124,8 @@ class RepoEntitlement(base.UAEntitlement):
 
     def process_contract_deltas(
         self,
-        orig_access: "Dict[str, Any]",
-        deltas: "Dict[str, Any]",
+        orig_access: Dict[str, Any],
+        deltas: Dict[str, Any],
         allow_enable: bool = False,
     ) -> bool:
         """Process any contract access deltas for this entitlement.
@@ -185,7 +185,7 @@ class RepoEntitlement(base.UAEntitlement):
 
     def install_packages(
         self,
-        package_list: "List[str]" = None,
+        package_list: List[str] = None,
         cleanup_on_failure: bool = True,
         verbose: bool = True,
     ) -> None:

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -1,8 +1,8 @@
+from typing import Any, Dict, List, Optional
+
 import pytest
 
 from uaclient import config
-
-from typing import Any, Dict, List, Optional
 
 
 def machine_token(

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -8,13 +8,13 @@ from uaclient import config
 def machine_token(
     entitlement_type: str,
     *,
-    affordances: "Dict[str, Any]" = None,
-    directives: "Dict[str, Any]" = None,
+    affordances: Dict[str, Any] = None,
+    directives: Dict[str, Any] = None,
     entitled: bool = True,
-    obligations: "Dict[str, Any]" = None,
-    suites: "List[str]" = None,
-    additional_packages: "List[str]" = None
-) -> "Dict[str, Any]":
+    obligations: Dict[str, Any] = None,
+    suites: List[str] = None,
+    additional_packages: List[str] = None
+) -> Dict[str, Any]:
     return {
         "resourceTokens": [
             {
@@ -44,13 +44,13 @@ def machine_token(
 def machine_access(
     entitlement_type: str,
     *,
-    affordances: "Dict[str, Any]" = None,
-    directives: "Dict[str, Any]" = None,
+    affordances: Dict[str, Any] = None,
+    directives: Dict[str, Any] = None,
     entitled: bool = True,
-    obligations: "Dict[str, Any]" = None,
-    suites: "List[str]" = None,
-    additional_packages: "List[str]" = None
-) -> "Dict[str, Any]":
+    obligations: Dict[str, Any] = None,
+    suites: List[str] = None,
+    additional_packages: List[str] = None
+) -> Dict[str, Any]:
     if affordances is None:
         affordances = {"series": []}  # Will match all series
     if suites is None:
@@ -89,17 +89,17 @@ def entitlement_factory(tmpdir):
     def factory_func(
         cls,
         *,
-        affordances: "Dict[str, Any]" = None,
-        directives: "Dict[str, Any]" = None,
-        obligations: "Dict[str, Any]" = None,
+        affordances: Dict[str, Any] = None,
+        directives: Dict[str, Any] = None,
+        obligations: Dict[str, Any] = None,
         entitled: bool = True,
         allow_beta: bool = False,
-        assume_yes: "Optional[bool]" = None,
-        suites: "List[str]" = None,
-        additional_packages: "List[str]" = None,
-        services_once_enabled: "Dict[str, bool]" = None,
-        cfg: "Optional[config.UAConfig]" = None,
-        cfg_extension: "Optional[Dict[str, Any]]" = None
+        assume_yes: Optional[bool] = None,
+        suites: List[str] = None,
+        additional_packages: List[str] = None,
+        services_once_enabled: Dict[str, bool] = None,
+        cfg: Optional[config.UAConfig] = None,
+        cfg_extension: Optional[Dict[str, Any]] = None
     ):
         if not cfg:
             cfg_arg = {"data_dir": tmpdir.strpath}

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -2,11 +2,7 @@ import pytest
 
 from uaclient import config
 
-try:
-    from typing import Any, Dict, List, Optional  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict, List, Optional
 
 
 def machine_token(

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -10,10 +10,7 @@ from uaclient import status
 from uaclient import util
 from uaclient.status import ContractStatus
 
-try:
-    from typing import Dict, Optional, Tuple  # noqa
-except ImportError:
-    pass
+from typing import Dict, Optional, Tuple
 
 
 class ConcreteTestEntitlement(base.UAEntitlement):

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1,16 +1,13 @@
 """Tests related to uaclient.entitlement.base module."""
 import logging
-import mock
+from typing import Dict, Optional, Tuple
 
+import mock
 import pytest
 
-from uaclient import config
+from uaclient import config, status, util
 from uaclient.entitlements import base
-from uaclient import status
-from uaclient import util
 from uaclient.status import ContractStatus
-
-from typing import Dict, Optional, Tuple
 
 
 class ConcreteTestEntitlement(base.UAEntitlement):

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -53,9 +53,9 @@ def concrete_entitlement_factory(tmpdir):
     def factory(
         *,
         entitled: bool,
-        applicability_status: "Tuple[status.ApplicabilityStatus, str]" = None,
-        application_status: "Tuple[status.ApplicationStatus, str]" = None,
-        feature_overrides: "Optional[Dict[str, str]]" = None,
+        applicability_status: Tuple[status.ApplicabilityStatus, str] = None,
+        application_status: Tuple[status.ApplicationStatus, str] = None,
+        feature_overrides: Optional[Dict[str, str]] = None,
         allow_beta: bool = False,
         enable: bool = False,
         disable: bool = False

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -2,15 +2,13 @@
 
 import copy
 import itertools
-import mock
 import os.path
 from types import MappingProxyType
 
+import mock
 import pytest
 
-from uaclient import apt
-from uaclient import config
-from uaclient import status
+from uaclient import apt, config, status
 from uaclient.entitlements.cc import CC_README, CommonCriteriaEntitlement
 from uaclient.entitlements.tests.conftest import machine_token
 

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -1,13 +1,10 @@
 """Tests related to uaclient.entitlement.base module."""
 
 import mock
-
 import pytest
 
-from uaclient import apt
-from uaclient import status
-from uaclient.entitlements.cis import CISEntitlement, CIS_DOCS_URL
-
+from uaclient import apt, status
+from uaclient.entitlements.cis import CIS_DOCS_URL, CISEntitlement
 
 M_REPOPATH = "uaclient.entitlements.repo."
 

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -1,13 +1,11 @@
 import contextlib
-import mock
 import os.path
 
+import mock
 import pytest
 
-from uaclient import apt
+from uaclient import apt, exceptions, util
 from uaclient.entitlements.esm import ESMAppsEntitlement, ESMInfraEntitlement
-from uaclient import exceptions
-from uaclient import util
 
 M_PATH = "uaclient.entitlements.esm.ESMInfraEntitlement."
 M_REPOPATH = "uaclient.entitlements.repo."

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -4,19 +4,15 @@ import contextlib
 import copy
 import io
 import logging
-import mock
 import os
 from functools import partial
 
+import mock
 import pytest
 
-from uaclient import apt
-from uaclient import defaults
-from uaclient import status, util
-from uaclient.entitlements.fips import FIPSEntitlement, FIPSUpdatesEntitlement
+from uaclient import apt, defaults, exceptions, status, util
 from uaclient.clouds.identity import NoCloudTypeReason
-from uaclient import exceptions
-
+from uaclient.entitlements.fips import FIPSEntitlement, FIPSUpdatesEntitlement
 
 M_PATH = "uaclient.entitlements.fips."
 M_LIVEPATCH_PATH = "uaclient.entitlements.livepatch.LivepatchEntitlement."

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -4,24 +4,22 @@ import contextlib
 import copy
 import io
 import logging
-import mock
 from functools import partial
 from types import MappingProxyType
 
+import mock
 import pytest
 
-from uaclient import apt
-from uaclient import exceptions
+from uaclient import apt, exceptions, status
 from uaclient.entitlements.livepatch import (
     LivepatchEntitlement,
-    process_config_directives,
     configure_livepatch_proxy,
     get_config_option_value,
+    process_config_directives,
     unconfigure_livepatch_proxy,
 )
-from uaclient.snap import SNAP_CMD
 from uaclient.entitlements.tests.conftest import machine_token
-from uaclient import status
+from uaclient.snap import SNAP_CMD
 from uaclient.status import ApplicationStatus, ContractStatus
 from uaclient.util import ProcessExecutionError
 

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -8,13 +8,6 @@ import mock
 from functools import partial
 from types import MappingProxyType
 
-try:
-    from typing import Any, Dict, List  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
-
-
 import pytest
 
 from uaclient import apt

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1,16 +1,12 @@
 import copy
+from types import MappingProxyType
 
 import mock
 import pytest
-from types import MappingProxyType
 
-from uaclient import apt
+from uaclient import apt, exceptions, status, util
 from uaclient.entitlements.repo import RepoEntitlement
 from uaclient.entitlements.tests.conftest import machine_token
-from uaclient import exceptions
-from uaclient import status
-from uaclient import util
-
 
 M_PATH = "uaclient.entitlements.repo."
 M_CONTRACT_PATH = "uaclient.entitlements.repo.contract.UAContractClient."

--- a/uaclient/jobs/gcp_auto_attach.py
+++ b/uaclient/jobs/gcp_auto_attach.py
@@ -3,11 +3,9 @@ Try to auto-attach in a GCP instance. This should only work
 if the instance has a new UA license attached to it
 """
 
-from uaclient import config
-from uaclient import exceptions
-
-from uaclient.clouds.identity import get_cloud_type
+from uaclient import config, exceptions
 from uaclient.cli import action_auto_attach
+from uaclient.clouds.identity import get_cloud_type
 
 
 def gcp_auto_attach(cfg: config.UAConfig) -> None:

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -10,11 +10,7 @@ import enum
 import logging
 import os
 
-try:
-    from typing import Dict, List, Optional, Tuple  # noqa
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import List, Tuple
 
 from uaclient import config
 from uaclient import entitlements

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -9,12 +9,9 @@ present updated text about Ubuntu Advantage service and token state.
 import enum
 import logging
 import os
-
 from typing import List, Tuple
 
-from uaclient import config
-from uaclient import entitlements
-from uaclient import defaults
+from uaclient import config, defaults, entitlements, util
 from uaclient.status import (
     MESSAGE_ANNOUNCE_ESM_TMPL,
     MESSAGE_CONTRACT_EXPIRED_APT_NO_PKGS_TMPL,
@@ -22,12 +19,11 @@ from uaclient.status import (
     MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL,
     MESSAGE_CONTRACT_EXPIRED_MOTD_PKGS_TMPL,
     MESSAGE_CONTRACT_EXPIRED_SOON_TMPL,
-    MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
     MESSAGE_DISABLED_APT_PKGS_TMPL,
+    MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
     MESSAGE_UBUNTU_NO_WARRANTY,
     ApplicationStatus,
 )
-from uaclient import util
 
 
 @enum.unique

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -54,7 +54,7 @@ class ExternalMessage(enum.Enum):
 
 def get_contract_expiry_status(
     cfg: config.UAConfig
-) -> "Tuple[ContractExpiryStatus, int]":
+) -> Tuple[ContractExpiryStatus, int]:
     """Return a tuple [ContractExpiryStatus, num_days]"""
     if not cfg.is_attached:
         return ContractExpiryStatus.NONE, 0
@@ -84,7 +84,7 @@ def _write_template_or_remove(msg: str, tmpl_file: str):
             util.remove_file(tmpl_file.replace(".tmpl", ""))
 
 
-def _remove_msg_templates(msg_dir: "str", msg_template_names: "List[str]"):
+def _remove_msg_templates(msg_dir: str, msg_template_names: List[str]):
     # Purge all template out output messages for this service
     for name in msg_template_names:
         _write_template_or_remove("", os.path.join(msg_dir, name))

--- a/uaclient/pip.py
+++ b/uaclient/pip.py
@@ -1,7 +1,5 @@
 import os
-
 from configparser import ConfigParser
-
 
 PIP_CONFIG_FILE = "/etc/pip.conf"
 

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -59,8 +59,8 @@ class UASecurityClient(serviceclient.UAServiceClient):
     api_error_cls = SecurityAPIError
 
     def _get_query_params(
-        self, query_params: "Dict[str, Any]"
-    ) -> "Dict[str, Any]":
+        self, query_params: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         Update query params with data from feature config.
         """
@@ -89,15 +89,15 @@ class UASecurityClient(serviceclient.UAServiceClient):
 
     def get_cves(
         self,
-        query: "Optional[str]" = None,
-        priority: "Optional[str]" = None,
-        package: "Optional[str]" = None,
-        limit: "Optional[int]" = None,
-        offset: "Optional[int]" = None,
-        component: "Optional[str]" = None,
-        version: "Optional[str]" = None,
-        status: "Optional[List[str]]" = None,
-    ) -> "List[CVE]":
+        query: Optional[str] = None,
+        priority: Optional[str] = None,
+        package: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        component: Optional[str] = None,
+        version: Optional[str] = None,
+        status: Optional[List[str]] = None,
+    ) -> List["CVE"]:
         """Query to match multiple-CVEs.
 
         @return: List of CVE instances based on the the JSON response.
@@ -129,12 +129,12 @@ class UASecurityClient(serviceclient.UAServiceClient):
 
     def get_notices(
         self,
-        details: "Optional[str]" = None,
-        release: "Optional[str]" = None,
-        limit: "Optional[int]" = None,
-        offset: "Optional[int]" = None,
-        order: "Optional[str]" = None,
-    ) -> "List[USN]":
+        details: Optional[str] = None,
+        release: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        order: Optional[str] = None,
+    ) -> List["USN"]:
         """Query to match multiple-USNs.
 
         @return: Sorted list of USN instances based on the the JSON response.
@@ -173,7 +173,7 @@ class UASecurityClient(serviceclient.UAServiceClient):
 class CVEPackageStatus:
     """Class representing specific CVE PackageStatus on an Ubuntu series"""
 
-    def __init__(self, cve_response: "Dict[str, Any]"):
+    def __init__(self, cve_response: Dict[str, Any]):
         self.response = cve_response
 
     @property
@@ -242,7 +242,7 @@ class CVEPackageStatus:
 class CVE:
     """Class representing CVE response from the SecurityClient"""
 
-    def __init__(self, client: UASecurityClient, response: "Dict[str, Any]"):
+    def __init__(self, client: UASecurityClient, response: Dict[str, Any]):
         self.response = response
         self.client = client
 
@@ -269,11 +269,11 @@ class CVE:
         return "\n".join(lines)
 
     @property
-    def notices_ids(self) -> "List[str]":
+    def notices_ids(self) -> List[str]:
         return self.response.get("notices_ids", [])
 
     @property
-    def notices(self) -> "List[USN]":
+    def notices(self) -> List["USN"]:
         """Return a list of USN instances from API response 'notices'.
 
         Cache the value to avoid extra work on multiple calls.
@@ -294,7 +294,7 @@ class CVE:
         return self.response.get("description")
 
     @property
-    def packages_status(self) -> "Dict[str, CVEPackageStatus]":
+    def packages_status(self) -> Dict[str, CVEPackageStatus]:
         """Dict of package status dicts for the current Ubuntu series.
 
         Top-level keys are source packages names and each value is a
@@ -316,7 +316,7 @@ class CVE:
 class USN:
     """Class representing USN response from the SecurityClient"""
 
-    def __init__(self, client: UASecurityClient, response: "Dict[str, Any]"):
+    def __init__(self, client: UASecurityClient, response: Dict[str, Any]):
         self.response = response
         self.client = client
 
@@ -330,12 +330,12 @@ class USN:
         return self.response.get("id", "UNKNOWN_USN_ID").upper()
 
     @property
-    def cves_ids(self) -> "List[str]":
+    def cves_ids(self) -> List[str]:
         """List of CVE IDs related to this USN."""
         return self.response.get("cves_ids", [])
 
     @property
-    def cves(self) -> "List[CVE]":
+    def cves(self) -> List[CVE]:
         """List of CVE instances based on API response 'cves' key.
 
         Cache the values to avoid extra work for multiple call-sites.
@@ -366,7 +366,7 @@ class USN:
         return "\n".join(lines)
 
     @property
-    def release_packages(self) -> "Dict[str, Dict[str, Dict[str, str]]]":
+    def release_packages(self) -> Dict[str, Dict[str, Dict[str, str]]]:
         """Binary package information available for this release.
 
 
@@ -428,7 +428,7 @@ class USN:
         return self._release_packages
 
 
-def query_installed_source_pkg_versions() -> "Dict[str, Dict[str, str]]":
+def query_installed_source_pkg_versions() -> Dict[str, Dict[str, str]]:
     """Return a dict of all source packages installed on the system.
 
     The dict keys will be source package name: "krb5". The value will be a dict
@@ -462,8 +462,8 @@ def query_installed_source_pkg_versions() -> "Dict[str, Dict[str, str]]":
 
 
 def merge_usn_released_binary_package_versions(
-    usns: "List[USN]", beta_pockets: "Dict[str, bool]"
-) -> "Dict[str,  Dict[str, Dict[str, str]]]":
+    usns: List[USN], beta_pockets: Dict[str, bool]
+) -> Dict[str, Dict[str, Dict[str, str]]]:
     """Walk related USNs, merging the released binary package versions.
 
     For each USN, iterate over release_packages to collect released binary
@@ -587,8 +587,8 @@ def fix_security_issue_id(cfg: UAConfig, issue_id: str) -> None:
 
 
 def get_usn_affected_packages_status(
-    usn: USN, installed_packages: "Dict[str, Dict[str, str]]"
-) -> "Dict[str, CVEPackageStatus]":
+    usn: USN, installed_packages: Dict[str, Dict[str, str]]
+) -> Dict[str, CVEPackageStatus]:
     """Walk CVEs related to a USN and return a dict of all affected packages.
 
     :return: Dict keyed on source package name, with active CVEPackageStatus
@@ -609,8 +609,8 @@ def get_usn_affected_packages_status(
 
 
 def get_cve_affected_source_packages_status(
-    cve: CVE, installed_packages: "Dict[str, Dict[str, str]]"
-) -> "Dict[str, CVEPackageStatus]":
+    cve: CVE, installed_packages: Dict[str, Dict[str, str]]
+) -> Dict[str, CVEPackageStatus]:
     """Get a dict of any CVEPackageStatuses affecting this Ubuntu release.
 
     :return: Dict of active CVEPackageStatus keyed by source package names.
@@ -625,7 +625,7 @@ def get_cve_affected_source_packages_status(
 
 
 def print_affected_packages_header(
-    issue_id: str, affected_pkg_status: "Dict[str, CVEPackageStatus]"
+    issue_id: str, affected_pkg_status: Dict[str, CVEPackageStatus]
 ):
     """Print header strings describing affected packages related to a CVE/USN.
 
@@ -660,7 +660,7 @@ def print_affected_packages_header(
 
 def override_usn_release_package_status(
     pkg_status: CVEPackageStatus,
-    usn_src_released_pkgs: "Dict[str, Dict[str, str]]",
+    usn_src_released_pkgs: Dict[str, Dict[str, str]],
 ) -> CVEPackageStatus:
     """Parse release status based on both pkg_status and USN.release_packages.
 
@@ -708,7 +708,7 @@ def group_by_usn_package_status(affected_pkg_status, usn_released_pkgs):
 
 
 def _format_packages_message(
-    pkg_status_list: "List[Tuple[str, CVEPackageStatus]]",
+    pkg_status_list: List[Tuple[str, CVEPackageStatus]],
     pkg_index: int,
     num_pkgs: int,
 ) -> str:
@@ -762,11 +762,11 @@ def _is_pocket_used_by_beta_service(pocket: str, cfg: UAConfig) -> bool:
 
 def _handle_released_package_fixes(
     cfg: UAConfig,
-    src_pocket_pkgs: "Dict[str, List[Tuple[str, CVEPackageStatus]]]",
-    binary_pocket_pkgs: "Dict[str, List[str]]",
+    src_pocket_pkgs: Dict[str, List[Tuple[str, CVEPackageStatus]]],
+    binary_pocket_pkgs: Dict[str, List[str]],
     pkg_index: int,
     num_pkgs: int,
-) -> "Tuple[bool, List[str], bool]":
+) -> Tuple[bool, List[str], bool]:
     """Handle the packages that could be fixed and have a released status.
 
     :returns: Tuple of
@@ -816,7 +816,7 @@ def _handle_released_package_fixes(
     return upgrade_status, unfixed_pkgs, all_already_installed
 
 
-def _format_unfixed_packages_msg(unfixed_pkgs: "List[str]") -> str:
+def _format_unfixed_packages_msg(unfixed_pkgs: List[str]) -> str:
     """Format the list of unfixed packages into an message.
 
     :returns: A string containing the message output for the unfixed
@@ -838,9 +838,9 @@ def _format_unfixed_packages_msg(unfixed_pkgs: "List[str]") -> str:
 def prompt_for_affected_packages(
     cfg: UAConfig,
     issue_id: str,
-    affected_pkg_status: "Dict[str, CVEPackageStatus]",
-    installed_packages: "Dict[str, Dict[str, str]]",
-    usn_released_pkgs: "Dict[str, Dict[str, Dict[str, str]]]",
+    affected_pkg_status: Dict[str, CVEPackageStatus],
+    installed_packages: Dict[str, Dict[str, str]],
+    usn_released_pkgs: Dict[str, Dict[str, Dict[str, str]]],
 ) -> None:
     """Process security CVE dict returning a CVEStatus object.
 
@@ -1108,7 +1108,7 @@ def _check_subscription_is_expired(cfg: UAConfig) -> bool:
 
 
 def upgrade_packages_and_attach(
-    cfg: UAConfig, upgrade_packages: "List[str]", pocket: str
+    cfg: UAConfig, upgrade_packages: List[str], pocket: str
 ) -> bool:
     """Upgrade available packages to fix a CVE.
 

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -21,11 +21,7 @@ from uaclient import util
 from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 from uaclient.defaults import BASE_UA_URL, PRINT_WRAP_WIDTH
 
-try:
-    from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict, List, Optional, Tuple
 
 
 CVE_OR_USN_REGEX = (

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -3,26 +3,19 @@ import itertools
 import os
 import socket
 import textwrap
-
 from collections import defaultdict
 from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
-from uaclient import apt
-from uaclient.config import UAConfig
+from uaclient import apt, exceptions, serviceclient, status, util
 from uaclient.clouds.identity import (
     CLOUD_TYPE_TO_TITLE,
     PRO_CLOUDS,
     get_cloud_type,
 )
-from uaclient import exceptions
-from uaclient import status
-from uaclient import serviceclient
-from uaclient import util
-from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
+from uaclient.config import UAConfig
 from uaclient.defaults import BASE_UA_URL, PRINT_WRAP_WIDTH
-
-from typing import Any, Dict, List, Optional, Tuple
-
+from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
 CVE_OR_USN_REGEX = (
     r"((CVE|cve)-\d{4}-\d{4,7}$|(USN|usn|LSN|lsn)-\d{1,5}-\d{1,2}$)"
@@ -975,6 +968,7 @@ def _run_ua_attach(cfg: UAConfig, token: str) -> bool:
     :return: True if attach performed without errors.
     """
     import argparse
+
     from uaclient import cli
 
     print(status.colorize_commands([["ua", "attach", token]]))
@@ -1017,6 +1011,7 @@ def _prompt_for_enable(cfg: UAConfig, service: str) -> bool:
     :return: True if enable performed.
     """
     import argparse
+
     from uaclient import cli
 
     print(status.MESSAGE_SECURITY_SERVICE_DISABLED.format(service=service))
@@ -1078,6 +1073,7 @@ def _prompt_for_new_token(cfg: UAConfig) -> bool:
     :return: True if attach performed.
     """
     import argparse
+
     from uaclient import cli
 
     _inform_ubuntu_pro_existence_if_applicable()

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -18,7 +18,7 @@ class UAServiceClient(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def api_error_cls(self) -> "Type[Exception]":
+    def api_error_cls(self) -> Type[Exception]:
         """Set in subclasses to the type of API error raised"""
         pass
 
@@ -28,7 +28,7 @@ class UAServiceClient(metaclass=abc.ABCMeta):
         """String in subclasses, the UAConfig attribute containing base url"""
         pass
 
-    def __init__(self, cfg: "Optional[config.UAConfig]" = None) -> None:
+    def __init__(self, cfg: Optional[config.UAConfig] = None) -> None:
         if not cfg:
             self.cfg = config.UAConfig()
         else:
@@ -119,7 +119,7 @@ class UAServiceClient(metaclass=abc.ABCMeta):
 
     def _get_fake_responses(
         self, url: str
-    ) -> "Tuple[Optional[Dict[str, Any]], Optional[Dict[str,str]]]":
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, str]]]:
         """Return response and headers if faked for this URL in uaclient.conf.
 
         :return: A tuple of response and header dicts if the URL has an overlay

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -1,16 +1,12 @@
 import abc
 import json
 import os
-
+from posixpath import join as urljoin
+from typing import Any, Dict, Optional, Tuple, Type
 from urllib import error
 from urllib.parse import urlencode
-from posixpath import join as urljoin
 
-from uaclient import config
-from uaclient import util
-from uaclient import version
-
-from typing import Any, Dict, Optional, Tuple, Type
+from uaclient import config, util, version
 
 
 class UAServiceClient(metaclass=abc.ABCMeta):

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -10,7 +10,7 @@ from uaclient import config
 from uaclient import util
 from uaclient import version
 
-from typing import Any, Dict, Optional, Tuple, Type  # noqa
+from typing import Any, Dict, Optional, Tuple, Type
 
 
 class UAServiceClient(metaclass=abc.ABCMeta):

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -1,6 +1,5 @@
-from typing import List, Optional
-
 import logging
+from typing import List, Optional
 
 from uaclient import apt, status, util
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -11,11 +11,7 @@ from uaclient.defaults import (
     DOCUMENTATION_URL,
 )
 
-try:
-    from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
+from typing import Any, Dict, List, Optional, Tuple
 
 
 class TxtColor:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -580,7 +580,7 @@ def colorize(string: str) -> str:
     return STATUS_COLOR.get(string, string) if sys.stdout.isatty() else string
 
 
-def colorize_commands(commands: "List[List[str]]") -> str:
+def colorize_commands(commands: List[List[str]]) -> str:
     content = ""
     for cmd in commands:
         if content:
@@ -609,8 +609,8 @@ def colorize_commands(commands: "List[List[str]]") -> str:
 
 
 def get_section_column_content(
-    column_data: "List[Tuple[str, str]]", header: "Optional[str]" = None
-) -> "List[str]":
+    column_data: List[Tuple[str, str]], header: Optional[str] = None
+) -> List[str]:
     """Return a list of content lines to print to console for a section
 
     Content lines will be center-aligned based on max value length of first
@@ -629,7 +629,7 @@ def get_section_column_content(
     return content
 
 
-def format_tabular(status: "Dict[str, Any]") -> str:
+def format_tabular(status: Dict[str, Any]) -> str:
     """Format status dict for tabular output."""
     if not status["attached"]:
         content = [
@@ -687,7 +687,7 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     return "\n".join(content)
 
 
-def _format_status_output(status: "Dict[str, Any]") -> "Dict[str, Any]":
+def _format_status_output(status: Dict[str, Any]) -> Dict[str, Any]:
     status["environment_vars"] = [
         {"name": name, "value": value}
         for name, value in sorted(os.environ.items())
@@ -709,7 +709,7 @@ def _format_status_output(status: "Dict[str, Any]") -> "Dict[str, Any]":
     return status
 
 
-def format_json_status(status: "Dict[str, Any]") -> str:
+def format_json_status(status: Dict[str, Any]) -> str:
     from uaclient.util import DatetimeAwareJSONEncoder
 
     return json.dumps(
@@ -717,7 +717,7 @@ def format_json_status(status: "Dict[str, Any]") -> str:
     )
 
 
-def format_yaml_status(status: "Dict[str, Any]") -> str:
+def format_yaml_status(status: Dict[str, Any]) -> str:
     import yaml
 
     return yaml.dump(_format_status_output(status), default_flow_style=False)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,17 +1,16 @@
 import enum
 import json
+import os
 import sys
 import textwrap
-import os
+from typing import Any, Dict, List, Optional, Tuple
 
 from uaclient.defaults import (
     BASE_UA_URL,
     CONFIG_FIELD_ENVVAR_ALLOWLIST,
-    PRINT_WRAP_WIDTH,
     DOCUMENTATION_URL,
+    PRINT_WRAP_WIDTH,
 )
-
-from typing import Any, Dict, List, Optional, Tuple
 
 
 class TxtColor:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1,40 +1,39 @@
 """Tests related to uaclient.apt module."""
 
 import glob
-import mock
 import os
 import stat
 import subprocess
 from textwrap import dedent
 
+import mock
 import pytest
 
+from uaclient import apt, exceptions, status, util
 from uaclient.apt import (
+    APT_AUTH_COMMENT,
     APT_CONFIG_PROXY_HTTP,
     APT_CONFIG_PROXY_HTTPS,
-    APT_RETRIES,
     APT_KEYS_DIR,
-    APT_AUTH_COMMENT,
-    KEYRINGS_DIR,
     APT_PROXY_CONF_FILE,
+    APT_RETRIES,
+    KEYRINGS_DIR,
     add_apt_auth_conf_entry,
     add_auth_apt_repo,
     add_ppa_pinning,
+    assert_valid_apt_credentials,
     clean_apt_files,
     find_apt_list_files,
     get_installed_packages,
     remove_apt_list_files,
     remove_auth_apt_repo,
     remove_repo_from_apt_auth_file,
-    assert_valid_apt_credentials,
     run_apt_command,
     setup_apt_proxy,
 )
-from uaclient import apt, exceptions, util, status
-from uaclient.entitlements.tests.test_repo import RepoTestEntitlement
-from uaclient.entitlements.repo import RepoEntitlement
 from uaclient.entitlements.base import UAEntitlement
-
+from uaclient.entitlements.repo import RepoEntitlement
+from uaclient.entitlements.tests.test_repo import RepoTestEntitlement
 
 POST_INSTALL_APT_CACHE_NO_UPDATES = """
 -32768 https://esm.ubuntu.com/ubuntu/ {0}-updates/main amd64 Packages

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -2,15 +2,16 @@ import contextlib
 import io
 import json
 import logging
-import mock
 import os
 import socket
 import stat
 import sys
 import textwrap
 
+import mock
 import pytest
 
+from uaclient import status, util
 from uaclient.cli import (
     action_help,
     assert_attached,
@@ -18,21 +19,17 @@ from uaclient.cli import (
     assert_not_attached,
     assert_root,
     get_parser,
-    main,
     get_valid_entitlement_names,
+    main,
     setup_logging,
 )
-
 from uaclient.exceptions import (
     AlreadyAttachedError,
     LockHeldError,
     NonRootUserError,
-    UserFacingError,
     UnattachedError,
+    UserFacingError,
 )
-from uaclient import status
-from uaclient import util
-
 
 BIG_DESC = "123456789 " * 7 + "next line"
 BIG_URL = "http://" + "adsf" * 10

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -1,8 +1,9 @@
 import copy
-import mock
 
+import mock
 import pytest
 
+from uaclient import status
 from uaclient.cli import (
     UA_AUTH_TOKEN_URL,
     action_attach,
@@ -15,7 +16,6 @@ from uaclient.exceptions import (
     NonRootUserError,
     UserFacingError,
 )
-from uaclient import status
 from uaclient.util import UrlError
 
 M_PATH = "uaclient.cli."

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -1,26 +1,25 @@
-import mock
 import textwrap
 
+import mock
 import pytest
 
+from uaclient import status, util
 from uaclient.cli import (
+    _get_contract_token_from_cloud_identity,
     action_auto_attach,
     auto_attach_parser,
     get_parser,
-    _get_contract_token_from_cloud_identity,
     main,
 )
 from uaclient.contract import ContractAPIError
 from uaclient.exceptions import (
     AlreadyAttachedError,
     LockHeldError,
-    NonRootUserError,
     NonAutoAttachImageError,
+    NonRootUserError,
     UserFacingError,
 )
-from uaclient import status
 from uaclient.tests.test_cli_attach import BASIC_MACHINE_TOKEN
-from uaclient import util
 
 M_PATH = "uaclient.cli."
 M_ID_PATH = "uaclient.clouds.identity."

--- a/uaclient/tests/test_cli_config_set.py
+++ b/uaclient/tests/test_cli_config_set.py
@@ -1,11 +1,9 @@
 import mock
-
 import pytest
 
-from uaclient.cli import main, action_config_set
+from uaclient import status, util
+from uaclient.cli import action_config_set, main
 from uaclient.exceptions import NonRootUserError, UserFacingError
-from uaclient import util
-from uaclient import status
 
 HELP_OUTPUT = """\
 usage: ua set <key>=<value> [flags]

--- a/uaclient/tests/test_cli_config_show.py
+++ b/uaclient/tests/test_cli_config_show.py
@@ -1,5 +1,4 @@
 import mock
-
 import pytest
 
 from uaclient.cli import action_config_show, main

--- a/uaclient/tests/test_cli_config_unset.py
+++ b/uaclient/tests/test_cli_config_unset.py
@@ -1,10 +1,9 @@
 import mock
-
 import pytest
 
-from uaclient.cli import main, action_config_unset
-from uaclient.exceptions import NonRootUserError
 from uaclient import status
+from uaclient.cli import action_config_unset, main
+from uaclient.exceptions import NonRootUserError
 
 HELP_OUTPUT = """\
 usage: ua unset <key> [flags]

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -1,11 +1,10 @@
-import mock
 from textwrap import dedent
 
+import mock
 import pytest
 
+from uaclient import exceptions, status
 from uaclient.cli import action_detach, detach_parser, get_parser
-from uaclient import exceptions
-from uaclient import status
 from uaclient.testing.fakes import FakeContractClient
 
 

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -1,12 +1,10 @@
-import mock
-import pytest
 import textwrap
 
-from uaclient.cli import action_disable, main
-from uaclient import entitlements
-from uaclient import exceptions
-from uaclient import status
+import mock
+import pytest
 
+from uaclient import entitlements, exceptions, status
+from uaclient.cli import action_disable, main
 
 ALL_SERVICE_MSG = "\n".join(
     textwrap.wrap(

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -1,14 +1,12 @@
 import contextlib
 import io
-import mock
 import textwrap
 
+import mock
 import pytest
 
+from uaclient import entitlements, exceptions, status
 from uaclient.cli import action_enable, main
-from uaclient import entitlements
-from uaclient import exceptions
-from uaclient import status
 
 HELP_OUTPUT = textwrap.dedent(
     """\

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -1,10 +1,9 @@
-import mock
 import textwrap
 
+import mock
 import pytest
 
 from uaclient import exceptions
-
 from uaclient.cli import action_fix, main
 
 M_PATH = "uaclient.cli."

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -1,12 +1,6 @@
 import mock
 import pytest
 
-try:
-    from typing import Any, Dict, Optional  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
-
 from uaclient import exceptions
 from uaclient import status
 from uaclient import util

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -1,9 +1,7 @@
 import mock
 import pytest
 
-from uaclient import exceptions
-from uaclient import status
-from uaclient import util
+from uaclient import exceptions, status, util
 from uaclient.cli import action_refresh, main
 
 HELP_OUTPUT = """\

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -1,19 +1,17 @@
 import datetime
 import io
 import json
-import mock
 import os
 import socket
 import sys
 import textwrap
+
+import mock
+import pytest
 import yaml
 
-import pytest
-
-from uaclient import util, version
-
+from uaclient import status, util, version
 from uaclient.cli import action_status, main
-from uaclient import status
 
 M_PATH = "uaclient.cli."
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -5,35 +5,34 @@ import json
 import logging
 import os
 import stat
-import yaml
 
 import mock
 import pytest
+import yaml
 
 from uaclient import entitlements, exceptions, status, util, version
 from uaclient.config import (
-    DataPath,
     DEFAULT_STATUS,
     PRIVATE_SUBDIR,
-    UAConfig,
     UA_CONFIGURABLE_KEYS,
     VALID_UA_CONFIG_KEYS,
-    parse_config,
+    DataPath,
+    UAConfig,
     depth_first_merge_overlay_dict,
     get_config_path,
+    parse_config,
 )
 from uaclient.defaults import CONFIG_DEFAULTS, DEFAULT_CONFIG_FILE
 from uaclient.entitlements import (
-    ENTITLEMENT_CLASSES,
     ENTITLEMENT_CLASS_BY_NAME,
+    ENTITLEMENT_CLASSES,
 )
 from uaclient.status import (
-    ContractStatus,
-    UserFacingStatus,
-    UserFacingConfigStatus,
     MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL,
+    ContractStatus,
+    UserFacingConfigStatus,
+    UserFacingStatus,
 )
-
 
 KNOWN_DATA_PATHS = (
     ("machine-access-cis", "machine-access-cis.json"),

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1,10 +1,12 @@
 import copy
 import json
 import logging
-import mock
-import pytest
 import socket
 
+import mock
+import pytest
+
+from uaclient import exceptions, util
 from uaclient.contract import (
     API_V1_CONTEXT_MACHINE_TOKEN,
     API_V1_RESOURCES,
@@ -16,22 +18,18 @@ from uaclient.contract import (
     process_entitlement_delta,
     request_updated_contract,
 )
-from uaclient import exceptions
-from uaclient import util
 from uaclient.status import (
     MESSAGE_ATTACH_EXPIRED_TOKEN,
     MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES,
     MESSAGE_ATTACH_FORBIDDEN,
     MESSAGE_ATTACH_FORBIDDEN_EXPIRED,
-    MESSAGE_ATTACH_FORBIDDEN_NOT_YET,
     MESSAGE_ATTACH_FORBIDDEN_NEVER,
+    MESSAGE_ATTACH_FORBIDDEN_NOT_YET,
     MESSAGE_ATTACH_INVALID_TOKEN,
     MESSAGE_UNEXPECTED_ERROR,
 )
-from uaclient.version import get_version
-
 from uaclient.testing.fakes import FakeContractClient
-
+from uaclient.version import get_version
 
 M_PATH = "uaclient.contract."
 M_REPO_PATH = "uaclient.entitlements.repo.RepoEntitlement."

--- a/uaclient/tests/test_gpg.py
+++ b/uaclient/tests/test_gpg.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from uaclient import exceptions, gpg, util

--- a/uaclient/tests/test_patch_status_json.py
+++ b/uaclient/tests/test_patch_status_json.py
@@ -1,7 +1,7 @@
-import logging
-import pytest
-
 import json
+import logging
+
+import pytest
 
 from lib.patch_status_json import patch_status_json_schema_0_1
 

--- a/uaclient/tests/test_pip.py
+++ b/uaclient/tests/test_pip.py
@@ -1,10 +1,10 @@
 """Tests related to uaclient.pip module."""
 
+from configparser import ConfigParser
+from textwrap import dedent
+
 import mock
 import pytest
-
-from textwrap import dedent
-from configparser import ConfigParser
 
 from uaclient.pip import update_pip_conf
 

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -1,16 +1,16 @@
 import logging
+
 import mock
 import pytest
 
+from lib.reboot_cmds import (
+    fix_pro_pkg_holds,
+    main,
+    process_reboot_operations,
+    run_command,
+)
 from uaclient.status import MESSAGE_REBOOT_SCRIPT_FAILED
 from uaclient.util import ProcessExecutionError
-
-from lib.reboot_cmds import (
-    main,
-    fix_pro_pkg_holds,
-    run_command,
-    process_reboot_operations,
-)
 
 M_FIPS_PATH = "uaclient.entitlements.fips.FIPSEntitlement."
 

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -1,18 +1,21 @@
 import copy
-import mock
-import pytest
 import textwrap
 
+import mock
+import pytest
+
+from uaclient import exceptions
+from uaclient.clouds.identity import NoCloudTypeReason
 from uaclient.security import (
-    API_V1_CVES,
     API_V1_CVE_TMPL,
-    API_V1_NOTICES,
+    API_V1_CVES,
     API_V1_NOTICE_TMPL,
+    API_V1_NOTICES,
     CVE,
-    CVEPackageStatus,
-    UASecurityClient,
     USN,
+    CVEPackageStatus,
     SecurityAPIError,
+    UASecurityClient,
     fix_security_issue_id,
     get_cve_affected_source_packages_status,
     merge_usn_released_binary_package_versions,
@@ -23,25 +26,27 @@ from uaclient.security import (
     version_cmp_le,
 )
 from uaclient.status import (
-    MESSAGE_SECURITY_USE_PRO_TMPL,
-    OKGREEN_CHECK,
     FAIL_X,
+    MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL,
     MESSAGE_SECURITY_APT_NON_ROOT,
+    MESSAGE_SECURITY_ISSUE_NOT_RESOLVED,
+    MESSAGE_SECURITY_SERVICE_DISABLED,
     MESSAGE_SECURITY_UA_SERVICE_NOT_ENABLED,
     MESSAGE_SECURITY_UA_SERVICE_NOT_ENTITLED,
-    MESSAGE_SECURITY_ISSUE_NOT_RESOLVED,
-    MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION as MSG_SUBSCRIPTION,
-    MESSAGE_SECURITY_SERVICE_DISABLED,
     MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_EXPIRED,
-    MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL,
+)
+from uaclient.status import (
+    MESSAGE_SECURITY_UPDATE_NOT_INSTALLED_SUBSCRIPTION as MSG_SUBSCRIPTION,
+)
+from uaclient.status import (
+    MESSAGE_SECURITY_USE_PRO_TMPL,
+    OKGREEN_CHECK,
     PROMPT_ENTER_TOKEN,
     PROMPT_EXPIRED_ENTER_TOKEN,
-    UserFacingStatus,
     ApplicabilityStatus,
+    UserFacingStatus,
     colorize_commands,
 )
-from uaclient.clouds.identity import NoCloudTypeReason
-from uaclient import exceptions
 from uaclient.util import UrlError
 
 M_PATH = "uaclient.contract."

--- a/uaclient/tests/test_serviceclient.py
+++ b/uaclient/tests/test_serviceclient.py
@@ -1,9 +1,9 @@
-import mock
+import json
+from io import BytesIO
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
-from io import BytesIO
-import json
 
+import mock
 import pytest
 
 from uaclient import util

--- a/uaclient/tests/test_snap.py
+++ b/uaclient/tests/test_snap.py
@@ -1,7 +1,6 @@
 """Tests related to uaclient.snap module."""
 
 import mock
-
 import pytest
 
 from uaclient import status

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -1,13 +1,14 @@
+import string
+
 import mock
 import pytest
-import string
 
 from uaclient import config
 from uaclient.status import (
-    format_tabular,
     TxtColor,
-    colorize_commands,
     UserFacingStatus,
+    colorize_commands,
+    format_tabular,
 )
 
 

--- a/uaclient/tests/test_ua_timer.py
+++ b/uaclient/tests/test_ua_timer.py
@@ -1,7 +1,9 @@
 import datetime
 import logging
+
 import mock
 import pytest
+
 from lib.timer import TimedJob, run_jobs
 
 

--- a/uaclient/tests/test_update_messaging.py
+++ b/uaclient/tests/test_update_messaging.py
@@ -1,13 +1,23 @@
 import datetime
-import mock
 import os
 
+import mock
 import pytest
 
+from uaclient import util
 from uaclient.defaults import (
     BASE_ESM_URL,
     BASE_UA_URL,
     CONTRACT_EXPIRY_GRACE_PERIOD_DAYS,
+)
+from uaclient.jobs.update_messaging import (
+    ContractExpiryStatus,
+    ExternalMessage,
+    _write_esm_service_msg_templates,
+    get_contract_expiry_status,
+    update_apt_and_motd_messages,
+    write_apt_and_motd_templates,
+    write_esm_announcement_message,
 )
 from uaclient.status import (
     MESSAGE_ANNOUNCE_ESM_TMPL,
@@ -15,21 +25,10 @@ from uaclient.status import (
     MESSAGE_CONTRACT_EXPIRED_APT_PKGS_TMPL,
     MESSAGE_CONTRACT_EXPIRED_GRACE_PERIOD_TMPL,
     MESSAGE_CONTRACT_EXPIRED_SOON_TMPL,
-    MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
     MESSAGE_DISABLED_APT_PKGS_TMPL,
+    MESSAGE_DISABLED_MOTD_NO_PKGS_TMPL,
     MESSAGE_UBUNTU_NO_WARRANTY,
     ApplicationStatus,
-)
-from uaclient import util
-
-from uaclient.jobs.update_messaging import (
-    ContractExpiryStatus,
-    ExternalMessage,
-    get_contract_expiry_status,
-    update_apt_and_motd_messages,
-    write_apt_and_motd_templates,
-    write_esm_announcement_message,
-    _write_esm_service_msg_templates,
 )
 
 M_PATH = "uaclient.jobs.update_messaging."

--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -1,4 +1,5 @@
 import logging
+
 import mock
 import pytest
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -5,13 +5,13 @@ import logging
 import posix
 import socket
 import subprocess
-import uuid
 import urllib
+import uuid
 
 import mock
 import pytest
 
-from uaclient import cli, util, exceptions, status
+from uaclient import cli, exceptions, status, util
 
 PRIVACY_POLICY_URL = (
     "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -1,8 +1,7 @@
-import mock
-
-import pytest
-
 import os.path
+
+import mock
+import pytest
 
 from uaclient import util
 from uaclient.version import get_version

--- a/uaclient/types.py
+++ b/uaclient/types.py
@@ -1,0 +1,3 @@
+from typing import Any, Callable, Tuple
+
+StaticAffordance = Tuple[str, Callable[[], Any], bool]

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -17,27 +17,19 @@ from http.client import HTTPMessage  # noqa: F401
 from uaclient import exceptions
 from uaclient import status
 
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
-
-
-try:
-    from typing import (  # noqa: F401
-        Any,
-        Callable,
-        Dict,
-        List,
-        Mapping,
-        Optional,
-        Sequence,
-        Tuple,
-        Union,
-    )
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
-
-
 ETC_MACHINE_ID = "/etc/machine-id"
 DBUS_MACHINE_ID = "/var/lib/dbus/machine-id"
 DROPPED_KEY = object()

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -1,4 +1,3 @@
-from errno import ENOENT
 import datetime
 import json
 import logging
@@ -7,16 +6,11 @@ import re
 import socket
 import subprocess
 import time
-from urllib import error, request
-from urllib.parse import urlparse
 import uuid
 from contextlib import contextmanager
+from errno import ENOENT
 from functools import lru_cache, wraps
 from http.client import HTTPMessage  # noqa: F401
-
-from uaclient import exceptions
-from uaclient import status
-
 from typing import (
     Any,
     Callable,
@@ -28,6 +22,10 @@ from typing import (
     Tuple,
     Union,
 )
+from urllib import error, request
+from urllib.parse import urlparse
+
+from uaclient import exceptions, status
 
 REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
 ETC_MACHINE_ID = "/etc/machine-id"

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -10,7 +10,7 @@ import uuid
 from contextlib import contextmanager
 from errno import ENOENT
 from functools import lru_cache, wraps
-from http.client import HTTPMessage  # noqa: F401
+from http.client import HTTPMessage
 from typing import (
     Any,
     Callable,
@@ -57,9 +57,9 @@ class UrlError(IOError):
     def __init__(
         self,
         cause: error.URLError,
-        code: "Optional[int]" = None,
-        headers: "Optional[Dict[str, str]]" = None,
-        url: "Optional[str]" = None,
+        code: Optional[int] = None,
+        headers: Optional[Dict[str, str]] = None,
+        url: Optional[str] = None,
     ):
         if getattr(cause, "reason", None):
             cause_error = str(cause.reason)
@@ -77,7 +77,7 @@ class ProcessExecutionError(IOError):
     def __init__(
         self,
         cmd: str,
-        exit_code: "Optional[int]" = None,
+        exit_code: Optional[int] = None,
         stdout: str = "",
         stderr: str = "",
     ) -> None:
@@ -138,7 +138,7 @@ class DatetimeAwareJSONDecoder(json.JSONDecoder):
 
 
 def apply_series_overrides(
-    orig_access: "Dict[str, Any]", series: str = None
+    orig_access: Dict[str, Any], series: str = None
 ) -> None:
     """Apply series-specific overrides to an entitlement dict.
 
@@ -255,8 +255,8 @@ def retry(exception, retry_sleeps):
 
 
 def get_dict_deltas(
-    orig_dict: "Dict[str, Any]", new_dict: "Dict[str, Any]", path: str = ""
-) -> "Dict[str, Any]":
+    orig_dict: Dict[str, Any], new_dict: Dict[str, Any], path: str = ""
+) -> Dict[str, Any]:
     """Return a dictionary of delta between orig_dict and new_dict."""
     deltas = {}  # type: Dict[str, Any]
     for key, value in orig_dict.items():
@@ -308,7 +308,7 @@ def get_machine_id(cfg) -> str:
     return machine_id
 
 
-def get_platform_info() -> "Dict[str, str]":
+def get_platform_info() -> Dict[str, str]:
     """
     Returns a dict of platform information.
 
@@ -421,7 +421,7 @@ def load_file(filename: str, decode: bool = True) -> str:
 
 
 @lru_cache(maxsize=None)
-def parse_os_release(release_file: "Optional[str]" = None) -> "Dict[str, str]":
+def parse_os_release(release_file: Optional[str] = None) -> Dict[str, str]:
     if not release_file:
         release_file = "/etc/os-release"
     data = {}
@@ -432,7 +432,7 @@ def parse_os_release(release_file: "Optional[str]" = None) -> "Dict[str, str]":
     return data
 
 
-def prompt_choices(msg: str = "", valid_choices: "List[str]" = []) -> str:
+def prompt_choices(msg: str = "", valid_choices: List[str] = []) -> str:
     """Interactive prompt message, returning a valid choice from msg.
 
     Expects a structured msg which designates choices with square brackets []
@@ -477,7 +477,7 @@ def prompt_for_confirmation(msg: str = "", assume_yes: bool = False) -> bool:
 
 
 def configure_web_proxy(
-    http_proxy: "Optional[str]", https_proxy: "Optional[str]"
+    http_proxy: Optional[str], https_proxy: Optional[str]
 ) -> None:
     """
     Configure urllib to use http and https proxies.
@@ -503,11 +503,11 @@ def configure_web_proxy(
 
 def readurl(
     url: str,
-    data: "Optional[bytes]" = None,
-    headers: "Dict[str, str]" = {},
-    method: "Optional[str]" = None,
-    timeout: "Optional[int]" = None,
-) -> "Tuple[Any, Union[HTTPMessage, Mapping[str, str]]]":
+    data: Optional[bytes] = None,
+    headers: Dict[str, str] = {},
+    method: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> Tuple[Any, Union[HTTPMessage, Mapping[str, str]]]:
     if data and not method:
         method = "POST"
     req = request.Request(url, data=data, headers=headers, method=method)
@@ -542,12 +542,12 @@ def readurl(
 
 
 def _subp(
-    args: "Sequence[str]",
-    rcs: "Optional[List[int]]" = None,
+    args: Sequence[str],
+    rcs: Optional[List[int]] = None,
     capture: bool = False,
-    timeout: "Optional[float]" = None,
-    env: "Optional[Dict[str, str]]" = None,
-) -> "Tuple[str, str]":
+    timeout: Optional[float] = None,
+    env: Optional[Dict[str, str]] = None,
+) -> Tuple[str, str]:
     """Run a command and return a tuple of decoded stdout, stderr.
 
     @param args: A list of arguments to feed to subprocess.Popen
@@ -603,13 +603,13 @@ def _subp(
 
 
 def subp(
-    args: "Sequence[str]",
-    rcs: "Optional[List[int]]" = None,
+    args: Sequence[str],
+    rcs: Optional[List[int]] = None,
     capture: bool = False,
-    timeout: "Optional[float]" = None,
-    retry_sleeps: "Optional[List[float]]" = None,
-    env: "Optional[Dict[str, str]]" = None,
-) -> "Tuple[str, str]":
+    timeout: Optional[float] = None,
+    retry_sleeps: Optional[List[float]] = None,
+    env: Optional[Dict[str, str]] = None,
+) -> Tuple[str, str]:
     """Run a command and return a tuple of decoded stdout, stderr.
 
      @param subp: A list of arguments to feed to subprocess.Popen
@@ -646,7 +646,7 @@ def subp(
     return out, err
 
 
-def which(program: str) -> "Optional[str]":
+def which(program: str) -> Optional[str]:
     """Find whether the provided program is executable in our PATH"""
     if os.path.sep in program:
         # if program had a '/' in it, then do not search PATH
@@ -685,7 +685,7 @@ def remove_file(file_path: str) -> None:
         os.unlink(file_path)
 
 
-def is_config_value_true(config: "Dict[str, Any]", path_to_value: str):
+def is_config_value_true(config: Dict[str, Any], path_to_value: str):
     """Check if value parameter can be translated into a boolean 'True' value.
 
     @param config: A config dict representing
@@ -737,7 +737,7 @@ REDACT_SENSITIVE_LOGS = [
 
 
 def redact_sensitive_logs(
-    log, redact_regexs: "List[str]" = REDACT_SENSITIVE_LOGS
+    log, redact_regexs: List[str] = REDACT_SENSITIVE_LOGS
 ) -> str:
     """Redact known sensitive information from log content."""
     redacted_log = log
@@ -760,7 +760,7 @@ def is_installed(package_name: str) -> bool:
 
 
 def handle_message_operations(
-    msg_ops: "List[Union[str, Tuple[Callable, Dict]]]",
+    msg_ops: List[Union[str, Tuple[Callable, Dict]]],
 ) -> bool:
     """Emit messages to the console for user interaction
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -5,8 +5,8 @@ These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
 import os.path
-from uaclient import util
 
+from uaclient import util
 
 __VERSION__ = "28.0"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"


### PR DESCRIPTION
## Commentary
While touching all of the imports in all of the files, it seemed like a good time to introduce isort, which will organize all of our imports for us (black doesn't do this). I like it because it is one less thing to think about, but I'm open to push-back on introducing more tooling.

Also, now that we can rely on typing being present, we no longer need to redefine custom types like StaticAffordance in several places. I added a new `types.py` where we can organize and define our custom types. We can start doing this more often now (where it makes sense) since it involves less overhead.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->
```
types: remove typing import exception code needed for trusty
```
```
refactor: define StaticAffordance type once
```
```
tooling: sort imports with isort 
```
```
types: only use type forward refs where necessary 
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Ensure all tests still pass and no imports were mangled by me or the new isort tooling.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
