### PR TITLE
Deb build cache for tests (SC-449)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,19 @@
 ## Proposed Commit Message
 <!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->
 
-> summary: no more than 70 characters
->
-> A description of what the change being made is and why it is being
-> made, if the summary line is insufficient.  The blank line above is
-> required. This should be wrapped at 72 characters, but otherwise has
-> no particular length requirements.
->
-> If you need to write multiple paragraphs, feel free.
->
-> LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
-> Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
+```
+summary: no more than 70 characters
+
+A description of what the change being made is and why it is being
+made, if the summary line is insufficient.  The blank line above is
+required. This should be wrapped at 72 characters, but otherwise has
+no particular length requirements.
+
+If you need to write multiple paragraphs, feel free.
+
+LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
+Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
+```
 
 ## Test Steps
 <!-- Please include any steps necessary to verify (and reproduce if
@@ -19,13 +21,13 @@ this is a bug fix) this change on a live deployed system,
 including any necessary configuration files, user-data,
 setup, and teardown. Scripts used may be attached directly to this PR. -->
 
-## Desired commit type::
+## Desired commit type
 <!-- put an `x` in one merge type to allow the reviewer to merge for you -->
  - [ ] Squash and merge: Using the "Proposed Commit Message"
  - [ ] Create a merge commit and use "Proposed Commit Message"
  - [ ] Rebase and merge, no merge commit, rely only on existing commit messages
 
-## Checklist:
+## Checklist
 <!-- Go over all the following points, and put an `x` in all the boxes
 that apply. -->
  - [ ] I have updated or added any unit tests accordingly

--- a/features/environment.py
+++ b/features/environment.py
@@ -5,7 +5,6 @@ import os
 import random
 import re
 import string
-import tempfile
 import textwrap
 from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
@@ -653,15 +652,9 @@ def build_debs_from_sbuild(context: Context, series: str) -> List[str]:
         )
 
         with emit_spinner_on_travis("Building debs from local source... "):
-            output_deb_dir = os.path.join(tempfile.gettempdir(), series)
             deb_paths = build_debs(
-                series=series,
-                output_deb_dir=output_deb_dir,
-                cache_source=context.config.cache_source,
+                series=series, cache_source=context.config.cache_source
             )
-            context.config.debs_path = output_deb_dir
-
-        logging.info("--- sbuild has finished building the packages")
 
     if "pro" in context.config.machine_type:
         return deb_paths

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,0 +1,13 @@
+import logging
+import sys
+
+from features.util import build_debs
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.INFO)
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        print("required arg: series")
+        sys.exit(1)
+    series = sys.argv[1]
+    print(build_debs(series))

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+env PYTHONPATH=. python3 tools/build.py "$@"


### PR DESCRIPTION
## Notes

Not urgent at all.

This is a build caching idea I've been messing with a bit while testing PRs and has worked pretty well. Feel free to say its a bad idea or point out flaws :). It has the potential to make iterating on an integration test less cumbersome.

Also includes a little build script to just call the build function we have for our integration tests.


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
test: automatically cache debs based on git repo state
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Try out `./tools/build.sh`
make changes to features and build again
make changes to uaclient code and build again

Ensure integration tests still work

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
