### PR TITLE
aws: support using IPv6 metadata endpoint (SC-515)

### DIFF
--- a/sru/manual-tests/test-aws-ipv6.sh
+++ b/sru/manual-tests/test-aws-ipv6.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -e
+
+KEY_PATH=$1
+DEB_PATH=$2
+sshopts=( -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR )
+
+REGION=us-west-2
+INSTANCE_TYPE=t3.micro
+KEY_NAME=KEY_NAME
+PRO_IMAGE_ID=ami-07e00b8a1a054fdbf  # bionic PRO image for us-west-2
+
+# You need to have a subnet that supports IPv6. The easiest path here is to launch an ec2
+# unstance through pycloudlib, which will already create a VPC with a subnet that supports
+# IPv6. You can also use the security group created by pycloudlib
+SUBNET_ID=<SUBNET-ID>
+SECURITY_GROUP_ID=<SG-ID>
+
+# Make sure that the awscli being used has support for the --metadata-options params, otherwise the
+# IPv6 endpoint will not work as expected
+instance_info=$(aws --region $REGION ec2 run-instances --instance-type $INSTANCE_TYPE --image-id $PRO_IMAGE_ID --subnet-id $SUBNET_ID --key-name $KEY_NAME --associate-public-ip-address --ipv6-address-count 1 --metadata-options HttpEndpoint=enabled,HttpProtocolIpv6=enabled --security-group-ids $SECURITY_GROUP_ID)
+instance_id=$(echo $instance_info | jq -r ".Instances[0].InstanceId")
+instance_ip=$(aws ec2 describe-instances --region $REGION --instance-ids $instance_id --query 'Reservations[*].Instances[*].PublicIpAddress' --output text)
+
+echo "---------------------------------------------"
+echo "Checking instance info"
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- lsb_release -a
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo ua status --wait
+echo "---------------------------------------------"
+echo -e "\n"
+
+echo "---------------------------------------------"
+echo "Detaching PRO instance"
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo ua detach --assume-yes
+echo "---------------------------------------------"
+echo -e "\n"
+
+echo "---------------------------------------------"
+echo "Installing package with IPv6 support"
+scp "${sshopts[@]}" -i $KEY_PATH $DEB_PATH ubuntu@$instance_ip:/home/ubuntu/ua.deb
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo dpkg -i ua.deb
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- ua version
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo ua status --wait
+echo "---------------------------------------------"
+echo -e "\n"
+
+echo "---------------------------------------------"
+echo "Modifying IPv4 address to make it fail"
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo rm /var/log/ubuntu-advantage.log
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo sed -i "s/169.254.169.254/169.254.169.1/g" /usr/lib/python3/dist-packages/uaclient/clouds/aws.py
+echo "---------------------------------------------"
+echo -e "\n"
+
+echo "---------------------------------------------"
+echo "Verify that auto-attach still works and IPv6 route was used instead"
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo ua auto-attach
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo ua status
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo grep -F \"Could not reach AWS IMDS at http://169.254.169.1\" /var/log/ubuntu-advantage.log
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo grep -F \"URL [PUT]: http://169.254.169.1/latest/api/token\" /var/log/ubuntu-advantage.log
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo grep -F \"URL [PUT]: http://[fd00:ec2::254]/latest/api/token\" /var/log/ubuntu-advantage.log
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo grep -F \"URL [PUT] response: http://[fd00:ec2::254]/latest/api/token\" /var/log/ubuntu-advantage.log
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo grep -F \"URL [GET]: http://[fd00:ec2::254]/latest/dynamic/instance-identity/pkcs7\" /var/log/ubuntu-advantage.log
+ssh "${sshopts[@]}" -i $KEY_PATH ubuntu@$instance_ip -- sudo grep -F \"URL [GET] response: http://[fd00:ec2::254]/latest/dynamic/instance-identity/pkcs7\" /var/log/ubuntu-advantage.log
+echo "---------------------------------------------"
+echo -e "\n"

--- a/sru/release-27.5/test-aws-ipv6.sh
+++ b/sru/release-27.5/test-aws-ipv6.sh
@@ -8,11 +8,11 @@ sshopts=( -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLeve
 
 REGION=us-west-2
 INSTANCE_TYPE=t3.micro
-KEY_NAME=KEY_NAME
+KEY_NAME=test-ipv6
 PRO_IMAGE_ID=ami-07e00b8a1a054fdbf  # bionic PRO image for us-west-2
 
 # You need to have a subnet that supports IPv6. The easiest path here is to launch an ec2
-# unstance through pycloudlib, which will already create a VPC with a subnet that supports
+# instance through pycloudlib, which will already create a VPC with a subnet that supports
 # IPv6. You can also use the security group created by pycloudlib
 SUBNET_ID=<SUBNET-ID>
 SECURITY_GROUP_ID=<SG-ID>

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -1,11 +1,17 @@
+import logging
 from typing import Any, Dict
 from urllib.error import HTTPError
 
-from uaclient import util
+from uaclient import exceptions, util
 from uaclient.clouds import AutoAttachCloudInstance
 
-IMDS_V2_TOKEN_URL = "http://169.254.169.254/latest/api/token"
-IMDS_URL = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
+IMDS_IPV4_ADDRESS = "169.254.169.254"
+IMDS_IPV6_ADDRESS = "[fd00:ec2::254]"
+
+IMDS_IP_ADDRESS = (IMDS_IPV4_ADDRESS, IMDS_IPV6_ADDRESS)
+IMDS_V2_TOKEN_URL = "http://{}/latest/api/token"
+IMDS_URL = "http://{}/latest/dynamic/instance-identity/pkcs7"
+
 SYS_HYPERVISOR_PRODUCT_UUID = "/sys/hypervisor/uuid"
 DMI_PRODUCT_SERIAL = "/sys/class/dmi/id/product_serial"
 DMI_PRODUCT_UUID = "/sys/class/dmi/id/product_uuid"
@@ -18,27 +24,58 @@ AWS_TOKEN_REQ_HEADER = AWS_TOKEN_PUT_HEADER + "-ttl-seconds"
 class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
 
     _api_token = None
+    _ip_address = None
+
+    def _get_imds_url_response(self):
+        headers = self._request_imds_v2_token_headers()
+        return util.readurl(
+            IMDS_URL.format(self._ip_address), headers=headers, timeout=1
+        )
 
     # mypy does not handle @property around inner decorators
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
     def identity_doc(self) -> Dict[str, Any]:
-        headers = self._get_imds_v2_token_headers()
-        response, _headers = util.readurl(IMDS_URL, headers=headers)
+        response, _headers = self._get_imds_url_response()
         return {"pkcs7": response}
 
+    def _request_imds_v2_token_headers(self):
+        for address in IMDS_IP_ADDRESS:
+            try:
+                headers = self._get_imds_v2_token_headers(ip_address=address)
+            except HTTPError as e:
+                raise e
+            except Exception as e:
+                msg = (
+                    "Could not reach AWS IMDS at http://{endpoint}:"
+                    " {reason}\n".format(
+                        endpoint=address, reason=getattr(e, "reason", "")
+                    )
+                )
+                logging.debug(msg)
+            else:
+                self._ip_address = address
+                break
+        if self._ip_address is None:
+            raise exceptions.UserFacingError(
+                "No valid AWS IMDS endpoint discovered at addresses: %s"
+                % ", ".join(IMDS_IP_ADDRESS)
+            )
+        return headers
+
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
-    def _get_imds_v2_token_headers(self):
+    def _get_imds_v2_token_headers(self, ip_address):
         if self._api_token == "IMDSv1":
             return None
         elif self._api_token:
             return {AWS_TOKEN_PUT_HEADER: self._api_token}
         try:
             response, _headers = util.readurl(
-                IMDS_V2_TOKEN_URL,
+                IMDS_V2_TOKEN_URL.format(ip_address),
                 method="PUT",
                 headers={AWS_TOKEN_REQ_HEADER: AWS_TOKEN_TTL_SECONDS},
+                timeout=1,
             )
         except HTTPError as e:
             if e.code == 404:
@@ -46,6 +83,7 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
                 return None
             else:
                 raise
+
         self._api_token = response
         return {AWS_TOKEN_PUT_HEADER: self._api_token}
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -1023,8 +1023,8 @@ class TestConfigureWebProxy:
                 None,
                 {},
                 {
-                    "NO_PROXY": "169.254.169.254,metadata",
-                    "no_proxy": "169.254.169.254,metadata",
+                    "NO_PROXY": "169.254.169.254,[fd00:ec2::254],metadata",
+                    "no_proxy": "169.254.169.254,[fd00:ec2::254],metadata",
                 },
             ),
             (
@@ -1032,8 +1032,8 @@ class TestConfigureWebProxy:
                 "https://proxy",
                 {"no_proxy": "a,10.0.0.1"},
                 {
-                    "NO_PROXY": "10.0.0.1,169.254.169.254,a,metadata",
-                    "no_proxy": "10.0.0.1,169.254.169.254,a,metadata",
+                    "NO_PROXY": "10.0.0.1,169.254.169.254,[fd00:ec2::254],a,metadata",  # noqa
+                    "no_proxy": "10.0.0.1,169.254.169.254,[fd00:ec2::254],a,metadata",  # noqa
                 },
             ),
             (
@@ -1041,8 +1041,8 @@ class TestConfigureWebProxy:
                 "https://proxy",
                 {"NO_PROXY": "a,169.254.169.254"},
                 {
-                    "NO_PROXY": "169.254.169.254,a,metadata",
-                    "no_proxy": "169.254.169.254,a,metadata",
+                    "NO_PROXY": "169.254.169.254,[fd00:ec2::254],a,metadata",
+                    "no_proxy": "169.254.169.254,[fd00:ec2::254],a,metadata",
                 },
             ),
         ),

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -38,7 +38,7 @@ DROPPED_KEY = object()
 # N.B. this relies on the version normalisation we perform in get_platform_info
 REGEX_OS_RELEASE_VERSION = r"(?P<release>\d+\.\d+) (LTS )?\((?P<series>\w+).*"
 
-UA_NO_PROXY_URLS = ("169.254.169.254", "metadata")
+UA_NO_PROXY_URLS = ("169.254.169.254", "metadata", "[fd00:ec2::254]")
 PROXY_VALIDATION_APT_HTTP_URL = "http://archive.ubuntu.com"
 PROXY_VALIDATION_APT_HTTPS_URL = "https://esm.ubuntu.com"
 PROXY_VALIDATION_SNAP_HTTP_URL = "http://api.snapcraft.io"


### PR DESCRIPTION
## Proposed Commit Message
aws: support using IPv6 metadata endpoint

We are now adding support for AWS instances to query the IPv6 metadata endpoint. However, we are defaulting to use the IPv4 endpoint first. Only if that fails, we will try to query the IPv6 endpoint.

## Test Steps
Run the manual test introduced in this PR.
PS: Guarantee that your awscli supports the `--metadata-options`, otherwise the IPv6 endpoint will not work as expected.

PS 2: I still need to confirm that disabling the IPv4 address will generate an URLError exception. I am assuming that
is true because this is what happens if we try to query the IPv6 endpoint without properly configuring the instance. This exception is raised because of the timeout issue we get when trying to query the IPv6 endpoint. I will perform this test, but I think the PR can already be reviewed as is

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
