### PR TITLE
fips: update integration tests for focal

### DIFF
--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -165,7 +165,6 @@ Feature: FIPS enablement in cloud based machines
             """
             Updating package lists
             Installing <fips-name> packages
-            <fips-name> strongswan-hmac package could not be installed
             <fips-name> enabled
             A reboot is required to complete install
             """
@@ -178,6 +177,8 @@ Feature: FIPS enablement in cloud based machines
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
         When I run `apt-cache policy ubuntu-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -207,6 +208,8 @@ Feature: FIPS enablement in cloud based machines
         When I reboot the `<release>` machine
         Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
         When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
         Then I will see the following on stdout:
         """
@@ -403,7 +406,6 @@ Feature: FIPS enablement in cloud based machines
             """
             Updating package lists
             Installing <fips-name> packages
-            <fips-name> strongswan-hmac package could not be installed
             <fips-name> enabled
             A reboot is required to complete install
             """
@@ -416,6 +418,8 @@ Feature: FIPS enablement in cloud based machines
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
         When I run `apt-cache policy ubuntu-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -445,6 +449,8 @@ Feature: FIPS enablement in cloud based machines
         When I reboot the `<release>` machine
         Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
         When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
         Then I will see the following on stdout:
         """

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -335,7 +335,6 @@ Feature: FIPS enablement in lxd VMs
             """
             Updating package lists
             Installing <fips-name> packages
-            FIPS strongswan-hmac package could not be installed
             <fips-name> enabled
             A reboot is required to complete install
             """
@@ -347,6 +346,8 @@ Feature: FIPS enablement in lxd VMs
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
         When I reboot the `<release>` machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
@@ -367,6 +368,8 @@ Feature: FIPS enablement in lxd VMs
         When I reboot the `<release>` machine
         Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
         When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
         Then I will see the following on stdout:
         """


### PR DESCRIPTION
## Proposed Commit Message
fips: update integration tests for focal

Initially, there was no strongswan-hmac FIPS package for Focal. Therefore, during the enable operation we state that this package could not be installed. Now that the package can be installed on a Focal machine, we are removing that message from the integration tests

## Test Steps
Run the modified integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
