### PR TITLE
jobs: do not run gcp job on non-gcp instances (SC-363)

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -246,6 +246,14 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Enabling default service esm-infra
         """
+        When I run `ua config show` with sudo
+        Then stdout matches regexp:
+        """
+        update_messaging_timer  +21600
+        update_status_timer     +43200
+        gcp_auto_attach_timer   +1800
+        metering_timer          +0
+        """
 
         Examples: ubuntu release livepatch status
            | release | lp_status | fips_status |

--- a/uaclient/jobs/gcp_auto_attach.py
+++ b/uaclient/jobs/gcp_auto_attach.py
@@ -2,22 +2,29 @@
 Try to auto-attach in a GCP instance. This should only work
 if the instance has a new UA license attached to it
 """
+import logging
 
 from uaclient import config, exceptions
 from uaclient.cli import action_auto_attach
 from uaclient.clouds.identity import get_cloud_type
 
+LOG = logging.getLogger(__name__)
+
 
 def gcp_auto_attach(cfg: config.UAConfig) -> None:
+    # We will not do anything in a non-GCP cloud
+    cloud_id, _ = get_cloud_type()
+    if not cloud_id or cloud_id != "gce":
+        # If we are not running on GCP cloud, we shouldn't run this
+        # job anymore
+        LOG.info("Disabling gcp_auto_attach job. Not running on GCP instance")
+        cfg.gcp_auto_attach_timer = 0
+        return
+
     # If the instance is already attached we will not do anything.
     # This implies that the user may have a new license attached to the
     # instance, but we will not perfom the change through this job.
     if cfg.is_attached:
-        return
-
-    # We will not do anything in a non-GCP cloud
-    cloud_id, _ = get_cloud_type()
-    if not cloud_id or cloud_id != "gce":
         return
 
     try:
@@ -26,7 +33,7 @@ def gcp_auto_attach(cfg: config.UAConfig) -> None:
         # lock only for the job
         action_auto_attach(args=None, cfg=cfg)
     except exceptions.NonAutoAttachImageError:
-        # If we get a NonAutoAttachImageError we now
+        # If we get a NonAutoAttachImageError we know
         # that the machine is not ready yet to perform an
         # auto-attach operation (i.e. the license may not
         # have been appended yet). If that happens, we will not

--- a/uaclient/jobs/tests/test_gcp_auto_attach.py
+++ b/uaclient/jobs/tests/test_gcp_auto_attach.py
@@ -1,0 +1,60 @@
+import logging
+
+import mock
+import pytest
+
+from uaclient.exceptions import NonAutoAttachImageError
+from uaclient.jobs.gcp_auto_attach import gcp_auto_attach
+
+
+class TestGCPAutoAttachJob:
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
+    def test_gcp_auto_attach_already_attached(
+        self, m_auto_attach, m_cloud_type, FakeConfig
+    ):
+        m_cloud_type.return_value = ("gce", None)
+        cfg = FakeConfig.for_attached_machine()
+        assert gcp_auto_attach(cfg) is None
+        assert m_auto_attach.call_count == 0
+
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @pytest.mark.parametrize(
+        "cloud_type", (("gce"), ("azure"), ("aws"), (None))
+    )
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
+    def test_gcp_auto_attach(
+        self, m_auto_attach, m_cloud_type, cloud_type, caplog_text, FakeConfig
+    ):
+        m_cloud_type.return_value = (cloud_type, None)
+        cfg = FakeConfig()
+
+        with mock.patch.object(type(cfg), "write_cfg") as m_write:
+            cfg.gcp_auto_attach_timer = 1000
+            assert gcp_auto_attach(cfg) is None
+
+        if cloud_type != "gce":
+            assert m_auto_attach.call_count == 0
+            assert cfg.gcp_auto_attach_timer == 0
+            assert m_write.call_count == 2
+            assert (
+                "Disabling gcp_auto_attach job. Not running on GCP instance"
+            ) in caplog_text()
+
+        else:
+            assert cfg.gcp_auto_attach_timer == 1000
+            assert m_write.call_count == 1
+            assert m_auto_attach.call_count == 1
+
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
+    def test_gcp_job_dont_fail_if_non_auto_attach_image_error_is_raised(
+        self, m_auto_attach, m_cloud_type, FakeConfig
+    ):
+        m_cloud_type.return_value = ("gce", None)
+        m_auto_attach.side_effect = NonAutoAttachImageError("error")
+        cfg = FakeConfig()
+
+        assert gcp_auto_attach(cfg) is None
+        assert m_auto_attach.call_count == 1


### PR DESCRIPTION
## Proposed Commit Message
jobs: do not run gcp job on non-gcp instances

When running the gcp_auto_attach job on an instance we can detect that the running instance is not a GCP one. If that happens, we will not update the gcp job time interval to 0. This will guarantee that this job will not run on the machine anymore.

## Test Steps
Run the modified integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
