### PR TITLE
fips: block enabling on focal clouds (SC-385)

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -185,7 +185,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
            | release | fips_status |lp_status | lp_desc                       |
            | xenial  | disabled    |enabled   | Canonical Livepatch service   |
            | bionic  | disabled    |enabled   | Canonical Livepatch service   |
-           | focal   | disabled    |enabled   | Canonical Livepatch service   |
+           | focal   | n/a         |enabled   | Canonical Livepatch service   |
 
     @series.all
     @uses.config.machine_type.azure.generic
@@ -218,7 +218,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
            | release | lp_status | fips_status |
            | xenial  | n/a       | n/a         |
            | bionic  | n/a       | disabled    |
-           | focal   | n/a       | disabled    |
+           | focal   | n/a       | n/a         |
 
     @series.all
     @uses.config.machine_type.gcp.generic

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -37,6 +37,39 @@ Feature: FIPS enablement in cloud based machines
            | fips          |
            | fips-updates  |
 
+    @series.focal
+    @uses.config.machine_type.azure.generic
+    Scenario Outline: Refuse to enable FIPS on a Focal Azure vm
+        Given a `focal` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then I verify that running `ua enable <fips_service> --assume-yes` `with sudo` exits `1`
+        And stdout matches regexp:
+        """
+        Ubuntu Focal does not provide an Azure optimized FIPS kernel
+        """
+
+        Examples: fips
+           | fips_service  |
+           | fips          |
+           | fips-updates  |
+
+    @series.focal
+    @uses.config.machine_type.aws.generic
+    Scenario Outline: Refuse to enable FIPS on a Focal AWS vm
+        Given a `focal` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then I verify that running `ua enable <fips_service> --assume-yes` `with sudo` exits `1`
+        And stdout matches regexp:
+        """
+        Ubuntu Focal does not provide an AWS optimized FIPS kernel
+        """
+
+        Examples: fips
+           | fips_service  |
+           | fips          |
+           | fips-updates  |
+
+
     @series.bionic
     @uses.config.machine_type.azure.generic
     Scenario Outline: Enable FIPS in an ubuntu Bionic Azure vm
@@ -122,6 +155,11 @@ Feature: FIPS enablement in cloud based machines
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
+        And I append the following on uaclient config:
+            """
+            features:
+              allow_default_fips_metapackage_on_focal_cloud: true
+            """
         And I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
@@ -352,6 +390,11 @@ Feature: FIPS enablement in cloud based machines
         And I run `ua disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
+        And I append the following on uaclient config:
+            """
+            features:
+              allow_default_fips_metapackage_on_focal_cloud: true
+            """
         And I run `ua enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """


### PR DESCRIPTION
## Proposed Commit Message
fips: block enabling on focal clouds

There is no cloud optimized FIPS kernel for focal clouds yet.
Because of that, we are momentarily blocking enabling FIPS on focal
clouds.

## Test Steps
Run the modified integration tests for fips on focal clouds

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
