### PR TITLE
Fix pythonpath issue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 ubuntu-advantage-tools (27.4~22.04.1) jammy; urgency=medium
 
+  * d/rules:
+    - Remove conftest file from the package
   * d/tools.postinst:
     - hardcode python binary to run python scripts (LP: #1930121)
     - undo unnecessary log file creation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 ubuntu-advantage-tools (27.4~22.04.1) jammy; urgency=medium
 
   * d/tools.postinst:
-    - hardcode python binary and PYTHONPATH (LP: #1930121)
+    - hardcode python binary to run python scripts (LP: #1930121)
     - undo unnecessary log file creation
+  * d/tools.prerm:
+    - hardcode python binary to run python scripts (LP: #1930121)
   * New upstream release 27.4 (LP: #1949634)
     - cc-eal: remove beta flag
     - cli:

--- a/debian/rules
+++ b/debian/rules
@@ -68,6 +68,8 @@ override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
 	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
+	# We want to guarantee that we are not shipping any conftest files
+	find $(CURDIR)/debian/ubuntu-advantage-tools -type f -name conftest.py -delete
 
 ifeq (${VERSION_ID},"14.04")
 	# Move ua-auto-attach.conf out to ubuntu-advantage-pro

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -16,8 +16,6 @@ fi
 # https://lintian.debian.org/tags/postinst-does-not-load-confmodule.html
 . /usr/share/debconf/confmodule
 
-PYTHON="/usr/bin/env PYTHONPATH=/usr/lib/python3/dist-packages /usr/bin/python3"
-
 APT_TRUSTED_KEY_DIR="/etc/apt/trusted.gpg.d"
 UA_KEYRING_DIR="/usr/share/keyrings/"
 
@@ -58,7 +56,7 @@ MACHINE_TOKEN_FILE="/var/lib/ubuntu-advantage/private/machine-token.json"
 # Rename apt config files for ua services removing ubuntu release names
 redact_ubuntu_release_from_ua_apt_filenames() {
     DIR=$1
-    UA_SERVICES=$($PYTHON -c "
+    UA_SERVICES=$(/usr/bin/python3 -c "
 from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 print(*ENTITLEMENT_CLASS_BY_NAME.keys(), sep=' ')
 ")
@@ -118,7 +116,7 @@ check_is_active_esm() {
 # Check whether a given service is beta
 check_service_is_beta() {
     service_name=$1
-    _IS_BETA_SVC=$($PYTHON -c "
+    _IS_BETA_SVC=$(/usr/bin/python3 -c "
 from uaclient.config import UAConfig
 from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 ent_cls = ENTITLEMENT_CLASS_BY_NAME.get('${service_name}')
@@ -140,7 +138,7 @@ fi
 # Check cached service status from status.json and return 0 if enabled else 1
 check_service_is_enabled() {
     service_name=$1
-    _RET=$($PYTHON -c "
+    _RET=$(/usr/bin/python3 -c "
 import os
 import json
 from uaclient.config import UAConfig
@@ -257,7 +255,7 @@ mark_reboot_for_fips_pro() {
 
 add_notice() {
     msg_name=$1
-    $PYTHON -c "
+    /usr/bin/python3 -c "
 from uaclient.config import UAConfig
 from uaclient.status import ${msg_name}
 cfg = UAConfig()

--- a/debian/ubuntu-advantage-tools.prerm
+++ b/debian/ubuntu-advantage-tools.prerm
@@ -2,10 +2,8 @@
 
 set -e
 
-PYTHON="/usr/bin/env PYTHONPATH=/usr/lib/python3/dist-packages /usr/bin/python3"
-
 remove_apt_files() {
-    $PYTHON -c '
+    /usr/bin/python3 -c '
 from uaclient.apt import clean_apt_files
 
 clean_apt_files()

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -52,8 +52,9 @@ Feature: UA Install and Uninstall related tests
     Scenario Outline: Do not fail during postinst with nonstandard python setup
         Given a `<release>` machine with ubuntu-advantage-tools installed
         # Works when in a python virtualenv
-        When I run `apt install python3-venv -y` with sudo
-        When I run `python3 -m venv env` with sudo
+        When I run `apt update` with sudo
+        And I run `apt install python3-venv -y` with sudo
+        And I run `python3 -m venv env` with sudo
         Then I verify that running `bash -c ". env/bin/activate && python3 -c 'import uaclient'"` `with sudo` exits `1`
         Then stderr matches regexp:
         """
@@ -80,17 +81,8 @@ Feature: UA Install and Uninstall related tests
         """
         Then I verify that running `dpkg-reconfigure ubuntu-advantage-tools` `with sudo` exits `0`
 
-        # Works even when user overwrites /usr/bin/python3 with their version
-        When I run `ln -sf /usr/local/bin/python3.10 /usr/bin/python3` with sudo
-        Then I verify that running `/usr/bin/python3 -c "import uaclient"` `with sudo` exits `1`
-        Then stderr matches regexp:
-        """
-        No module named 'uaclient'
-        """
-        Then I verify that running `dpkg-reconfigure ubuntu-advantage-tools` `with sudo` exits `0`
-
         Examples: ubuntu release
-           | release | deadsnakes-pkg | deadsnakes-version |
-           | xenial  | python3.9      | 3.9.4              |
-           | bionic  | python3.9      | 3.9.7              |
-           | focal   | python3.9      | 3.9.7              |
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |


### PR DESCRIPTION
## Proposed Commit Message
Fix pythonpath issue

Instead of setting the PYTHONPATH to guarantee that uaclient will be present in the user environment, we are now running the python scripts through /usr/bin/python3. This will guarantee that if the user has not replaced that path with a custom version, that uaclient will be imported successfully.

## Test Steps
Run the modified integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
