### PR TITLE
Change `setup_logging` and the timer logger (SC-370)

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -434,7 +434,8 @@ Feature: Command behaviour when attached to an UA subscription
         update_status_timer     +43200
         gcp_auto_attach_timer   +0
         """
-        And I verify that running `grep "Disabling gcp_auto_attach job" /var/log/ubuntu-advantage.log` `with sudo` exits `0`
+        And I verify that running `grep "Disabling gcp_auto_attach job" /var/log/ubuntu-advantage-timer.log` `with sudo` exits `0`
+        And I verify that running `grep "Disabling gcp_auto_attach job" /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         When I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
         And I run `ua config set update_messaging_timer=0` with sudo
         And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
@@ -494,18 +495,9 @@ Feature: Command behaviour when attached to an UA subscription
           metering_timer: 0
         """
         And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
-        Then stderr matches regexp:
-        """
-        Invalid value for update_messaging interval found in config.
-        """
-        And stderr matches regexp:
-        """
-        Invalid value for update_status interval found in config.
-        """
-        And stderr does not match regexp:
-        """
-        Invalid value for gcp_auto_attach interval found in config.
-        """
+        Then I verify that running `grep "Invalid value for update_messaging interval found in config." /var/log/ubuntu-advantage-timer.log` `with sudo` exits `0`
+        And I verify that running `grep "Invalid value for update_status interval found in config." /var/log/ubuntu-advantage-timer.log` `with sudo` exits `0`
+        And I verify that running `grep "Invalid value for gcp_auto_attach interval found in config." /var/log/ubuntu-advantage-timer.log` `with sudo` exits `1`
         And I verify that the timer interval for `update_messaging` is `21600`
         And I verify that the timer interval for `update_status` is `43200`
         And I verify that the timer interval for `gcp_auto_attach` is `0`

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -415,7 +415,7 @@ Feature: Command behaviour when attached to an UA subscription
         Then I verify that running `ua config set update_messaging_timer=-2` `with sudo` exits `1`
         And stderr matches regexp:
         """
-        <value> for interval must be a positive integer.
+        Cannot set update_messaging_timer to -2: <value> for interval must be a positive integer.
         """
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         And I run `cat /var/lib/ubuntu-advantage/jobs-status.json` with sudo

--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -24,7 +24,6 @@ from uaclient.cli import setup_logging
 
 def patch_status_json_schema_0_1(status_file: str):
     """Patch incompatible status.json file schema to align with version 0.1."""
-    setup_logging(logging.INFO, logging.DEBUG)
     content = util.load_file(status_file)
     try:
         status = json.loads(content, cls=util.DatetimeAwareJSONDecoder)
@@ -65,6 +64,7 @@ def patch_status_json_schema_0_1(status_file: str):
 
 
 if __name__ == "__main__":
+    setup_logging(logging.INFO, logging.DEBUG)
     patch_status_json_schema_0_1(
         status_file="/var/lib/ubuntu-advantage/status.json"
     )

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -105,7 +105,6 @@ def process_remaining_deltas(cfg):
 @assert_lock_file("ua-reboot-cmds")
 def process_reboot_operations(cfg):
 
-    setup_logging(logging.INFO, logging.DEBUG)
     reboot_cmd_marker_file = cfg.data_path("marker-reboot-cmds")
 
     if not cfg.is_attached:
@@ -159,4 +158,5 @@ def main(cfg):
 
 if __name__ == "__main__":
     cfg = config.UAConfig()
+    setup_logging(logging.INFO, logging.DEBUG, log_file=cfg.log_file)
     main(cfg=cfg)

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -47,7 +47,7 @@ class TimedJob:
             if self._job_func(cfg=cfg):
                 LOG.debug("Executed job: %s", self.name)
         except Exception as e:
-            LOG.warning("Error executing job %s: %s", self.name, str(e))
+            LOG.error("Error executing job %s: %s", self.name, str(e))
             return False
 
         return True
@@ -110,5 +110,17 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
 if __name__ == "__main__":
     cfg = UAConfig()
     current_time = datetime.utcnow()
-    setup_logging(logging.INFO, logging.DEBUG)
+
+    # The ua-timer logger should log everything to its file
+    setup_logging(
+        logging.CRITICAL,
+        logging.DEBUG,
+        log_file=cfg.timer_log_file,
+        logger=LOG,
+    )
+    # Make sure the ua-timer logger does not generate double logging
+    LOG.propagate = False
+    # The root logger should log any error to the timer log file
+    setup_logging(logging.CRITICAL, logging.ERROR, log_file=cfg.timer_log_file)
+
     run_jobs(cfg=cfg, current_time=current_time)

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -46,7 +46,6 @@ current_codename_to_past_codename = {
 
 
 def process_contract_delta_after_apt_lock() -> None:
-    setup_logging(logging.INFO, logging.DEBUG)
     logging.debug("Check whether to upgrade-lts-contract")
     if not UAConfig().is_attached:
         logging.debug("Skiping upgrade-lts-contract. Machine is unattached")
@@ -96,4 +95,5 @@ def process_contract_delta_after_apt_lock() -> None:
 
 
 if __name__ == "__main__":
+    setup_logging(logging.INFO, logging.DEBUG)
     process_contract_delta_after_apt_lock()

--- a/systemd/ua-timer.service
+++ b/systemd/ua-timer.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Ubuntu Advantage Timer for running repeated jobs
 After=network.target network-online.target systemd-networkd.service ua-auto-attach.service
-Wants=ua-auto-attach.service
 
 [Service]
 Type=oneshot

--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -4,6 +4,7 @@ data_dir: /var/tmp/uaclient
 log_file: ubuntu-advantage-devel.log
 log_level: debug
 security_url: https://ubuntu.com/security
+timer_log_file: ubuntu-advantage-timer-devel.log
 ua_config:
   apt_http_proxy: null
   apt_https_proxy: null

--- a/uaclient.conf
+++ b/uaclient.conf
@@ -7,6 +7,7 @@ data_dir: /var/lib/ubuntu-advantage
 log_file: /var/log/ubuntu-advantage.log
 log_level: debug
 security_url: https://ubuntu.com/security
+timer_log_file: /var/log/ubuntu-advantage-timer.log
 ua_config:
   apt_http_proxy: null
   apt_https_proxy: null

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -682,8 +682,13 @@ def action_config_set(args, *, cfg, **kwargs):
                 raise ValueError("Invalid interval for {}".format(set_key))
         except ValueError:
             subparser.print_help()
+            # More readable in the CLI, without breaking the line in the logs
+            print("")
             raise exceptions.UserFacingError(
-                "\n<value> for interval must be a positive integer."
+                (
+                    "Cannot set {} to {}: "
+                    "<value> for interval must be a positive integer."
+                ).format(set_key, set_value)
             )
     setattr(cfg, set_key, set_value)
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1223,17 +1223,19 @@ def action_help(args, *, cfg):
     return 0
 
 
-def setup_logging(console_level, log_level, log_file=None):
+def setup_logging(console_level, log_level, log_file=None, logger=None):
     """Setup console logging and debug logging to log_file"""
     if log_file is None:
         log_file = config.CONFIG_DEFAULTS["log_file"]
     console_formatter = util.LogFormatter()
     log_formatter = logging.Formatter(DEFAULT_LOG_FORMAT)
-    root = logging.getLogger()
-    root.setLevel(log_level)
+    if logger is None:
+        # Then we configure the root logger
+        logger = logging.getLogger()
+    logger.setLevel(log_level)
     # Setup console logging
     stderr_found = False
-    for handler in root.handlers:
+    for handler in logger.handlers:
         if hasattr(handler, "stream") and hasattr(handler.stream, "name"):
             if handler.stream.name == "<stderr>":
                 handler.setLevel(console_level)
@@ -1246,7 +1248,7 @@ def setup_logging(console_level, log_level, log_file=None):
         console.setFormatter(console_formatter)
         console.setLevel(console_level)
         console.set_name("console")  # Used to disable console logging
-        root.addHandler(console)
+        logger.addHandler(console)
     if os.getuid() == 0:
         # Setup readable-by-root-only debug file logging if running as root
         log_file_path = pathlib.Path(log_file)
@@ -1256,7 +1258,7 @@ def setup_logging(console_level, log_level, log_file=None):
         filehandler = logging.FileHandler(log_file)
         filehandler.setLevel(log_level)
         filehandler.setFormatter(log_formatter)
-        root.addHandler(filehandler)
+        logger.addHandler(filehandler)
 
 
 def main_error_handler(func):

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -79,6 +79,7 @@ VALID_UA_CONFIG_KEYS = (
     "log_level",
     "security_url",
     "settings_overrides",
+    "timer_log_file",
     "ua_config",
 )
 
@@ -305,6 +306,12 @@ class UAConfig:
     @property
     def log_file(self):
         return self.cfg.get("log_file", CONFIG_DEFAULTS["log_file"])
+
+    @property
+    def timer_log_file(self):
+        return self.cfg.get(
+            "timer_log_file", CONFIG_DEFAULTS["timer_log_file"]
+        )
 
     @property
     def entitlements(self):
@@ -887,7 +894,13 @@ class UAConfig:
         if "log_level" not in cfg_dict:
             cfg_dict["log_level"] = CONFIG_DEFAULTS["log_level"]
         # Ensure defaults are present in uaclient.conf if absent
-        for attr in ("contract_url", "security_url", "data_dir", "log_file"):
+        for attr in (
+            "contract_url",
+            "security_url",
+            "data_dir",
+            "log_file",
+            "timer_log_file",
+        ):
             cfg_dict[attr] = getattr(self, attr)
 
         # Each UA_CONFIGURABLE_KEY needs to have a property on UAConfig

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -77,8 +77,9 @@ def logging_sandbox():
 @pytest.fixture
 def FakeConfig(tmpdir):
     class _FakeConfig(UAConfig):
-        def __init__(self, features_override=None) -> None:
-            super().__init__({"data_dir": tmpdir.strpath})
+        def __init__(self, cfg_overrides={}, features_override=None) -> None:
+            cfg_overrides.update({"data_dir": tmpdir.strpath})
+            super().__init__(cfg_overrides)
 
         @classmethod
         def for_attached_machine(

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -29,11 +29,13 @@ CONFIG_DEFAULTS = {
     "data_dir": DEFAULT_DATA_DIR,
     "log_level": "INFO",
     "log_file": "/var/log/ubuntu-advantage.log",
+    "timer_log_file": "/var/log/ubuntu-advantage-timer.log",
 }
 
 CONFIG_FIELD_ENVVAR_ALLOWLIST = [
     "ua_data_dir",
     "ua_log_file",
+    "ua_timer_log_file",
     "ua_log_level",
     "ua_security_url",
 ]

--- a/uaclient/jobs/gcp_auto_attach.py
+++ b/uaclient/jobs/gcp_auto_attach.py
@@ -5,7 +5,7 @@ if the instance has a new UA license attached to it
 import logging
 
 from uaclient import config, exceptions
-from uaclient.cli import action_auto_attach
+from uaclient.cli import action_auto_attach, setup_logging
 from uaclient.clouds.gcp import GCP_LICENSES, UAAutoAttachGCPInstance
 from uaclient.clouds.identity import get_cloud_type
 from uaclient.util import get_platform_info
@@ -14,6 +14,12 @@ LOG = logging.getLogger(__name__)
 
 
 def gcp_auto_attach(cfg: config.UAConfig) -> bool:
+    setup_logging(
+        logging.CRITICAL,
+        logging.DEBUG,
+        log_file=cfg.timer_log_file,
+        logger=LOG,
+    )
     # We will not do anything in a non-GCP cloud
     cloud_id, _ = get_cloud_type()
     if not cloud_id or cloud_id != "gce":

--- a/uaclient/jobs/metering.py
+++ b/uaclient/jobs/metering.py
@@ -10,13 +10,13 @@ from uaclient.status import UserFacingStatus
 
 
 @assert_lock_file("timer metering job")
-def metering_enabled_resources(cfg: config.UAConfig) -> None:
+def metering_enabled_resources(cfg: config.UAConfig) -> bool:
     # We only run this job if there is no other job running.
     # The reason for that is to avoid potential conflicts with
     # auto-attach, attach and enable operations.
 
     if not cfg.is_attached:
-        return
+        return False
 
     enabled_services = [
         ent(cfg).name
@@ -26,3 +26,4 @@ def metering_enabled_resources(cfg: config.UAConfig) -> None:
 
     contract = UAContractClient(cfg)
     contract.report_machine_activity(enabled_services=enabled_services)
+    return True

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -320,7 +320,7 @@ def write_esm_announcement_message(cfg: config.UAConfig, series: str) -> None:
         util.remove_file(esm_news_file)
 
 
-def update_apt_and_motd_messages(cfg: config.UAConfig) -> None:
+def update_apt_and_motd_messages(cfg: config.UAConfig) -> bool:
     """Emit templates and human-readable status messages in msg_dir.
 
     These structured messages will be sourced by both /etc/update.motd.d
@@ -345,10 +345,11 @@ def update_apt_and_motd_messages(cfg: config.UAConfig) -> None:
             util.remove_file(msg_path)
             if msg_path.endswith(".tmpl"):
                 util.remove_file(msg_path.replace(".tmpl", ""))
-        return
+        return True
 
     # Announce ESM availabilty on active ESM LTS releases
     write_esm_announcement_message(cfg, series)
     write_apt_and_motd_templates(cfg, series)
     # Now that we've setup/cleanedup templates render them with apt-hook
     util.subp(["/usr/lib/ubuntu-advantage/apt-esm-hook", "process-templates"])
+    return True

--- a/uaclient/jobs/update_state.py
+++ b/uaclient/jobs/update_state.py
@@ -5,5 +5,6 @@ Update system state module, like status cache or contract cached files
 from uaclient.config import UAConfig
 
 
-def update_status(cfg: UAConfig):
+def update_status(cfg: UAConfig) -> bool:
     cfg.status()
+    return True

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -231,6 +231,7 @@ data_dir: /var/lib/ubuntu-advantage
 log_file: /var/log/ubuntu-advantage.log
 log_level: debug
 security_url: https://ubuntu.com/security
+timer_log_file: /var/log/ubuntu-advantage-timer.log
 """
 
 CFG_FEATURES_CONTENT = """\
@@ -251,6 +252,7 @@ security_url: https://ubuntu.com/security
 settings_overrides:
   c: 1
   d: 2
+timer_log_file: /var/log/ubuntu-advantage-timer.log
 """
 
 UA_CFG_DICT = {
@@ -1444,6 +1446,7 @@ class TestParseConfig:
             "security_url": "https://ubuntu.com/security",
             "data_dir": "/var/lib/ubuntu-advantage",
             "log_file": "/var/log/ubuntu-advantage.log",
+            "timer_log_file": "/var/log/ubuntu-advantage-timer.log",
             "log_level": "INFO",
         }
         assert expected_default_config == config

--- a/uaclient/tests/test_ua_timer.py
+++ b/uaclient/tests/test_ua_timer.py
@@ -9,18 +9,26 @@ from lib.timer import TimedJob, run_jobs
 
 class TestTimedJob:
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @pytest.mark.parametrize("return_value", (True, False))
     def test_run_job_returns_true_on_successful_job_run(
-        self, FakeConfig, caplog_text
+        self, return_value, caplog_text, FakeConfig
     ):
         """Return True on successful job run."""
         config = FakeConfig()
 
         def success_job(cfg):
             assert cfg == config
+            return return_value
 
         job = TimedJob("day_job", success_job, 14400)
         assert True is job.run(config)
-        assert "Running job: day_job" in caplog_text()
+
+        if return_value:
+            # Job executed
+            assert "Sucessfully executed job: day_job" in caplog_text()
+        else:
+            # Job noops
+            assert "Sucessfully executed job: day_job" not in caplog_text()
 
     @pytest.mark.parametrize("caplog_text", [logging.WARNING], indirect=True)
     def test_run_job_returns_false_on_failed_job(
@@ -36,15 +44,23 @@ class TestTimedJob:
         assert False is job.run(cfg)
         assert "Error executing job day_job: Something broke" in caplog_text()
 
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
     @pytest.mark.parametrize("is_cfg_set", (False, True))
-    def test_get_default_run_interval(self, is_cfg_set, FakeConfig):
+    def test_get_default_run_interval(
+        self, is_cfg_set, caplog_text, FakeConfig
+    ):
         """Use the default run interval when config is absent or invalid."""
         cfg = FakeConfig()
         if is_cfg_set:
-            setattr(cfg, "day_job_timer", None)
+            setattr(cfg, "day_job_timer", -3)
         job = TimedJob("day_job", lambda: None, 14400)
 
         assert 14400 == job.run_interval_seconds(cfg)
+        if is_cfg_set:
+            assert (
+                "Invalid value for day_job interval found in config."
+                in caplog_text()
+            )
 
     def test_get_configured_run_interval(self, FakeConfig):
         """Use the configured run interval when not overriden."""

--- a/uaclient/tests/test_ua_timer.py
+++ b/uaclient/tests/test_ua_timer.py
@@ -25,10 +25,10 @@ class TestTimedJob:
 
         if return_value:
             # Job executed
-            assert "Sucessfully executed job: day_job" in caplog_text()
+            assert "Executed job: day_job" in caplog_text()
         else:
             # Job noops
-            assert "Sucessfully executed job: day_job" not in caplog_text()
+            assert "Executed job: day_job" not in caplog_text()
 
     @pytest.mark.parametrize("caplog_text", [logging.WARNING], indirect=True)
     def test_run_job_returns_false_on_failed_job(

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -202,7 +202,7 @@ def disable_log_to_console():
     potential_handlers = [
         handler
         for handler in logging.getLogger().handlers
-        if handler.name == "console"
+        if handler.name == "ua-console"
     ]
     if not potential_handlers:
         # We didn't find a handler, so execute the body as normal then end

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -147,6 +147,10 @@ The logging level used when writing to \fBlog_file\fP
 .B
 \fBlog_file\fP
 The log file for the Ubuntu Advantage client
+.TP
+.B
+\fBtimer_log_file\fP
+The log file for the Ubuntu Advantage timer and timer jobs
 
 .P
 \fBThe following options must be nested under the "ua_config" key:\fP
@@ -189,7 +193,8 @@ username and password in the URL itself, as in:
 Additionally, some configuration options can be overridden in the environment
 by setting an environment variable prefaced by \fBUA_<option_name>\fP. Both
 uppercase and lowercase environment variables are allowed. The configuration
-options that support this are: data_dir, log_file, log_level, and security_url.
+options that support this are: data_dir, log_file, timer_log_file, log_level,
+and security_url.
 
 For example, the following overrides the log_level found in uaclient.conf:
 .PP


### PR DESCRIPTION
This PR changes the way we set up the logging, so we have better control of our handlers, and uses that change to make the timer and the timer jobs run without logging everything they see.

The `setup_logging` function now accepts a `logger` parameter, so we can configure any logger instance, and not just the root logger. It gives us control to configure module based loggers.
Also, it will wipe out existing handlers, and add the uaclient handlers (for console and log file), ensuring we have a single instance of each handler every time the loggers are configured / reconfigured. For this to work, it's important that setup_logging is inside our main entrypoints (CLI and the `lib/` scripts). When importing anything from our modules, the root logger will not be changed by default.
`lib/timer.py` will then have its own logger configured, which will not propagate to the root logger. Any message triggered by the timer will have to come from the local one.

As a curious side-effect:
Fixes: #553

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
 