### PR TITLE
timer: adjust interval values for gcp_auto_attach and metering (SC-390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Current jobs being checked and executed are:
 | --- | ----------- | -------- |
 | update_messaging | Update MOTD and APT messages | 6 hours |
 | update_status | Update UA status | 12 hours |
-| gcp_auto_attach | Try to auto-attach on a GCP instance | 30 minutes |
+| gcp_auto_attach | Try to auto-attach on a GCP instance | 5 minutes |
 
 - The `update_messaging` job makes sure that the MOTD and APT messages match the
 available/enabled services on the system, showing information about available

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -251,7 +251,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         update_messaging_timer  +21600
         update_status_timer     +43200
-        gcp_auto_attach_timer   +1800
+        gcp_auto_attach_timer   +300
         metering_timer          +0
         """
 

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -21,9 +21,6 @@ Feature: Proxy configuration
         ua_config:
           http_proxy: http://<ci-proxy-ip>:3128
           https_proxy: http://<ci-proxy-ip>:3128
-          update_messaging_timer: 21600
-          update_status_timer: 43200
-          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I attach `contract_token` with sudo
@@ -42,9 +39,6 @@ Feature: Proxy configuration
         ua_config:
           apt_http_proxy: http://<ci-proxy-ip>:3128
           apt_https_proxy: http://<ci-proxy-ip>:3128
-          update_messaging_timer: 21600
-          update_status_timer: 43200
-          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         Then I verify that no files exist matching `/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy`
@@ -84,9 +78,6 @@ Feature: Proxy configuration
         ua_config:
             apt_http_proxy: "invalidurl"
             apt_https_proxy: "invalidurls"
-            update_messaging_timer: 21600
-            update_status_timer: 43200
-            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -97,9 +88,6 @@ Feature: Proxy configuration
         """
         ua_config:
             apt_https_proxy: "https://localhost:12345"
-            update_messaging_timer: 21600
-            update_status_timer: 43200
-            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -184,9 +172,6 @@ Feature: Proxy configuration
         ua_config:
             http_proxy: ""
             https_proxy: ""
-            update_messaging_timer: 21600
-            update_status_timer: 43200
-            gcp_auto_attach_timer: 1800
         """
         And I run `ua refresh config` with sudo
         Then I will see the following on stdout:
@@ -201,9 +186,6 @@ Feature: Proxy configuration
         ua_config:
             http_proxy: "invalidurl"
             https_proxy: "invalidurls"
-            update_messaging_timer: 21600
-            update_status_timer: 43200
-            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -214,9 +196,6 @@ Feature: Proxy configuration
         """
         ua_config:
             https_proxy: "https://localhost:12345"
-            update_messaging_timer: 21600
-            update_status_timer: 43200
-            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:
@@ -250,9 +229,6 @@ Feature: Proxy configuration
         ua_config:
           http_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
           https_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
-          update_messaging_timer: 21600
-          update_status_timer: 43200
-          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I attach `contract_token` with sudo
@@ -271,9 +247,6 @@ Feature: Proxy configuration
         ua_config:
           apt_http_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
           apt_https_proxy: http://someuser:somepassword@<ci-proxy-ip>:3128
-          update_messaging_timer: 21600
-          update_status_timer: 43200
-          gcp_auto_attach_timer: 1800
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `ua refresh config` with sudo
@@ -287,9 +260,6 @@ Feature: Proxy configuration
         """
         ua_config:
             apt_https_proxy: http://wronguser:wrongpassword@<ci-proxy-ip>:3128
-            update_messaging_timer: 21600
-            update_status_timer: 43200
-            gcp_auto_attach_timer: 1800
         """
         And I verify that running `ua refresh config` `with sudo` exits `1`
         Then stderr matches regexp:

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -16,8 +16,8 @@ from uaclient.jobs.update_state import update_status
 LOG = logging.getLogger(__name__)
 UPDATE_MESSAGING_INTERVAL = 21600  # 6 hours
 UPDATE_STATUS_INTERVAL = 43200  # 12 hours
-GCP_AUTO_ATTACH_INTERVAL = 1800  # 30 minutes
-METERING_INTERVAL = 14400  # 4 hours
+GCP_AUTO_ATTACH_INTERVAL = 300  # 5 minutes
+METERING_INTERVAL = 0  # 4 hours in the future, disabled as of now
 
 
 class TimedJob:

--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -11,4 +11,5 @@ ua_config:
   https_proxy: null
   update_messaging_timer: 21600
   update_status_timer: 43200
-  gcp_auto_attach_timer: 1800
+  gcp_auto_attach_timer: 300
+  metering_timer: 0

--- a/uaclient.conf
+++ b/uaclient.conf
@@ -14,5 +14,5 @@ ua_config:
   https_proxy: null
   update_messaging_timer: 21600
   update_status_timer: 43200
-  gcp_auto_attach_timer: 1800
+  gcp_auto_attach_timer: 300
   metering_timer: 0

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1366,7 +1366,7 @@ class TestProcessConfig:
                     "https_proxy": https_proxy,
                     "update_messaging_timer": 21600,
                     "update_status_timer": 43200,
-                    "gcp_auto_attach_timer": 1800,
+                    "gcp_auto_attach_timer": 300,
                     "metering_timer": 0,
                 }
             }
@@ -1415,7 +1415,7 @@ class TestProcessConfig:
                 "ua_config": {
                     "update_messaging_timer": "wrong",
                     "update_status_timer": 43200,
-                    "gcp_auto_attach_timer": 1800,
+                    "gcp_auto_attach_timer": 300,
                 }
             }
         )


### PR DESCRIPTION
Metering should be disabled,
GCP auto attach should be 5 minutes.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages


## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
(this is the first PR where I checked all 3 of those I guess hahaha)