### PR TITLE
Reduce the amount of logging due to timer (SC-370)

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -457,7 +457,7 @@ class UAConfig:
     def read_cache(self, key: str, silent: bool = False) -> Optional[Any]:
         cache_path = self.data_path(key)
         try:
-            content = util.load_file(cache_path)
+            content = util.load_file(cache_path, silent=silent)
         except Exception:
             if not os.path.exists(cache_path) and not silent:
                 logging.debug("File does not exist: %s", cache_path)
@@ -467,7 +467,9 @@ class UAConfig:
         except ValueError:
             return content
 
-    def write_cache(self, key: str, content: Any) -> None:
+    def write_cache(
+        self, key: str, content: Any, silent: bool = False
+    ) -> None:
         filepath = self.data_path(key)
         data_dir = os.path.dirname(filepath)
         if not os.path.exists(data_dir):
@@ -489,7 +491,7 @@ class UAConfig:
         if key in self.data_paths:
             if not self.data_paths[key].private:
                 mode = 0o644
-        util.write_file(filepath, content, mode=mode)
+        util.write_file(filepath, content, mode=mode, silent=silent)
 
     def _remove_beta_resources(self, response) -> Dict[str, Any]:
         """Remove beta services from response dict"""

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -836,10 +836,10 @@ class TestFIPSEntitlementApplicationStatus:
     ):
         orig_load_file = util.load_file
 
-        def fake_load_file(path):
+        def fake_load_file(path, **kwargs):
             if path == "/proc/sys/crypto/fips_enabled":
                 return proc_content
-            return orig_load_file(path)
+            return orig_load_file(path, **kwargs)
 
         orig_exists = os.path.exists
 

--- a/uaclient/jobs/gcp_auto_attach.py
+++ b/uaclient/jobs/gcp_auto_attach.py
@@ -8,27 +8,28 @@ from uaclient.cli import action_auto_attach
 from uaclient.clouds.identity import get_cloud_type
 
 
-def gcp_auto_attach(cfg: config.UAConfig) -> None:
+def gcp_auto_attach(cfg: config.UAConfig) -> bool:
     # If the instance is already attached we will not do anything.
     # This implies that the user may have a new license attached to the
     # instance, but we will not perfom the change through this job.
     if cfg.is_attached:
-        return
+        return False
 
     # We will not do anything in a non-GCP cloud
     cloud_id, _ = get_cloud_type()
     if not cloud_id or cloud_id != "gce":
-        return
+        return False
 
     try:
         # This function already uses the assert lock decorator,
         # which means that we don't need to make create another
         # lock only for the job
         action_auto_attach(args=None, cfg=cfg)
+        return True
     except exceptions.NonAutoAttachImageError:
         # If we get a NonAutoAttachImageError we now
         # that the machine is not ready yet to perform an
         # auto-attach operation (i.e. the license may not
         # have been appended yet). If that happens, we will not
         # error out.
-        return
+        return False

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -320,7 +320,7 @@ def write_esm_announcement_message(cfg: config.UAConfig, series: str) -> None:
         util.remove_file(esm_news_file)
 
 
-def update_apt_and_motd_messages(cfg: config.UAConfig) -> None:
+def update_apt_and_motd_messages(cfg: config.UAConfig) -> bool:
     """Emit templates and human-readable status messages in msg_dir.
 
     These structured messages will be sourced by both /etc/update.motd.d
@@ -345,10 +345,11 @@ def update_apt_and_motd_messages(cfg: config.UAConfig) -> None:
             util.remove_file(msg_path)
             if msg_path.endswith(".tmpl"):
                 util.remove_file(msg_path.replace(".tmpl", ""))
-        return
+        return True
 
     # Announce ESM availabilty on active ESM LTS releases
     write_esm_announcement_message(cfg, series)
     write_apt_and_motd_templates(cfg, series)
     # Now that we've setup/cleanedup templates render them with apt-hook
     util.subp(["/usr/lib/ubuntu-advantage/apt-esm-hook", "process-templates"])
+    return True

--- a/uaclient/jobs/update_state.py
+++ b/uaclient/jobs/update_state.py
@@ -5,5 +5,6 @@ Update system state module, like status cache or contract cached files
 from uaclient.config import UAConfig
 
 
-def update_status(cfg: UAConfig):
+def update_status(cfg: UAConfig) -> bool:
     cfg.status()
+    return True

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -413,9 +413,10 @@ def is_service_url(url: str) -> bool:
     return True
 
 
-def load_file(filename: str, decode: bool = True) -> str:
+def load_file(filename: str, decode: bool = True, silent: bool = False) -> str:
     """Read filename and decode content."""
-    logging.debug("Reading file: %s", filename)
+    if not silent:
+        logging.debug("Reading file: %s", filename)
     with open(filename, "rb") as stream:
         content = stream.read()
     return content.decode("utf-8")
@@ -664,7 +665,9 @@ def which(program: str) -> Optional[str]:
     return None
 
 
-def write_file(filename: str, content: str, mode: int = 0o644) -> None:
+def write_file(
+    filename: str, content: str, mode: int = 0o644, silent: bool = False
+) -> None:
     """Write content to the provided filename encoding it if necessary.
 
     @param filename: The full path of the file to write.
@@ -672,7 +675,8 @@ def write_file(filename: str, content: str, mode: int = 0o644) -> None:
     @param mode: The filesystem mode to set on the file.
     @param omode: The open mode used when opening the file (w, wb, a, etc.)
     """
-    logging.debug("Writing file: %s", filename)
+    if not silent:
+        logging.debug("Writing file: %s", filename)
     with open(filename, "wb") as fh:
         fh.write(content.encode("utf-8"))
         fh.flush()


### PR DESCRIPTION
When a job run sucessfully but noops, the timer should not log it.
Timer jobs can return True on sucessful run to indicate something was changed, and False when it noops. The timer then only adds debug logs if the job actually did something.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
