### PR TITLE
repo: update apt url check for commented source (SC-483)

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -116,10 +116,22 @@ class RepoEntitlement(base.UAEntitlement):
         :return: False if apt url is already found on the source file.
                  True otherwise.
         """
+        apt_file = self.repo_list_file_tmpl.format(name=self.name)
+        # If the apt file is commented out, we will assume that we need
+        # to regenerate the apt file, regardless of the apt url delta
+        if all(
+            line.startswith("#")
+            for line in util.load_file(apt_file).strip().split("\n")
+        ):
+            return False
+
+        # If the file is not commented out and we don't have delta,
+        # we will not do anything
         if not apt_url:
             return True
 
-        apt_file = self.repo_list_file_tmpl.format(name=self.name)
+        # If the delta is already in the file, we won't reconfigure it
+        # again
         return bool(apt_url in util.load_file(apt_file))
 
     def process_contract_deltas(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -980,6 +980,33 @@ class TestSetupAptConfig:
         ] == m_run_apt_command.call_args_list
 
 
+class TestCheckAptURLIsApplied:
+    @pytest.mark.parametrize("apt_url", (("test"), (None)))
+    @mock.patch("uaclient.util.load_file")
+    def test_check_apt_url_for_commented_apt_source_file(
+        self, m_load_file, apt_url, entitlement
+    ):
+        m_load_file.return_value = "#test1\n#test2\n"
+        assert not entitlement._check_apt_url_is_applied(apt_url)
+
+    @mock.patch("uaclient.util.load_file")
+    def test_check_apt_url_when_delta_apt_url_is_none(
+        self, m_load_file, entitlement
+    ):
+        m_load_file.return_value = "test1\n#test2\n"
+        assert entitlement._check_apt_url_is_applied(apt_url=None)
+
+    @pytest.mark.parametrize(
+        "apt_url,expected", (("test", True), ("blah", False))
+    )
+    @mock.patch("uaclient.util.load_file")
+    def test_check_apt_url_inspects_apt_source_file(
+        self, m_load_file, apt_url, expected, entitlement
+    ):
+        m_load_file.return_value = "test\n#test2\n"
+        assert expected == entitlement._check_apt_url_is_applied(apt_url)
+
+
 class TestApplicationStatus:
     # TODO: Write tests for all functionality
 


### PR DESCRIPTION
## Proposed Commit Message
repo: update apt url check for commented source

When we are running the process_contract_deltas function, we verify if the delta apt url is already on the service apt source file. However, there are situations were there will no apt url deltas and we still want to regenerate the service apt source file, for example if we have a commented apt source file. We are updating the code to address that situation.

PS: If we agree on that solution, we will also need to update the contracts side to generate a delta when comparing the `bionic` and `xenial` contracts

## Test Steps
PS: The CS has updated the ROS product on staging, we can now better test this PR

1. Launch a xenial container
2. Install the latest version of UA (27.3)
3. Use the staging token to perform an attach
4. Enable `ros` on the container
5. Perform a `do-release-upgrade` but do not reboot the machine when it ends
6. Push the PR version of `repo.py` into `/usr/lib/python3/dist-packages/uaclient/entitlements/repo.py`
7. Certify that `ros` service is shown as `enabled` on `/var/lib/ubuntu-advantage/status.json`. If not change it to `enabled`
8. Run `python3 /usr/lib/ubuntu-advantage/upgrade_lts_contract.py`
9. Certify that `ros` is now `enabled`on the system.


## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
