### PR TITLE
fips: fix focal cloud block on PRO instances

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -148,7 +148,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 config=self.cfg.cfg, path_to_value=cfg_path
             ):
                 return True
-            return "ubuntu-{}-fips".format(cloud_id) in super().packages
+            return False
 
         if cloud_id not in ("azure", "gce"):
             return True

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -700,34 +700,24 @@ class TestFIPSEntitlementEnable:
             assert actual_value
 
     @pytest.mark.parametrize(
-        "additional_pkgs",
-        (("ubuntu-fips"), ("ubuntu-aws-fips"), ("ubuntu-azure-fips")),
-    )
-    @pytest.mark.parametrize(
         "cfg_fips_metapkg_on_focal_cloud", ((True), (False))
     )
     @pytest.mark.parametrize("cloud_id", (("azure"), ("aws")))
     @mock.patch("uaclient.util.is_config_value_true")
-    def test_prevent_enabling_fips_on_cloud(
+    def test_prevent_enabling_fips_on_focal_cloud(
         self,
         m_is_config_value,
         cloud_id,
         cfg_fips_metapkg_on_focal_cloud,
-        additional_pkgs,
-        fips_entitlement_factory,
+        entitlement,
     ):
         series = "focal"
         m_is_config_value.return_value = cfg_fips_metapkg_on_focal_cloud
-        entitlement = fips_entitlement_factory(
-            additional_packages=additional_pkgs
-        )
         actual_value = entitlement._allow_fips_on_cloud_instance(
             series=series, cloud_id=cloud_id
         )
 
         if cfg_fips_metapkg_on_focal_cloud:
-            assert actual_value
-        elif cloud_id in additional_pkgs:
             assert actual_value
         else:
             assert not actual_value


### PR DESCRIPTION
## Proposed Commit Message
fips: fix focal cloud block on PRO instances

On PRO instances, the contract does return the cloud specific fips metadata to be installed. However, this package doesn't exist
yet and the check we are performing for the PRO instances is not taking that into consideration. We are updating the logic to properly handle the PRO instances

## Test Steps
1. Launch a focal PRO machine with the proposed changes
2. Try to enable fips on it and verify that it outputting the correct message stating why fips can't be enabled

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
