### PR TITLE
Revert "tests: allow snapshot images to be ephemeral"

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -737,10 +737,7 @@ def create_instance_with_uat_installed(
                 ppa_url=ppa, ppa_keyid=ppa_keyid
             )
     inst = context.config.cloud_manager.launch(
-        instance_name=name,
-        series=series,
-        user_data=user_data,
-        ephemeral=context.config.ephemeral_instance,
+        instance_name=name, series=series, user_data=user_data
     )
     instance_name = context.config.cloud_manager.get_instance_id(inst)
 

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@4fb989489541cbf20119ccf20eab1e3cb70f07c3
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@dd27b604137cc5a20fb54e233ecb6a028b3d6891
 
 
 # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
This reverts commit ec7a0e65e2c0e014932ecb7ec95ab5be41343bca.

lxd xenial tests are now stuck because of this commit. We are reverting it now until we can figure out why this is happening