### PR TITLE
timer: check for GCP PRO License before trying to auto attach (SC-389)

### DIFF
--- a/sru/release-27.3/gcp_auto_attach_test.sh
+++ b/sru/release-27.3/gcp_auto_attach_test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+ZONE="us-east1-b"
+INSTANCE_NAME="test-auto-attach"
+INSTANCE_TYPE="n1-standard-1"
+DISK_NAME="persistent-disk-0"
+
+set -x
+
+gcloud compute instances create $INSTANCE_NAME \
+    --image="ubuntu-minimal-1604-xenial-v20210430" \
+    --image-project="ubuntu-os-cloud" \
+    --machine-type=$INSTANCE_TYPE \
+    --zone=$ZONE
+sleep 30
+
+gcloud compute ssh $INSTANCE_NAME -- "sudo apt install software-properties-common -y"
+gcloud compute scp ubuntu-advantage-tools.deb $INSTANCE_NAME:/tmp/
+gcloud compute ssh $INSTANCE_NAME -- "sudo apt update"
+gcloud compute ssh $INSTANCE_NAME -- "sudo apt install ubuntu-advantage-tools -y"
+gcloud compute ssh $INSTANCE_NAME -- "sudo dpkg -i /tmp/ubuntu-advantage-tools.deb"
+gcloud compute ssh $INSTANCE_NAME -- "sudo sh -c \"printf \\\"    else:\n        print('pro license not present')\\\" >>  /usr/lib/python3/dist-packages/uaclient/jobs/gcp_auto_attach.py\""
+# Without the license, it will not try to auto_attach
+gcloud compute ssh $INSTANCE_NAME -- "sudo rm /var/lib/ubuntu-advantage/jobs-status.json"
+gcloud compute ssh $INSTANCE_NAME -- "sudo python3 /usr/lib/ubuntu-advantage/timer.py"
+gcloud compute ssh $INSTANCE_NAME -- "sudo ua status --wait"
+
+gcloud compute instances stop $INSTANCE_NAME
+gcloud beta compute disks update $INSTANCE_NAME --zone=$ZONE --update-user-licenses="https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-1604-lts"
+gcloud compute instances start $INSTANCE_NAME
+sleep 30
+
+# Now with the license, it will succeed auto_attaching
+gcloud compute ssh $INSTANCE_NAME -- "sudo rm /var/lib/ubuntu-advantage/jobs-status.json"
+gcloud compute ssh $INSTANCE_NAME -- "sudo python3 /usr/lib/ubuntu-advantage/timer.py"
+gcloud compute ssh $INSTANCE_NAME -- "sudo ua status --wait"
+gcloud compute ssh $INSTANCE_NAME -- "sudo ua detach --assume-yes"
+
+gcloud compute instances delete $INSTANCE_NAME

--- a/uaclient/jobs/tests/test_gcp_auto_attach.py
+++ b/uaclient/jobs/tests/test_gcp_auto_attach.py
@@ -4,9 +4,16 @@ import mock
 import pytest
 
 from uaclient.exceptions import NonAutoAttachImageError
-from uaclient.jobs.gcp_auto_attach import gcp_auto_attach
+from uaclient.jobs.gcp_auto_attach import (
+    UAAutoAttachGCPInstance,
+    gcp_auto_attach,
+)
 
 
+@mock.patch(
+    "uaclient.jobs.gcp_auto_attach.GCP_LICENSES",
+    {"ubuntu-lts": "test-license-id"},
+)
 class TestGCPAutoAttachJob:
     @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
     @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
@@ -23,11 +30,22 @@ class TestGCPAutoAttachJob:
         "cloud_type", (("gce"), ("azure"), ("aws"), (None))
     )
     @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch.object(UAAutoAttachGCPInstance, "get_licenses_from_identity")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_platform_info")
     @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
     def test_gcp_auto_attach(
-        self, m_auto_attach, m_cloud_type, cloud_type, caplog_text, FakeConfig
+        self,
+        m_auto_attach,
+        m_platform_info,
+        m_get_licenses,
+        m_cloud_type,
+        cloud_type,
+        caplog_text,
+        FakeConfig,
     ):
         m_cloud_type.return_value = (cloud_type, None)
+        m_get_licenses.return_value = ["test-license-id"]
+        m_platform_info.return_value = {"series": "ubuntu-lts"}
         cfg = FakeConfig()
 
         with mock.patch.object(type(cfg), "write_cfg") as m_write:
@@ -41,20 +59,90 @@ class TestGCPAutoAttachJob:
             assert (
                 "Disabling gcp_auto_attach job. Not running on GCP instance"
             ) in caplog_text()
-
         else:
             assert cfg.gcp_auto_attach_timer == 1000
             assert m_write.call_count == 1
             assert m_auto_attach.call_count == 1
 
     @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch.object(UAAutoAttachGCPInstance, "get_licenses_from_identity")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_platform_info")
     @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
     def test_gcp_job_dont_fail_if_non_auto_attach_image_error_is_raised(
-        self, m_auto_attach, m_cloud_type, FakeConfig
+        self,
+        m_auto_attach,
+        m_platform_info,
+        m_get_licenses,
+        m_cloud_type,
+        FakeConfig,
     ):
         m_cloud_type.return_value = ("gce", None)
+        m_get_licenses.return_value = ["test-license-id"]
+        m_platform_info.return_value = {"series": "ubuntu-lts"}
         m_auto_attach.side_effect = NonAutoAttachImageError("error")
         cfg = FakeConfig()
 
         assert gcp_auto_attach(cfg) is None
         assert m_auto_attach.call_count == 1
+
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch.object(UAAutoAttachGCPInstance, "get_licenses_from_identity")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_platform_info")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
+    def test_gcp_job_dont_fail_if_licenses_fail(
+        self,
+        m_auto_attach,
+        m_platform_info,
+        m_get_licenses,
+        m_cloud_type,
+        FakeConfig,
+    ):
+        m_cloud_type.return_value = ("gce", None)
+        m_get_licenses.side_effect = TypeError("error")
+        m_platform_info.return_value = {"series": "ubuntu-lts"}
+        cfg = FakeConfig()
+
+        assert gcp_auto_attach(cfg) is None
+        assert m_auto_attach.call_count == 0
+        assert m_get_licenses.call_count == 1
+
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch.object(UAAutoAttachGCPInstance, "get_licenses_from_identity")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_platform_info")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
+    def test_gcp_auto_attach_license_not_present(
+        self,
+        m_auto_attach,
+        m_platform_info,
+        m_get_licenses,
+        m_cloud_type,
+        FakeConfig,
+    ):
+        m_cloud_type.return_value = ("gce", None)
+        m_get_licenses.return_value = ["unsupported-license"]
+        m_platform_info.return_value = {"series": "ubuntu-lts"}
+        cfg = FakeConfig()
+
+        assert gcp_auto_attach(cfg) is None
+        assert m_auto_attach.call_count == 0
+        assert m_get_licenses.call_count == 1
+
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_cloud_type")
+    @mock.patch.object(UAAutoAttachGCPInstance, "get_licenses_from_identity")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.get_platform_info")
+    @mock.patch("uaclient.jobs.gcp_auto_attach.action_auto_attach")
+    def test_gcp_auto_attach_skips_non_lts(
+        self,
+        m_auto_attach,
+        m_platform_info,
+        m_get_licenses,
+        m_cloud_type,
+        FakeConfig,
+    ):
+        m_cloud_type.return_value = ("gce", None)
+        m_platform_info.return_value = {"series": "ubuntu-non-lts"}
+        cfg = FakeConfig()
+
+        assert gcp_auto_attach(cfg) is None
+        assert m_auto_attach.call_count == 0
+        assert m_get_licenses.call_count == 0


### PR DESCRIPTION
Only try to auto attach if the PRO license is detected in the instance metadata.

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
