### PR TITLE
proof of concept: daemon to long poll gcp metadata

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -56,13 +56,10 @@ override_dh_systemd_enable:
 	dh_systemd_enable -pubuntu-advantage-tools ua-reboot-cmds.service
 	dh_systemd_enable -pubuntu-advantage-tools ua-timer.timer
 	dh_systemd_enable -pubuntu-advantage-tools ua-timer.service
-	dh_systemd_enable -pubuntu-advantage-tools ua-license-check.timer
-	dh_systemd_enable -pubuntu-advantage-tools ua-license-check.service
-	dh_systemd_enable -pubuntu-advantage-tools ua-license-check.path
+	dh_systemd_enable -pubuntu-advantage-tools ua-daemon.service
 
 override_dh_systemd_start:
 	dh_systemd_start -pubuntu-advantage-tools ua-timer.timer
-	dh_systemd_start -pubuntu-advantage-tools ua-license-check.path
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -1,0 +1,44 @@
+import datetime
+import logging
+import sys
+import threading
+
+from uaclient import util
+from uaclient.cli import setup_logging
+from uaclient.clouds.identity import get_cloud_type
+
+
+def gcp_auto_attach():
+    # just a for loop in case I mess up, it'll only do whatever mistake 100 times
+    for _i in range(100):
+        now = datetime.datetime.now()
+        logging.info("Requesting metadata at {}".format(now))
+        try:
+            result = util.readurl(
+                "http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true&wait_for_change=true",
+                headers={"Metadata-Flavor": "Google"},
+            )
+            logging.info(result)
+        except Exception as e:
+            logging.exception(e)
+
+
+def main():
+    cloud, _none_reason = get_cloud_type()
+    threads = []
+    if cloud == "gce":
+        thread = threading.Thread(target=gcp_auto_attach)
+        thread.start()
+        threads.append(thread)
+
+    # maybe do other stuff in other threads one day
+
+    for thread in threads:
+        thread.join()
+
+    return 0
+
+
+if __name__ == "__main__":
+    setup_logging(logging.DEBUG, logging.DEBUG)
+    sys.exit(main())

--- a/systemd/ua-daemon.service
+++ b/systemd/ua-daemon.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=The simplest daemon
+
+[Service]
+Type=simple 
+ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/daemon.py
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Don't merge this.

This was a quick proof of concept to explore what a daemon to long poll for gcp license changes might look like. It isn't fully fleshed out.

This actually long polls for instance metadata keyvalue changes (not licenses). You can test it by:
1. installing this on a fresh gcp instance
2. `systemctl start ua-daemon`
3. `tail -f /var/log/ubuntu-advantage.log`
4. in the gcp console (or via cli) edit the instance metadata keyvalue pairs
5. see the updated metadata and a new request started in the log
6. repeat 4-5 as much as desired

I think the thing that pushes this into "next cycle" territory though is that AFAIK gcp doesn't support changing licenses without a stop-start yet. Until they do, this wouldn't be functional and we won't be able to test this.