### PR TITLE
tests: fix integration test script wip scenarios

### DIFF
--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -88,7 +88,7 @@ def build_commands(
 
                 # Wip
                 if wip:
-                    command.extend(["--tags='wip'", "--stop"])
+                    command.extend(["--", "--tags=wip", "--stop"])
 
                 commands.append((command, env))
 


### PR DESCRIPTION
Fix the command line for running the `@wip` tests in the test script.

## Test Steps
Pass `-w` to `tools/run-integration-tests.py` and verify it does run the tests.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
