### PR TITLE
Show non-root user updated information in security-status

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -733,7 +733,7 @@ Feature: Command behaviour when attached to an UA subscription
         "status": "pending_attach"
         """
         When I attach `contract_token` with sudo
-        And I run `ua security-status --format json --beta` with sudo
+        And I run `ua security-status --format json --beta` as non-root
         Then stdout matches regexp:
         """
         "_schema_version": "0"
@@ -744,11 +744,11 @@ Feature: Command behaviour when attached to an UA subscription
         """
         And stdout matches regexp:
         """
-        "enabled_services": \["esm-infra", "esm-apps"\]
+        "enabled_services": \["esm-apps", "esm-infra"\]
         """
         And stdout matches regexp:
         """
-        "entitled_services": \["esm-infra", "esm-apps"\]
+        "entitled_services": \["esm-apps", "esm-infra"\]
         """
         And stdout matches regexp:
         """

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -28,8 +28,9 @@ optional arguments:
 )
 
 
+@mock.patch(M_PATH + "security_status.security_status")
 class TestActionSecurityStatus:
-    def test_security_status_help(self, capsys):
+    def test_security_status_help(self, _m_security_status, capsys):
         with pytest.raises(SystemExit):
             with mock.patch(
                 "sys.argv", ["/usr/bin/ua", "security-status", "--help"]
@@ -40,7 +41,6 @@ class TestActionSecurityStatus:
         assert HELP_OUTPUT == out
 
     @pytest.mark.parametrize("output_format", ("json", "yaml"))
-    @mock.patch(M_PATH + "security_status.security_status")
     @mock.patch(M_PATH + "yaml.safe_dump")
     @mock.patch(M_PATH + "json.dumps")
     def test_action_security_status(
@@ -71,7 +71,9 @@ class TestActionSecurityStatus:
 
     # Remove this once we have human-readable text
     @pytest.mark.parametrize("with_wrong_format", (False, True))
-    def test_require_format_flag(self, with_wrong_format, FakeConfig, capsys):
+    def test_require_format_flag(
+        self, _m_security_status, with_wrong_format, FakeConfig, capsys
+    ):
         cmdline_args = ["/usr/bin/ua", "security-status"]
         if with_wrong_format:
             cmdline_args.extend(["--format", "unsupported"])
@@ -97,7 +99,10 @@ class TestActionSecurityStatus:
         "beta_flag, expected_err",
         ((False, "the following arguments are required: --beta"), (True, "")),
     )
-    def test_require_beta_flag(self, beta_flag, expected_err, capsys):
+    def test_require_beta_flag(
+        self, m_security_status, beta_flag, expected_err, capsys
+    ):
+        m_security_status.return_value = {}
         cmdline_args = ["/usr/bin/ua", "security-status", "--format", "json"]
         if beta_flag:
             cmdline_args.extend(["--beta"])


### PR DESCRIPTION
A non-root user cannot read internals like `UAConfig.is_attached`, for instance.
Using the `.status` dict makes sure the same information surfaced to `ua status` reflects in the `security-status` output.

(Then, since we already have the status dict, we can check the services there as well)

## Test Steps
Run the related integration test

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
