### PR TITLE
timer: change frequency to 2 hours

### DIFF
--- a/systemd/ua-timer.timer
+++ b/systemd/ua-timer.timer
@@ -2,9 +2,8 @@
 Description=Ubuntu Advantage Timer for running repeated jobs
 
 [Timer]
-OnUnitActiveSec=6h
+OnUnitActiveSec=2h
 RandomizedDelaySec=1h
-Persistent=true
 OnStartupSec=1min
 
 [Install]


### PR DESCRIPTION
This is something I meant to bring more attention to during the gcp timer PR but forgot. I had set the ua-timer frequency much lower, but we may want it more like this to make adding the metering job easier in the future. Also should we change it back to using OnCalendar or no?

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
timer: change frequency to 2 hours
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
