### PR TITLE
postinst: remove old ua-messaging.timer services (SC-409)

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -32,6 +32,8 @@ ESM_APPS_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-esm-apps.list"
 FIPS_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-fips.list"
 
 OLD_CLIENT_FIPS_PPA="private-ppa.launchpad.net/ubuntu-advantage/fips/ubuntu"
+OLD_MESSAGING_TIMER="ua-messaging.timer"
+OLD_MESSAGING_TIMER_MASKED_LOCATION="/etc/systemd/system/timers.target.wants/$OLD_MESSAGING_TIMER"
 
 ESM_APT_PREF_FILE_TRUSTY="$APT_PREFERENCES_DIR/ubuntu-esm-trusty"
 ESM_INFRA_OLD_APT_PREF_FILE_TRUSTY="$APT_PREFERENCES_DIR/ubuntu-esm-infra-trusty"
@@ -316,6 +318,18 @@ enable_periodic_license_check() {
     fi
 }
 
+remove_old_systemd_timers() {
+    # These are the commands that are run when the package is purged.
+    # Since we actually want to remove this service from now on
+    # we have replicated that behavior here
+    if [ -L $OLD_MESSAGING_TIMER_MASKED_LOCATION ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+            deb-systemd-helper purge ua-messaging.timer > /dev/null || true
+            deb-systemd-helper unmask ua-messaging.timer > /dev/null || true
+        fi
+    fi
+}
+
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -389,8 +403,8 @@ case "$1" in
         fi
       fi
       mark_reboot_for_fips_pro
-
       enable_periodic_license_check
+      remove_old_systemd_timers
       ;;
 esac
 


### PR DESCRIPTION
## Proposed Commit Message
postinst: remove old ua-messaging.timer services

The postrm script will mask the service `ua-messaging.timer` since it will no longer be delivered by the package. Although this operation will indeed disable the service, we can still see it when running `systemctl list-timers --all`. The reason for that is because the mask operation creates a symlink on `/etc/systemd/system/timer.target.wants/` for this service that points to `/lib/systemd/system/ua-messaging.timer` . We cannot unmask the service, since the unit will not be there anymore, so one way to avoid this service to appear when running `list-timers` is by deleting this symlink and perfoming a `systemctl daemon-reload` operation.

## Test Steps
1. Launch a xenial container
2. Upgrade UA to the daily version
3. Verify that `systemctl list-timers --all`  displays `ua-messaging.timer
4. Launch a new container and upgrade to an UA version if this postinst modifiction
5. Verify that `ua-messaging.timer` no longer appears when running list-timers

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
