### PR TITLE
cc-eal: remove beta flag

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -57,6 +57,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
+        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
         cis          +yes      +disabled        +Center for Internet Security Audit Tools
         esm-apps     +yes      +enabled  +UA Apps: Extended Security Maintenance \(ESM\)
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
@@ -151,10 +152,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
         """
         Examples: ubuntu release packages
-           | release | downrev_pkg                 |
-           | xenial  | libkrad0=1.13.2+dfsg-5      |
-           | bionic  | libkrad0=1.16-2build1       |
-           | focal   | hello=2.10-2ubuntu2         |
+           | release | downrev_pkg                 | cc_status |
+           | xenial  | libkrad0=1.13.2+dfsg-5      | disabled  |
+           | bionic  | libkrad0=1.16-2build1       | n/a       |
+           | focal   | hello=2.10-2ubuntu2         | n/a       |
 
     @series.all
     @uses.config.machine_type.aws.generic
@@ -192,6 +193,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
+        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
         cis          +yes      +disabled +Center for Internet Security Audit Tools
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
         fips         +yes      +<fips_status>      +NIST-certified core packages
@@ -204,10 +206,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
 
         Examples: ubuntu release livepatch status
-           | release | fips_status |lp_status | lp_desc                       |
-           | xenial  | disabled    |enabled   | Canonical Livepatch service   |
-           | bionic  | disabled    |enabled   | Canonical Livepatch service   |
-           | focal   | n/a         |enabled   | Canonical Livepatch service   |
+           | release | fips_status |lp_status | lp_desc                       | cc_status |
+           | xenial  | disabled    |enabled   | Canonical Livepatch service   | disabled  |
+           | bionic  | disabled    |enabled   | Canonical Livepatch service   | n/a       |
+           | focal   | n/a         |enabled   | Canonical Livepatch service   | n/a       |
 
     @series.all
     @uses.config.machine_type.azure.generic
@@ -245,6 +247,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
+        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
         cis          +yes      +disabled +Center for Internet Security Audit Tools
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
         fips         +yes      +<fips_status> +NIST-certified core packages
@@ -257,10 +260,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
 
         Examples: ubuntu release livepatch status
-           | release | lp_status | fips_status |
-           | xenial  | n/a       | n/a         |
-           | bionic  | n/a       | disabled    |
-           | focal   | n/a       | n/a         |
+           | release | lp_status | fips_status | cc_status |
+           | xenial  | n/a       | n/a         | disabled  |
+           | bionic  | n/a       | disabled    | n/a       |
+           | focal   | n/a       | n/a         | n/a       |
 
     @series.all
     @uses.config.machine_type.gcp.generic
@@ -298,6 +301,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
+        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
         cis          +yes      +disabled +Center for Internet Security Audit Tools
         esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance \(ESM\)
         fips         +yes      +<fips_status> +NIST-certified core packages
@@ -310,7 +314,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
 
         Examples: ubuntu release livepatch status
-           | release | lp_status | fips_status |
-           | xenial  | n/a       | n/a         |
-           | bionic  | n/a       | disabled    |
-           | focal   | enabled   | n/a         |
+           | release | lp_status | fips_status | cc_status |
+           | xenial  | n/a       | n/a         | disabled  |
+           | bionic  | n/a       | disabled    | n/a       |
+           | focal   | enabled   | n/a         | n/a       |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -314,6 +314,8 @@ Feature: Command behaviour when attached to an UA subscription
         Then stdout matches regexp:
         """
         Client to manage Ubuntu Advantage services on a machine.
+         - cc-eal: Common Criteria EAL2 Provisioning Packages
+           \(https://ubuntu.com/cc-eal\)
          - cis: Center for Internet Security Audit Tools
            \(https://ubuntu.com/security/certifications#cis\)
          - esm-infra: UA Infra: Extended Security Maintenance \(ESM\)
@@ -325,10 +327,12 @@ Feature: Command behaviour when attached to an UA subscription
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
         """
-        When I run `ua help` as non-root
+        When I run `ua help` with sudo
         Then stdout matches regexp:
         """
         Client to manage Ubuntu Advantage services on a machine.
+         - cc-eal: Common Criteria EAL2 Provisioning Packages
+           \(https://ubuntu.com/cc-eal\)
          - cis: Center for Internet Security Audit Tools
            \(https://ubuntu.com/security/certifications#cis\)
          - esm-infra: UA Infra: Extended Security Maintenance \(ESM\)

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -11,7 +11,7 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo).
             """
-        When I run `ua enable cc-eal --beta` with sudo
+        When I run `ua enable cc-eal` with sudo
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
@@ -24,6 +24,7 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.bionic
     @series.focal
+    @series.hirsute
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -37,45 +38,13 @@ Feature: Enable command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             One moment, checking your subscription first
-            CC EAL2 is not available for Ubuntu <version> LTS (<full_name>).
+            CC EAL2 is not available for Ubuntu <version> (<full_name>).
             """
         Examples: ubuntu release
-            | release | version | full_name     |
-            | bionic  | 18.04   | Bionic Beaver |
-            | focal   | 20.04   | Focal Fossa   |
-
-    @series.all
-    @uses.config.machine_type.lxd.container
-    Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `ua enable cc-eal` `as non-root` exits `1`
-        And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo).
-            """
-        And I verify that running `ua enable cc-eal --beta` `with sudo` exits `1`
-        And I will see the following on stdout
-            """
-            One moment, checking your subscription first
-            <msg>
-            """
-        And I verify that running `ua enable cc-eal` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        And stderr matches regexp:
-            """
-            Cannot enable unknown service 'cc-eal'.
-            Try cis, esm-infra, fips, fips-updates, livepatch.
-            """
-
-        Examples: ubuntu release
-           | release | msg                                                            |
-           | bionic  | CC EAL2 is not available for Ubuntu 18.04 LTS (Bionic Beaver). |
-           | focal   | CC EAL2 is not available for Ubuntu 20.04 LTS (Focal Fossa).   |
-           | hirsute | CC EAL2 is not available for Ubuntu 21.04 (Hirsute Hippo).     |
+            | release | version    | full_name     |
+            | bionic  | 18.04 LTS  | Bionic Beaver |
+            | focal   | 20.04 LTS  | Focal Fossa   |
+            | hirsute | 21.04      | Hirsute Hippo |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -95,17 +64,17 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stderr matches regexp:
             """
             Cannot enable unknown service 'foobar'.
-            Try cis, esm-infra, fips, fips-updates, livepatch.
+            Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch.
             """
-        And I verify that running `ua enable cc-eal foobar` `with sudo` exits `1`
+        And I verify that running `ua enable ros foobar` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
             """
         And stderr matches regexp:
             """
-            Cannot enable unknown service 'foobar, cc-eal'.
-            Try cis, esm-infra, fips, fips-updates, livepatch.
+            Cannot enable unknown service 'foobar, ros'.
+            Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch.
             """
         And I verify that running `ua enable esm-infra` `with sudo` exits `1`
         Then I will see the following on stdout:

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -17,6 +17,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION
+            cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
             cis           +yes  +<cis-s>  +Center for Internet Security Audit Tools
             esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
@@ -109,6 +110,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION
+            cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
             cis           +yes +<cis-s> +Center for Internet Security Audit Tools
             esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
@@ -201,6 +203,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION
+            cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
             cis           +yes +<cis-s> +Center for Internet Security Audit Tools
             esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
             esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -69,7 +69,6 @@ Feature: Upgrade between releases when uaclient is unattached
         When I run `ua status` with sudo
         Then stdout matches regexp:
         """
-        SERVICE       AVAILABLE  DESCRIPTION
         cis           yes      +Center for Internet Security Audit Tools
         esm-infra     yes      +UA Infra: Extended Security Maintenance \(ESM\)
         """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -34,6 +34,7 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        <cc-eal>    +Common Criteria EAL2 Provisioning Packages
             cis           <cis>       +Center for Internet Security Audit Tools
             esm-infra     <infra>     +UA Infra: Extended Security Maintenance \(ESM\)
             fips          <fips>      +NIST-certified core packages
@@ -64,6 +65,7 @@ Feature: Unattached status
         Then stdout matches regexp:
             """
             SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        <cc-eal>    +Common Criteria EAL2 Provisioning Packages
             cis           <cis>       +Center for Internet Security Audit Tools
             esm-infra     <infra>     +UA Infra: Extended Security Maintenance \(ESM\)
             fips          <fips>      +NIST-certified core packages

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -12,7 +12,6 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     title = "CC EAL2"
     description = "Common Criteria EAL2 Provisioning Packages"
     repo_key_file = "ubuntu-advantage-cc-eal.gpg"
-    is_beta = True
     apt_noninteractive = True
 
     @property

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -62,6 +62,8 @@ Client to manage Ubuntu Advantage services on a machine.
 SERVICES_WRAPPED_HELP = textwrap.dedent(
     """
 Client to manage Ubuntu Advantage services on a machine.
+ - cc-eal: Common Criteria EAL2 Provisioning Packages
+   (https://ubuntu.com/cc-eal)
  - cis: Center for Internet Security Audit Tools
    (https://ubuntu.com/security/certifications#cis)
  - esm-infra: UA Infra: Extended Security Maintenance (ESM)

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -23,7 +23,7 @@ Disable an Ubuntu Advantage service.
 
 Arguments:
   service       the name(s) of the Ubuntu Advantage services to disable One
-                of: cis, esm-infra, fips, fips-updates, livepatch
+                of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch
 
 Flags:
   -h, --help    show this help message and exit

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -16,7 +16,7 @@ Enable an Ubuntu Advantage service.
 
 Arguments:
   service       the name(s) of the Ubuntu Advantage services to enable. One
-                of: cis, esm-infra, fips, fips-updates, livepatch
+                of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch
 
 Flags:
   -h, --help    show this help message and exit

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -58,6 +58,8 @@ Technical support level: n/a
 # Omit beta services from status
 ATTACHED_STATUS_NOBETA = """\
 SERVICE       ENTITLED  STATUS    DESCRIPTION
+cc-eal        no        {dash}         Common Criteria EAL2 Provisioning\
+ Packages
 cis           no        {dash}         Center for Internet Security Audit Tools
 esm-infra     no        {dash}         UA Infra: Extended Security Maintenance\
  (ESM)
@@ -74,7 +76,7 @@ Enable services with: ua enable <service>
 Technical support level: n/a
 """
 
-BETA_SVC_NAMES = ["cc-eal", "esm-apps", "ros", "ros-updates"]
+BETA_SVC_NAMES = ["esm-apps", "ros", "ros-updates"]
 
 SERVICES_JSON_ALL = [
     {

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -699,7 +699,7 @@ class TestDeleteCache:
 @mock.patch("uaclient.util.should_reboot", return_value=False)
 class TestStatus:
     esm_desc = ENTITLEMENT_CLASS_BY_NAME["esm-infra"].description
-    cc_eal_desc = ENTITLEMENT_CLASS_BY_NAME["cc-eal"].description
+    ros_desc = ENTITLEMENT_CLASS_BY_NAME["ros"].description
 
     def check_beta(self, cls, show_beta, uacfg=None, status=""):
         if not show_beta:
@@ -725,14 +725,14 @@ class TestStatus:
                 True,
                 [
                     {
-                        "available": "no",
-                        "name": "cc-eal",
-                        "description": cc_eal_desc,
-                    },
-                    {
                         "available": "yes",
                         "name": "esm-infra",
                         "description": esm_desc,
+                    },
+                    {
+                        "available": "no",
+                        "name": "ros",
+                        "description": ros_desc,
                     },
                 ],
             ),
@@ -764,7 +764,7 @@ class TestStatus:
         cfg = FakeConfig()
         m_get_available_resources.return_value = [
             {"name": "esm-infra", "available": True},
-            {"name": "cc-eal", "available": False},
+            {"name": "ros", "available": False},
         ]
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected["services"] = expected_services


### PR DESCRIPTION
This PR makes cc-eal non-beta.
- Will be listed without the --all flag
- Can be enabled without the --beta flag

## Desired commit type::
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
