### PR TITLE
tests: use correct instance ids for snapshots

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -602,12 +602,12 @@ def after_all(context):
 
 
 def capture_container_as_image(
-    container_name: str, image_name: str, cloud_api: pycloudlib.cloud.BaseCloud
+    container_id: str, image_name: str, cloud_api: pycloudlib.cloud.BaseCloud
 ) -> str:
     """Capture a container as an image.
 
-    :param container_name:
-        The name of the container to be captured.  Note that this container
+    :param container_id:
+        The id of the container to be captured.  Note that this container
         will be stopped.
     :param image_name:
         The name under which the image should be published.
@@ -615,9 +615,9 @@ def capture_container_as_image(
         machine_types.
     """
     logging.info(
-        "--- Creating  base image snapshot from vm {}".format(container_name)
+        "--- Creating  base image snapshot from vm {}".format(container_id)
     )
-    inst = cloud_api.get_instance(container_name)
+    inst = cloud_api.get_instance(container_id)
     return cloud_api.snapshot(instance=inst)
 
 
@@ -742,10 +742,10 @@ def create_instance_with_uat_installed(
         user_data=user_data,
         ephemeral=context.config.ephemeral_instance,
     )
-    instance_name = context.config.cloud_manager.get_instance_id(inst)
+    instance_id = context.config.cloud_manager.get_instance_id(inst)
 
     _install_uat_in_container(
-        instance_name,
+        instance_id,
         series=series,
         config=context.config,
         machine_type=context.config.machine_type,
@@ -756,7 +756,7 @@ def create_instance_with_uat_installed(
 
 
 def _install_uat_in_container(
-    container_name: str,
+    container_id: str,
     series: str,
     config: UAClientBehaveConfig,
     machine_type: str,
@@ -764,8 +764,8 @@ def _install_uat_in_container(
 ) -> None:
     """Install ubuntu-advantage-tools into the specified container
 
-    :param container_name:
-        The name of the container into which ubuntu-advantage-tools should be
+    :param container_id:
+        The id of the container into which ubuntu-advantage-tools should be
         installed.
     :param series: The name of the series that is being used
     :param config: UAClientBehaveConfig
@@ -780,7 +780,7 @@ def _install_uat_in_container(
         cmds.append(["sudo", "apt-get", "update", "-qqy"])
 
         deb_files = []
-        inst = config.cloud_api.get_instance(container_name)
+        inst = config.cloud_api.get_instance(container_id)
 
         for deb_file in deb_paths:
             if "pro" in deb_file and "pro" not in config.machine_type:
@@ -841,7 +841,7 @@ def _install_uat_in_container(
         cmds.append("sudo ua detach --assume-yes")
 
     cmds.append(["ua", "version"])
-    instance = config.cloud_api.get_instance(container_name)
+    instance = config.cloud_api.get_instance(container_id)
     for cmd in cmds:  # type: ignore
         result = instance.execute(cmd)
         if result.failed:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -67,18 +67,22 @@ def given_a_machine(context, series):
                 build_container_name = add_test_name_suffix(
                     context, series, IMAGE_BUILD_PREFIX
                 )
-                image_name = add_test_name_suffix(
-                    context, series, IMAGE_PREFIX
-                )
                 image_inst = create_instance_with_uat_installed(
                     context, series, build_container_name
                 )
-                image_name = capture_container_as_image(
-                    build_container_name,
+
+                image_name = add_test_name_suffix(
+                    context, series, IMAGE_PREFIX
+                )
+                image_inst_id = context.config.cloud_manager.get_instance_id(
+                    image_inst
+                )
+                image_id = capture_container_as_image(
+                    image_inst_id,
                     image_name=image_name,
                     cloud_api=context.config.cloud_api,
                 )
-                context.series_image_name[series] = image_name
+                context.series_image_name[series] = image_id
                 image_inst.delete(wait=False)
 
         inst = context.config.cloud_manager.launch(


### PR DESCRIPTION
## Notes
The main thing here is fixing a bug I introduced in #1751. I had just used the instance name instead of calling `cloud_manager.get_instance_id` which returns the instance id for some platforms. We now are correctly using the result of `get_instance_id`.

I also changed some parameter names to be called `id` instead of `name` to match the name of `get_instance_id`

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
tests: use correct instance ids for snapshots
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run a test on each platform with `UACLIENT_BEHAVE_SNAPSHOT_STRATEGY=1`

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
