### PR TITLE
proxy: better handle port errors (SC-387)

### DIFF
--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -93,6 +93,11 @@ Feature: Proxy configuration
         """
         "invalidurl" is not a valid url. Not setting as proxy.
         """
+        When I verify that running `ua config set http_proxy=http://host:port` `with sudo` exits `1`
+        Then stderr matches regexp:
+        """
+        "http://host:port" is not a valid url. Not setting as proxy
+        """
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         ua_config:

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -596,7 +596,13 @@ class TestGetMachineId:
 class TestIsServiceUrl:
     @pytest.mark.parametrize(
         "url,is_valid",
-        (("http://asdf", True), ("http://asdf/", True), ("asdf", False)),
+        (
+            ("http://asdf", True),
+            ("http://asdf/", True),
+            ("asdf", False),
+            ("http://host:port", False),
+            ("http://asdf:1234", True),
+        ),
     )
     def test_is_valid_url(self, url, is_valid):
         ret = util.is_service_url(url)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -408,8 +408,15 @@ def is_service_url(url: str) -> bool:
         parsed_url = urlparse(url)
     except ValueError:
         return False
+
     if parsed_url.scheme not in ("https", "http"):
         return False
+
+    try:
+        parsed_url.port
+    except ValueError:
+        return False
+
     return True
 
 


### PR DESCRIPTION
## Proposed Commit Message
proxy: better handle port errors

We are showing a better error message when an user tries to set up a proxy wih an invalid port

## Test Steps
Run the modified integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
