### PR TITLE
postinst: make check for gce instance more robust

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ ubuntu-advantage-tools (27.3~21.10.1) impish; urgency=medium
   * d/tools.postinst:
     - consider cloud to be "none" on any cloud-id error
     - purge old ua-messaging.timer/service files
+    - keep ua-timer.timer disabled if ua-messaging.timer was disabled by
+      the user
   * systemd:
     - remove ua-messaging.timer/service
     - add new ua-timer.timer that runs every 2 hours

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -32,6 +32,7 @@ ESM_APPS_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-esm-apps.list"
 FIPS_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-fips.list"
 
 OLD_CLIENT_FIPS_PPA="private-ppa.launchpad.net/ubuntu-advantage/fips/ubuntu"
+UA_TIMER_NAME="ua-timer.timer"
 OLD_MESSAGING_TIMER="ua-messaging.timer"
 OLD_MESSAGING_TIMER_MASKED_LOCATION="/etc/systemd/system/timers.target.wants/$OLD_MESSAGING_TIMER"
 
@@ -318,6 +319,40 @@ enable_periodic_license_check() {
     fi
 }
 
+disable_new_timer_if_old_timer_already_disabled() {
+    # If the user has disabled the ua-messaging
+    # then we will assume that the user would want the
+    # ua-timer to be disabled as well. In that case, we will
+    # disable the ua-timer here.
+    PREVIOUS_PKG_VER=$1
+
+    # We should only perform this check on UA version that have the
+    # ua-messaging.timer: 27.0 until 27.2. This will also guarantee
+    # that on 27.3 and forward, we will not run this logic.
+    if dpkg --compare-versions "$PREVIOUS_PKG_VER" ge-nl "27.0~"; then
+        if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "27.3~"; then
+            if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                if ! deb-systemd-helper --quiet was-enabled $OLD_MESSAGING_TIMER; then
+                    # We have the following entry on our rules file:
+                    #    dh_systemd_enable -pubuntu-advantage-tools ua-timer.timer
+                    # This rule will append some code at the end of the postinst script
+                    # that checks if the ua-timer.timer was already enabled on the system.
+                    # This means that if we manually disable the service here, that logic will
+                    # still enable it in the end of the postinst script.
+                    # Because of this logic we are now manually enabling ua-timer.timer here
+                    # and then we manually disable it. This will guarantee that the was-enabled
+                    # logic introduced by the rules file will not be triggered and we will not
+                    # re-enable the ua-timer.timer service after calling this function.
+                    echo "$OLD_MESSAGING_TIMER was disabled. Disabling $UA_TIMER_NAME." >&2
+                    deb-systemd-helper enable $UA_TIMER_NAME > /dev/null 2>&1 || true
+                    systemctl stop $UA_TIMER_NAME > /dev/null 2>&1 || true
+                    systemctl disable $UA_TIMER_NAME > /dev/null 2>&1 || true
+                fi
+            fi
+        fi
+    fi
+}
+
 remove_old_systemd_timers() {
     # These are the commands that are run when the package is purged.
     # Since we actually want to remove this service from now on
@@ -404,6 +439,7 @@ case "$1" in
       fi
       mark_reboot_for_fips_pro
       enable_periodic_license_check
+      disable_new_timer_if_old_timer_already_disabled $PREVIOUS_PKG_VER
       remove_old_systemd_timers
       ;;
 esac

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -309,7 +309,7 @@ notify_wrong_fips_metapackage_on_cloud() {
 
 enable_periodic_license_check() {
     cloud_id=$(cloud-id 2>/dev/null) || cloud_id=""
-    if echo "$cloud_id" | grep -q "gce"; then
+    if echo "$cloud_id" | grep -q "^gce"; then
         if check_is_lts "${UBUNTU_CODENAME}"; then
             if [ ! -f $MACHINE_TOKEN_FILE ]; then
                 touch $LICENSE_CHECK_MARKER_FILE

--- a/sru/release-27.3/ua-messaging-disabled.sh
+++ b/sru/release-27.3/ua-messaging-disabled.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+series=$1
+name="test-systemd-$series"
+DEB_PATH=$2
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+lxc file push $DEB_PATH $name/tmp/ua.deb
+echo "List timers in default state"
+echo "--------------------------"
+lxc exec $name -- sudo systemctl list-timers --all
+echo "--------------------------"
+echo "Disabling ua-messaging.timer"
+echo "--------------------------"
+lxc exec $name -- sudo systemctl stop ua-messaging.timer
+lxc exec $name -- sudo systemctl disable ua-messaging.timer
+lxc exec $name -- sudo systemctl list-timers --all
+sleep 2
+echo "--------------------------"
+echo "Installing new UA package"
+echo "--------------------------"
+lxc exec $name -- sudo dpkg -i /tmp/ua.deb
+echo "--------------------------"
+echo "Verifying ua-timer.timer is disabled"
+lxc exec $name -- sudo systemctl list-timers --all
+echo "--------------------------"
+lxc delete $name --force


### PR DESCRIPTION
## Proposed Commit Message
postinst: make check for gce instance more robust

Currently, we have a check on postinst to verify if we are on a gce cloud. We only verify if the gce string is in the cloud-id of the instance. Therefore, we are open to matching non-gce clouds that have the gce string on their cloud-id. We are now updating this part of the code to make the match more robust by verifying if the cloud-id starts if the gce string.

## Test Steps
Check if the license check tests are still working

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
