### PR TITLE
config: ignore null / absent configuration for the timers (SC-369)

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -390,6 +390,7 @@ Feature: Command behaviour when attached to an UA subscription
            | focal   | cloud-init-dev-ubuntu-daily-focal  |
 
     @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Run timer script on an attached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -480,7 +481,7 @@ Feature: Command behaviour when attached to an UA subscription
         """
         Invalid value for update_status interval found in config.
         """
-        And stderr matches regexp:
+        And stderr does not match regexp:
         """
         Invalid value for gcp_auto_attach interval found in config.
         """

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -386,19 +386,14 @@ def then_i_will_see_on_stdout(context):
 def then_conditional_stdout_matches_regexp(context, value1, value2):
     """Only apply regex assertion if value1 in value2."""
     if value1 in value2.split(" or "):
-        then_stdout_matches_regexp(context)
+        then_stream_matches_regexp(context, "stdout")
 
 
 @then("if `{value1}` in `{value2}` and stdout does not match regexp")
 def then_conditional_stdout_does_not_match_regexp(context, value1, value2):
     """Only apply regex assertion if value1 in value2."""
     if value1 in value2.split(" or "):
-        then_stdout_does_not_match_regexp(context)
-
-
-@then("stdout matches regexp")
-def then_stdout_matches_regexp(context):
-    assert_that(context.process.stdout.strip(), matches_regexp(context.text))
+        then_stream_does_not_match_regexp(context, "stdout")
 
 
 @then("stdout is formatted as `{output_format}` and has keys")
@@ -428,9 +423,10 @@ def then_stream_does_not_match_regexp(context, stream):
     assert_that(content, not_(matches_regexp(context.text)))
 
 
-@then("stderr matches regexp")
-def then_stderr_matches_regexp(context):
-    assert_that(context.process.stderr.strip(), matches_regexp(context.text))
+@then("{stream} matches regexp")
+def then_stream_matches_regexp(context, stream):
+    content = getattr(context.process, stream).strip()
+    assert_that(content, matches_regexp(context.text))
 
 
 @then("I will see the following on stderr")

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -56,7 +56,15 @@ class TimedJob:
     def run_interval_seconds(self, cfg: UAConfig):
         """Return the run_interval for the job based on config or defaults."""
         configured_interval = getattr(cfg, "{}_timer".format(self.name), None)
-        if not isinstance(configured_interval, int) or configured_interval < 0:
+        if configured_interval is None:
+            debug_msg = (
+                "No config set for {}, default value will be used."
+            ).format(self.name)
+            LOG.debug(debug_msg)
+            return self._default_interval_seconds
+        elif (
+            not isinstance(configured_interval, int) or configured_interval < 0
+        ):
             error_msg = (
                 "Invalid value for {} interval found in config. "
                 "Default value will be used."

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -797,7 +797,11 @@ class UAConfig:
             "gcp_auto_attach_timer",
         ):
             value = getattr(self, prop)
-            if not isinstance(value, int) or value < 0:
+            if value is None:
+                logging.debug(
+                    "No config set for {}, default value will be used."
+                )
+            elif not isinstance(value, int) or value < 0:
                 error_msg = (
                     "Value for the {} interval must be a positive integer. "
                     "Default value will be used."

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1366,7 +1366,7 @@ class TestProcessConfig:
                     "https_proxy": https_proxy,
                     "update_messaging_timer": 21600,
                     "update_status_timer": 43200,
-                    "gcp_auto_attach_timer": 1800,
+                    "gcp_auto_attach_timer": None,
                 }
             }
         )


### PR DESCRIPTION
If there is no config entry in `ua_config` for a timer or if it is set to null, just use the default values.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
