### PR TITLE
fips: allow enabling fips on GCP bionic instances

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -226,7 +226,27 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     @uses.config.machine_type.gcp.generic
     Scenario Outline: Attach command in an generic GCP Ubuntu VM
        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
+        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        """
+        {
+            "machineTokenInfo": {
+                "contractInfo": {
+                    "resourceEntitlements": [
+                        {
+                            "type": "esm-apps",
+                            "entitled": false
+                        }
+                    ]
+                }
+            }
+        }
+        """
+        And I append the following on uaclient config:
+        """
+        features:
+          machine_token_overlay: "/tmp/machine-token-overlay.json"
+        """
+        And I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
         UA Infra: ESM enabled
@@ -252,5 +272,5 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Examples: ubuntu release livepatch status
            | release | lp_status | fips_status |
            | xenial  | n/a       | n/a         |
-           | bionic  | n/a       | n/a         |
+           | bionic  | n/a       | disabled    |
            | focal   | n/a       | n/a         |

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -16,8 +16,6 @@ Feature: FIPS enablement in cloud based machines
             | release | release_title | fips_service  |
             | xenial  | Xenial        | fips          |
             | xenial  | Xenial        | fips-updates  |
-            | bionic  | Bionic        | fips          |
-            | bionic  | Bionic        | fips-updates  |
             | focal   | Focal         | fips          |
             | focal   | Focal         | fips-updates  |
 
@@ -458,3 +456,151 @@ Feature: FIPS enablement in cloud based machines
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                               |
            | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main |
+
+    @series.bionic
+    @uses.config.machine_type.gcp.generic
+    Scenario Outline: Attached enable of FIPS in an ubuntu Bionic GCP vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
+        And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
+        And I run `ua enable <fips-service> --assume-yes` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing <fips-name> packages
+            <fips-name> enabled
+            A reboot is required to complete install
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                enabled
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        Then stdout does not match regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I reboot the `<release>` machine
+        And  I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            gcp-fips
+            """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+        When I run `ua disable <fips-service> --assume-yes` with sudo
+        Then stdout matches regexp:
+        """
+        Updating package lists
+        """
+        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        Then stdout matches regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I reboot the `<release>` machine
+        Then I verify that `openssh-server` installed version matches regexp `fips`
+        And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `openssh-server-hmac` installed version matches regexp `fips`
+        And I verify that `openssh-client-hmac` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
+        When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
+        Then I will see the following on stdout:
+        """
+        openssh-client was already not hold.
+        openssh-server was already not hold.
+        strongswan was already not hold.
+        """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                disabled
+            """
+
+        Examples: ubuntu release
+           | release | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+
+    @series.bionic
+    @uses.config.machine_type.gcp.generic
+    Scenario Outline: Attached enable of FIPS in an ubuntu GCP AWS vm
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
+        And I run `ua enable <fips-service> --assume-yes` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            Installing <fips-name> packages
+            <fips-name> enabled
+            A reboot is required to complete install
+            """
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                enabled
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        Then stdout does not match regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I reboot the `<release>` machine
+        And  I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            gcp-fips
+            """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+        When I run `ua disable <fips-service> --assume-yes` with sudo
+        Then stdout matches regexp:
+        """
+        Updating package lists
+        """
+        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        Then stdout matches regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I reboot the `<release>` machine
+        Then I verify that `openssh-server` installed version matches regexp `fips`
+        And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `openssh-server-hmac` installed version matches regexp `fips`
+        And I verify that `openssh-client-hmac` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
+        When I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            <fips-service> +yes                disabled
+            """
+
+        Examples: ubuntu release
+           | release | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main |

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -159,6 +159,11 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 path_to_value="features.allow_default_fips_metapackage_on_gcp",
             ):
                 return True
+
+            # GCE only has FIPS support for bionic machines
+            if series == "bionic":
+                return True
+
             return bool("ubuntu-gcp-fips" in super().packages)
 
         # Azure FIPS cloud support
@@ -226,12 +231,13 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         if cloud_id is None:
             cloud_id = ""
 
-        cloud_match = re.match(r"^(?P<cloud>(azure|aws)).*", cloud_id)
+        cloud_match = re.match(r"^(?P<cloud>(azure|aws|gce)).*", cloud_id)
         cloud_id = cloud_match.group("cloud") if cloud_match else ""
 
-        if cloud_id not in ("azure", "aws"):
+        if cloud_id not in ("azure", "aws", "gce"):
             return packages
 
+        cloud_id = "gcp" if cloud_id == "gce" else cloud_id
         cloud_metapkg = "ubuntu-{}-fips".format(cloud_id)
         # Replace only the ubuntu-fips meta package if exists
         return [

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -656,8 +656,10 @@ class TestFIPSEntitlementEnable:
 
         if cloud_id == "aws" or cloud_id is None:
             assert actual_value
-        elif cloud_id == "gce":
+        elif cloud_id == "gce" and series != "bionic":
             assert not actual_value
+        elif cloud_id == "gce":
+            assert actual_value
         elif all([allow_xenial_fips_on_cloud, series == "xenial"]):
             assert actual_value
         elif series == "xenial":
@@ -693,6 +695,7 @@ class TestFIPSEntitlementEnable:
             [
                 not cfg_allow_default_fips_metapkg_on_gcp,
                 "ubuntu-gcp-fips" not in additional_pkgs,
+                series != "bionic",
             ]
         ):
             assert not actual_value
@@ -1142,11 +1145,19 @@ class TestFipsEntitlementPackages:
             [
                 series == "bionic",
                 cloud_id
-                in ("azure", "aws", "aws-china", "aws-gov", "azure-china"),
+                in (
+                    "azure",
+                    "aws",
+                    "aws-china",
+                    "aws-gov",
+                    "azure-china",
+                    "gce",
+                ),
                 not cfg_disable_fips_metapckage_override,
             ]
         ):
             cloud_id = cloud_id.split("-")[0]
+            cloud_id = "gcp" if cloud_id == "gce" else cloud_id
             assert packages == [
                 "test1",
                 "ubuntu-{}-fips".format(cloud_id),


### PR DESCRIPTION
## Proposed Commit Message
fips: allow enabling fips on GCP bionic instances

GCP has now a FIPS optimized kernel on bionic. We are now updating
the code to allow enabling the service on those types of instances

## Test Steps
Run the modified integration tests

PS: FIPS Updates test is not passing at the moment because of openssh package releated issues that we still need to debug.

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
