### PR TITLE
fix: update return code

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -368,8 +368,21 @@ Feature: Command behaviour when unattached
             """
         And stdout matches regexp:
             """
-            .*\{ apt update && apt install --only-upgrade -y libcurl3-gnutls curl \}.*
+            .*\{ apt update && apt install --only-upgrade -y curl libcurl3-gnutls \}.*
             .*✔.* USN-5079-2 is resolved.
+            """
+        When I verify that running `ua fix USN-5051-2` `with sudo` exits `2`
+        Then stdout matches regexp:
+            """
+            USN-5051-2: OpenSSL vulnerability
+            Found CVEs:
+            https://ubuntu.com/security/CVE-2021-3712
+            1 affected package is installed: openssl
+            \(1/1\) openssl:
+            A fix is available in UA Infra.
+            .*\{ apt update && apt install --only-upgrade -y libssl1.0.0 openssl \}.*
+            A reboot is required to complete fix operation.
+            .*✘.* USN-5051-2 is not resolved.
             """
 
         Examples: ubuntu release details

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -237,7 +237,6 @@ Feature: Command behaviour when unattached
            | focal   |
            | hirsute |
 
-
     @series.focal
     @uses.config.machine_type.lxd.container
     Scenario Outline: Fix command on an unattached machine
@@ -299,7 +298,7 @@ Feature: Command behaviour when unattached
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt install -y libawl-php` with sudo
         And I reboot the `<release>` machine
-        And I run `ua fix USN-4539-1` as non-root
+        And I verify that running `ua fix USN-4539-1` `as non-root` exits `1`
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
@@ -331,7 +330,7 @@ Feature: Command behaviour when unattached
             .*✔.* CVE-2020-28196 is resolved.
             """
         When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza ghostscript` with sudo
-        And I run `ua fix CVE-2017-9233` with sudo
+        And I verify that running `ua fix CVE-2017-9233` `with sudo` exits `1`
         Then stdout matches regexp:
             """
             CVE-2017-9233: Expat vulnerability
@@ -377,7 +376,7 @@ Feature: Command behaviour when unattached
             Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
             """
         When I run `apt install -y libawl-php` with sudo
-        And I run `ua fix USN-4539-1` as non-root
+        And I verify that running `ua fix USN-4539-1` `as non-root` exits `1`
         Then stdout matches regexp:
             """
             USN-4539-1: AWL vulnerability
@@ -401,7 +400,7 @@ Feature: Command behaviour when unattached
             .*✔.* CVE-2020-28196 is resolved.
             """
         When I run `apt-get install xterm=330-1ubuntu2 -y` with sudo
-        And I run `ua fix CVE-2021-27135` as non-root
+        And I verify that running `ua fix CVE-2021-27135` `as non-root` exits `1`
         Then stdout matches regexp:
         """
         CVE-2021-27135: xterm vulnerability

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -293,6 +293,7 @@ Feature: Command behaviour when unattached
            | focal   |
 
     @series.xenial
+    @uses.config.contract_token
     @uses.config.machine_type.lxd.container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -343,6 +344,32 @@ Feature: Command behaviour when unattached
             .*\{ apt update && apt install --only-upgrade -y expat \}.*
             2 packages are still affected: matanza, swish-e
             .*✘.* CVE-2017-9233 is not resolved.
+            """
+        When I fix `USN-5079-2` by attaching to a subscription with `contract_token`
+        Then stdout matches regexp:
+            """
+            USN-5079-2: curl vulnerabilities
+            Found CVEs:
+            https://ubuntu.com/security/CVE-2021-22946
+            https://ubuntu.com/security/CVE-2021-22947
+            1 affected package is installed: curl
+            \(1/1\) curl:
+            A fix is available in UA Infra.
+            The update is not installed because this system is not attached to a
+            subscription.
+
+            Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
+            > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
+            > .*\{ ua attach .*\}.*
+            Updating package lists
+            UA Apps: ESM enabled
+            Updating package lists
+            UA Infra: ESM enabled
+            """
+        And stdout matches regexp:
+            """
+            .*\{ apt update && apt install --only-upgrade -y libcurl3-gnutls curl \}.*
+            .*✔.* USN-5079-2 is resolved.
             """
 
         Examples: ubuntu release details

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -385,7 +385,8 @@ def action_fix(args, *, cfg, **kwargs):
         ).format(args.security_issue)
         raise exceptions.UserFacingError(msg)
 
-    return security.fix_security_issue_id(cfg, args.security_issue)
+    fix_status = security.fix_security_issue_id(cfg, args.security_issue)
+    return fix_status.value
 
 
 def detach_parser(parser):

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -385,8 +385,7 @@ def action_fix(args, *, cfg, **kwargs):
         ).format(args.security_issue)
         raise exceptions.UserFacingError(msg)
 
-    security.fix_security_issue_id(cfg, args.security_issue)
-    return 0
+    return security.fix_security_issue_id(cfg, args.security_issue)
 
 
 def detach_parser(parser):

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -59,6 +59,7 @@ class TestActionFix:
         """Check that root and non-root will emit attached status"""
         cfg = FakeConfig()
         args = mock.MagicMock(security_issue=issue)
+        m_fix_security_issue_id.return_value = 0
         if is_valid:
             assert 0 == action_fix(args, cfg=cfg)
             assert [

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -5,6 +5,7 @@ import pytest
 
 from uaclient import exceptions
 from uaclient.cli import action_fix, main
+from uaclient.security import FixStatus
 
 M_PATH = "uaclient.cli."
 
@@ -59,7 +60,7 @@ class TestActionFix:
         """Check that root and non-root will emit attached status"""
         cfg = FakeConfig()
         args = mock.MagicMock(security_issue=issue)
-        m_fix_security_issue_id.return_value = 0
+        m_fix_security_issue_id.return_value = FixStatus.SYSTEM_NON_VULNERABLE
         if is_valid:
             assert 0 == action_fix(args, cfg=cfg)
             assert [

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -12,11 +12,9 @@ from uaclient.security import (
     API_V1_NOTICE_TMPL,
     API_V1_NOTICES,
     CVE,
-    SYSTEM_NON_VULNERABLE,
-    SYSTEM_STILL_VULNERABLE,
-    SYSTEM_VULNERABLE_UNTIL_REBOOT,
     USN,
     CVEPackageStatus,
+    FixStatus,
     SecurityAPIError,
     UASecurityClient,
     fix_security_issue_id,
@@ -983,7 +981,7 @@ class TestPromptForAffectedPackages:
                         check=OKGREEN_CHECK  # noqa: E126
                     )  # noqa: E126
                 ),
-                SYSTEM_NON_VULNERABLE,
+                FixStatus.SYSTEM_NON_VULNERABLE,
             ),
             (  # version is >= released affected package
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED)},
@@ -1001,7 +999,7 @@ class TestPromptForAffectedPackages:
                         check=OKGREEN_CHECK  # noqa: E126
                     )  # noqa: E126
                 ),
-                SYSTEM_NON_VULNERABLE,
+                FixStatus.SYSTEM_NON_VULNERABLE,
             ),
             (  # usn_released_pkgs version is used instead of CVE (2.1)
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED)},
@@ -1020,7 +1018,7 @@ class TestPromptForAffectedPackages:
                 )
                 + "\n"
                 + "{check} USN-### is resolved.\n".format(check=OKGREEN_CHECK),
-                SYSTEM_NON_VULNERABLE,
+                FixStatus.SYSTEM_NON_VULNERABLE,
             ),
             (  # version is < released affected package standard updates
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED)},
@@ -1049,7 +1047,7 @@ class TestPromptForAffectedPackages:
                         ),
                     ]
                 ),
-                SYSTEM_NON_VULNERABLE,
+                FixStatus.SYSTEM_NON_VULNERABLE,
             ),
             (  # version is < released affected package esm-infra updates
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_INFRA)},
@@ -1071,7 +1069,7 @@ class TestPromptForAffectedPackages:
                         MSG_SUBSCRIPTION,
                     ]
                 ),
-                SYSTEM_STILL_VULNERABLE,
+                FixStatus.SYSTEM_STILL_VULNERABLE,
             ),
             (  # version < released package in esm-infra updates and aws cloud
                 {"slsrc": CVEPackageStatus(CVE_PKG_STATUS_RELEASED_ESM_INFRA)},
@@ -1093,7 +1091,7 @@ class TestPromptForAffectedPackages:
                         MSG_SUBSCRIPTION,
                     ]
                 ),
-                SYSTEM_STILL_VULNERABLE,
+                FixStatus.SYSTEM_STILL_VULNERABLE,
             ),
             (  # version is < released affected both esm-apps and standard
                 {
@@ -1135,7 +1133,7 @@ class TestPromptForAffectedPackages:
                 )
                 + "\n"
                 + "1 package is still affected: slsrc",
-                SYSTEM_STILL_VULNERABLE,
+                FixStatus.SYSTEM_STILL_VULNERABLE,
             ),
             (  # version is < released affected both esm-apps and standard
                 {
@@ -1231,7 +1229,7 @@ class TestPromptForAffectedPackages:
                         "    pkg4, pkg5, pkg6, pkg7, pkg8, pkg9"
                     )
                 ),
-                SYSTEM_STILL_VULNERABLE,
+                FixStatus.SYSTEM_STILL_VULNERABLE,
             ),
             (  # No released version
                 {
@@ -1270,7 +1268,7 @@ class TestPromptForAffectedPackages:
                 )
                 + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
-                SYSTEM_STILL_VULNERABLE,
+                FixStatus.SYSTEM_STILL_VULNERABLE,
             ),
             (  # text wrapping required in several places
                 {
@@ -1333,7 +1331,7 @@ A fix is available in Ubuntu standard updates.\n"""
                 )
                 + "\n"
                 + "{check} USN-### is resolved.\n".format(check=OKGREEN_CHECK),
-                SYSTEM_NON_VULNERABLE,
+                FixStatus.SYSTEM_NON_VULNERABLE,
             ),
         ),
     )
@@ -2027,7 +2025,7 @@ A fix is available in Ubuntu standard updates.\n"""
                 + "A reboot is required to complete fix operation."
                 + "\n"
                 + "{check} USN-### is not resolved.\n".format(check=FAIL_X),
-                SYSTEM_VULNERABLE_UNTIL_REBOOT,
+                FixStatus.SYSTEM_VULNERABLE_UNTIL_REBOOT,
             ),
         ),
     )


### PR DESCRIPTION
## Proposed Commit Message
fix: update return code

Currently, ua fix will always return 0 no matter what happens during the execution of the command. We are updating the command to only return 0 if the system ends up in a non-vulnerable state. Meaning that either the CVE/USN does not affect the system, the packages required by the fix are already installed or that we have successfully installed all of the packages necessary for the fix.

## Test Steps
Run the modified integration/unit tests

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
