### PR TITLE
cli: detach won't ask to disable dependent service (SC-455)

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -644,6 +644,15 @@ Feature: Enable command behaviour when attached to an UA subscription
         """
         esm-infra     yes                enabled            UA Infra: Extended Security Maintenance \(ESM\)
         """
+        When I run `ua detach` `with sudo` and stdin `y`
+        Then stdout matches regexp:
+        """
+        Updating package lists
+        Updating package lists
+        Updating package lists
+        Updating package lists
+        This machine is now detached.
+        """
 
         Examples: ubuntu release
            | release | ros-security-source                                    | ros-updates-source                                            |

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -9,7 +9,9 @@ from uaclient.testing.fakes import FakeContractClient
 
 
 def entitlement_cls_mock_factory(can_disable, name=None):
-    m_instance = mock.Mock(can_disable=mock.Mock(return_value=can_disable))
+    m_instance = mock.Mock(
+        can_disable=mock.Mock(return_value=can_disable), dependent_services=()
+    )
     if name:
         m_instance.name = name
     return mock.Mock(return_value=m_instance)


### PR DESCRIPTION
## Proposed Commit Message
cli: detach won't ask to disable dependent service

Currently, when running detach without --assume-yes we will ask to disable dependent services if we have ros enabled services during the operation. We are now sorting the services to be disabled based on the length of the depedent services tuple of each entitlement.

## Test Steps
Run the modified integration test

## Desired commit type::
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
