### PR TITLE
proxy: no_proxy defaults for link-local IMDS routes (SC-518)

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -69,6 +69,7 @@ class Cloud:
         image_name: Optional[str] = None,
         user_data: Optional[str] = None,
         ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
     ) -> pycloudlib.instance:
         """Create an instance for on the cloud provider.
 
@@ -82,8 +83,10 @@ class Cloud:
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
-        :param ephemeral":
+        :param ephemeral:
             If instance should be ephemeral
+        :param inbound_ports:
+            List of ports to open for network ingress to the instance
 
         :returns:
             A cloud provider instance
@@ -116,6 +119,7 @@ class Cloud:
         image_name: Optional[str] = None,
         user_data: Optional[str] = None,
         ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
     ) -> pycloudlib.instance.BaseInstance:
         """Create and wait for cloud provider instance to be ready.
 
@@ -129,8 +133,10 @@ class Cloud:
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
-        :param ephemeral":
+        :param ephemeral:
             If instance should be ephemeral
+        :param inbound_ports:
+            List of ports to open for network ingress to the instance
 
         :returns:
             An cloud provider instance
@@ -141,6 +147,7 @@ class Cloud:
             image_name=image_name,
             user_data=user_data,
             ephemeral=ephemeral,
+            inbound_ports=inbound_ports,
         )
         logging.info(
             "--- {} instance launched: {}. Waiting for ssh access".format(
@@ -347,6 +354,7 @@ class EC2(Cloud):
         image_name: Optional[str] = None,
         user_data: Optional[str] = None,
         ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -360,8 +368,10 @@ class EC2(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
-        :param ephemeral":
+        :param ephemeral:
             If instance should be ephemeral
+        :param inbound_ports:
+            List of ports to open for network ingress to the instance
 
         :returns:
             An AWS cloud provider instance
@@ -509,6 +519,7 @@ class Azure(Cloud):
         image_name: Optional[str] = None,
         user_data: Optional[str] = None,
         ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -522,8 +533,10 @@ class Azure(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
-        :param ephemeral":
+        :param ephemeral:
             If instance should be ephemeral
+        :param inbound_ports:
+            List of ports to open for network ingress to the instance
 
         :returns:
             An AWS cloud provider instance
@@ -534,7 +547,11 @@ class Azure(Cloud):
         logging.info(
             "--- Launching Azure image {}({})".format(image_name, series)
         )
-        inst = self.api.launch(image_id=image_name, user_data=user_data)
+        inst = self.api.launch(
+            image_id=image_name,
+            user_data=user_data,
+            inbound_ports=inbound_ports,
+        )
         return inst
 
 
@@ -617,6 +634,7 @@ class GCP(Cloud):
         image_name: Optional[str] = None,
         user_data: Optional[str] = None,
         ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -630,8 +648,10 @@ class GCP(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
-        :param ephemeral":
+        :param ephemeral:
             If instance should be ephemeral
+        :param inbound_ports:
+            List of ports to open for network ingress to the instance
 
         :returns:
             An AWS cloud provider instance
@@ -675,6 +695,7 @@ class _LXD(Cloud):
         image_name: Optional[str] = None,
         user_data: Optional[str] = None,
         ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
     ) -> pycloudlib.instance:
         """Launch an instance on the cloud provider.
 
@@ -688,8 +709,10 @@ class _LXD(Cloud):
             The name of the image to be used when creating the instance
         :param user_data:
             The user data to be passed when creating the instance
-        :param ephemeral":
+        :param ephemeral:
             If instance should be ephemeral
+        :param inbound_ports:
+            List of ports to open for network ingress to the instance
 
         :returns:
             An AWS cloud provider instance

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -156,8 +156,7 @@ Feature: Proxy configuration
         """
         .*CONNECT contracts.canonical.com.*
         """
-        When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
-        Then stdout matches regexp:
+        And stdout matches regexp:
         """
         .*CONNECT api.snapcraft.io:443.*
         """

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -110,15 +110,15 @@ def given_a_machine(context, series):
                     context.instances["uaclient"].name
                 )
             )
-        else:
-            try:
-                context.instances["uaclient"].delete(wait=False)
-            except RuntimeError as e:
-                logging.error(
-                    "Failed to delete instance: {}\n{}".format(
-                        context.instances["uaclient"].name, str(e)
-                    )
+            return
+        try:
+            context.instances["uaclient"].delete(wait=False)
+        except RuntimeError as e:
+            logging.error(
+                "Failed to delete instance: {}\n{}".format(
+                    context.instances["uaclient"].name, str(e)
                 )
+            )
 
     context.add_cleanup(cleanup_instance)
     logging.info(
@@ -137,6 +137,13 @@ def launch_machine(context, series, instance_name):
     )
 
     def cleanup_instance() -> None:
+        if not context.config.destroy_instances:
+            logging.info(
+                "--- Leaving instance running: {}".format(
+                    context.instances[instance_name].name
+                )
+            )
+            return
         try:
             context.instances[instance_name].delete(wait=False)
         except RuntimeError as e:

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -43,15 +43,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         .*CONNECT 169.254.169.254.*
         """
-        And stdout does not match regexp:
-        """
-        .*CONNECT metadata.*
-        """
         Examples: ubuntu release
            | release | fips-s   | cc-eal-s | cis-s    |
            | xenial  | disabled | disabled | disabled |
            | bionic  | disabled | n/a      | disabled |
-	   | focal   | n/a      | n/a      | disabled |
+           | focal   | n/a      | n/a      | disabled |
 
     @series.lts
     @uses.config.machine_type.azure.pro
@@ -96,13 +92,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         .*CONNECT 169.254.169.254.*
         """
-        And stdout does not match regexp:
-        """
-        .*CONNECT metadata.*
-        """
         Examples: ubuntu release
            | release | fips-s   | cc-eal-s | cis-s    | livepatch-s |
-           | xenial  | disabled | disabled | disabled | enabled     |
+           | xenial  | n/a      | disabled | disabled | enabled     |
            | bionic  | disabled | n/a      | disabled | n/a         |
            | focal   | n/a      | n/a      | disabled | enabled     |
 
@@ -114,7 +106,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_port 3389\nhttp_access allow all
             """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -138,7 +130,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
             fips          +yes +<fips-s> +NIST-certified core packages
             fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
-            livepatch     +yes +enabled  +Canonical Livepatch service
+            livepatch     +yes +<livepatch-s> +Canonical Livepatch service
             """
         When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
         Then stdout matches regexp:
@@ -147,17 +139,13 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         And stdout does not match regexp:
         """
-        .*CONNECT 169.254.169.254.*
-        """
-        And stdout does not match regexp:
-        """
         .*CONNECT metadata.*
         """
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    |
-           | xenial  | disabled | disabled | disabled |
-           | bionic  | disabled | n/a      | disabled |
-           | focal   | n/a      | n/a      | disabled |
+           | release | fips-s   | cc-eal-s | cis-s    | livepatch-s |
+           | xenial  | n/a      | disabled | disabled | n/a         |
+           | bionic  | disabled | n/a      | disabled | n/a         |
+           | focal   | n/a      | n/a      | disabled | enabled     |
 
     @series.lts
     @uses.config.machine_type.aws.pro

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # Integration testing
 behave
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@dd27b604137cc5a20fb54e233ecb6a028b3d6891
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@756a2c2de044ca60eaa7cdc76653d23a1339dc0a
 
 
 # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
## Proposed Commit Message
```
    * tests: bump pycloudlib commitish to include azure inbound_ports
    
    * tests: accept inbound_ports during launch to allow network ingress
    
      This is required on Azure because the squid proxy port 3128 is not
      allowed for public ingress.
    
      Azure is complicated as well by the fact that we create instances
      in their own subnet, so even private IP accessibility between proxy
      and test instance is prohibited.

    * tests: do not delete proxy instances when destroy_instances is false
    
    * proxy: no_proxy defaults for link-local IMDS routes
    
       Set no_proxy environment variables to avoid using http_proxy
       or https_proxy settings in our ProxyHandler when talking to
       link-local cloud IMDS endpoints.
    
      Avoid issues with auto-attach for PRO images in network-limited
      environments.
```

## Test Steps

```bash
# see failure without this Branch
UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID=...   UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY=...  tox -e behave-awspro-18.04 features/ubuntu_pro.feature:55
# see success
UACLIENT_BEHAVE_BUILD_PR=1 UACLIENT_BEHAVE_AWS_ACCESS_KEY_ID=...   UACLIENT_BEHAVE_AWS_SECRET_ACCESS_KEY=...  tox -e behave-awspro-18.04 features/ubuntu_pro.feature:55

```
## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
