### PR TITLE
Save machine id during attach operation (SC-531)

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -68,6 +68,37 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.all
     @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached and detach don't reach contract endpoint if machine-id changes
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I update contract to use `machineId` as `new-machine-id`
+        And I run `ua detach --assume-yes` with sudo
+        Then I will see the following on stdout:
+            """
+            Detach will disable the following services:
+                esm-apps
+                esm-infra
+            Updating package lists
+            Updating package lists
+            This machine is now detached.
+            """
+        And I verify that running `grep "Found new machine-id. Do not call detach on contract backend" /var/log/ubuntu-advantage.log` `with sudo` exits `0`
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+          """
+          This machine is not attached to a UA subscription.
+          """
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | xenial  |
+           | hirsute |
+           | impish  |
+
+    @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -52,6 +52,22 @@ Feature: Command behaviour when attached to an UA subscription
 
     @series.all
     @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached and detach correctly reach contract endpoint
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `ua detach --assume-yes` with sudo
+        Then I verify that running `grep "Found new machine-id. Do not call detach on contract backend" /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+
+        Examples: ubuntu release
+           | release |
+           | bionic  |
+           | focal   |
+           | xenial  |
+           | hirsute |
+           | impish  |
+
+    @series.all
+    @uses.config.machine_type.lxd.container
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -78,7 +78,13 @@ class UAContractClient(serviceclient.UAServiceClient):
             API_V1_CONTEXT_MACHINE_TOKEN, data=data, headers=headers
         )
         self.cfg.write_cache("machine-token", machine_token)
+
         util.get_machine_id.cache_clear()
+        machine_id = machine_token.get("machineTokenInfo", {}).get(
+            "machineId", data.get("machineId")
+        )
+        self.cfg.write_cache("machine-id", machine_id)
+
         return machine_token
 
     def request_resources(self) -> Dict[str, Any]:
@@ -257,7 +263,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         if not detach:
             self.cfg.write_cache("machine-token", response)
             util.get_machine_id.cache_clear()
-            machine_id = response.get("machinetTokenInfo", {}).get(
+            machine_id = response.get("machineTokenInfo", {}).get(
                 "machineId", data.get("machineId")
             )
             self.cfg.write_cache("machine-id", machine_id)

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -541,8 +541,7 @@ class TestGetMachineId:
         self, FakeConfig, tmpdir
     ):
         """When no machine-id is found, use machine-id from data_dir."""
-
-        data_machine_id = tmpdir.join("machine-id")
+        data_machine_id = tmpdir.mkdir("private").join("machine-id")
         data_machine_id.write("data-machine-id")
 
         cfg = FakeConfig()
@@ -559,7 +558,7 @@ class TestGetMachineId:
         self, FakeConfig, tmpdir
     ):
         """When no machine-id is found, create one in data_dir using uuid4."""
-        data_machine_id = tmpdir.join("machine-id")
+        data_machine_id = tmpdir.mkdir("private").join("machine-id")
 
         cfg = FakeConfig()
         with mock.patch("uaclient.util.os.path.exists") as m_exists:
@@ -576,7 +575,7 @@ class TestGetMachineId:
     def test_fallback_used_if_all_other_files_are_empty(
         self, FakeConfig, tmpdir, empty_value
     ):
-        data_machine_id = tmpdir.join("machine-id")
+        data_machine_id = tmpdir.mkdir("private").join("machine-id")
         cfg = FakeConfig().for_attached_machine(
             machine_token={"some": "thing"}
         )

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -299,7 +299,7 @@ def get_machine_id(cfg) -> str:
         if cfg_machine_id:
             return cfg_machine_id
 
-    fallback_machine_id_file = os.path.join(cfg.data_dir, "machine-id")
+    fallback_machine_id_file = cfg.data_path("machine-id")
 
     for path in [ETC_MACHINE_ID, DBUS_MACHINE_ID, fallback_machine_id_file]:
         if os.path.exists(path):


### PR DESCRIPTION
## Proposed Commit Message
contract: save machine id during attach operation
    
When running an attach operation we are now saving the machine-id into our cache. We need to have that information saved on the cache to properly perform the detach operation. We are now updating our contract logic to save that information after we receive the machine token during an attach operation

## Test Steps
Run the new integration and unit tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
