### PR TITLE
token redaction: redact token log if apt-helper download-file fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Jobs are executed by the timer script if:
 - Their interval since last successful run is already exceeded.
 
 There is a random delay applied to the timer, to desynchronize job execution time
-on machines spinned at the same time, avoiding multiple synchronized calls to the
+on machines spun at the same time, avoiding multiple synchronized calls to the
 same service.
 
 Current jobs being checked and executed are:
@@ -574,5 +574,5 @@ sudo shutdown -h now
 * Use your cloud platform to clone or snapshot this VM as a golden image
 
 
-## Releasing ubuntu-adantage-tools
+## Releasing ubuntu-advantage-tools
 see [RELEASES.md](RELEASES.md)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ https://ubuntu.com/advantage.
   token, service credentials, affordances, directives and obligations to allow
   enabling and disabling Ubuntu Advantage services
 * UA client writes the machine token API response to the root-readonly
-  /var/lib/ubuntu-advantage/machine-token.json
+  /var/lib/ubuntu-advantage/private/machine-token.json
 * UA client auto-enables any services defined with
   `obligations:{enableByDefault: true}`
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -58,7 +58,7 @@ def assert_valid_apt_credentials(repo_url, username, password):
     except util.ProcessExecutionError as e:
         if e.exit_code == 100:
             stderr = str(e.stderr).lower()
-            if re.search(r"401\s+unauthorized|httperror401", stderr):
+            if re.search(r"401\s+[uU]nauthorized|httperror401", stderr):
                 raise exceptions.UserFacingError(
                     "Invalid APT credentials provided for {}".format(repo_url)
                 )

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -58,7 +58,7 @@ def assert_valid_apt_credentials(repo_url, username, password):
     except util.ProcessExecutionError as e:
         if e.exit_code == 100:
             stderr = str(e.stderr).lower()
-            if re.search(r"401\s+[uU]nauthorized|httperror401", stderr):
+            if re.search(r"401\s+unauthorized|httperror401", stderr):
                 raise exceptions.UserFacingError(
                     "Invalid APT credentials provided for {}".format(repo_url)
                 )

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -916,6 +916,16 @@ class TestRedactSensitiveLogs:
                 "'machineToken': 'SEKRET', 'machineTokenInfo': 'blah'",
                 "'machineToken': '<REDACTED>', 'machineTokenInfo': 'blah'",
             ),
+            (
+                "Failed running command '/usr/lib/apt/apt-helper download-file"
+                "https://bearer:S3-Kr3T@esm.ubuntu.com/infra/ubuntu/pool/ "
+                "[exit(100)]. Message: Download of file failed"
+                " pkgAcquire::Run (13: Permission denied)",
+                "Failed running command '/usr/lib/apt/apt-helper download-file"
+                "https://bearer:<REDACTED>@esm.ubuntu.com/infra/ubuntu/pool/ "
+                "[exit(100)]. Message: Download of file failed"
+                " pkgAcquire::Run (13: Permission denied)",
+            ),
         ),
     )
     def test_redact_all_matching_regexs(self, raw_log, expected):

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -667,7 +667,7 @@ def subp(
             if not retry_sleeps:
                 raise
             retry_msg = " Retrying %d more times." % len(retry_sleeps)
-            logging.debug(str(e) + retry_msg)
+            logging.debug(redact_sensitive_logs(str(e) + retry_msg))
             time.sleep(retry_sleeps.pop(0))
     return out, err
 
@@ -759,6 +759,7 @@ REDACT_SENSITIVE_LOGS = [
     r"(\'token\': \')[^\']+",
     r"(\'X-aws-ec2-metadata-token\': \')[^\']+",
     r"(.*\[PUT\] response.*api/token,.*data: ).*",
+    r"(https://bearer:)[\w-]*",
 ]
 
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -759,7 +759,7 @@ REDACT_SENSITIVE_LOGS = [
     r"(\'token\': \')[^\']+",
     r"(\'X-aws-ec2-metadata-token\': \')[^\']+",
     r"(.*\[PUT\] response.*api/token,.*data: ).*",
-    r"(https://bearer:)[\w-]*",
+    r"(https://bearer:)[^\@]+",
 ]
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

token redaction: redact token log if apt-helper download-file fails.

This redacts the token logged during apt-helper failure e.g. when there the tokens are incorrect. 
It also corrects the path to the *machine-token.json* file in the README. 


Fixes: #1860

## Test Steps
Run the test_util test.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
