### PR TITLE
Return 2 when attaching an already attached machine (SC-573)

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -71,6 +71,12 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         """
         Enabling default service esm-infra
         """
+        When I verify that running `ua attach contract_token` `with sudo` exits `2`
+        Then stderr matches regexp:
+        """
+        This machine is already attached to '.+'
+        To use a different subscription first run: sudo ua detach.
+        """
         When I run `ua disable esm-apps --assume-yes` with sudo
         When I append the following on uaclient config:
             """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -213,7 +213,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
             This command must be run as root \(try using sudo\).
             """
-        When I run `ua auto-attach` with sudo
+        When I verify that running `ua auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
             """
             This machine is already attached

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -186,6 +186,21 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             ros           +no  +(-|—) +Security Updates for the Robot Operating System
             ros-updates   +no  +(-|—) +All Updates for the Robot Operating System
             """
+        When I run `systemctl start ua-auto-attach.service` with sudo
+        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
+        Then stdout matches regexp:
+        """
+        .*status=0\/SUCCESS.*
+        """
+        And stdout matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
+        When I run `ua auto-attach` with sudo
+        Then stderr matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
         """
@@ -279,6 +294,21 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             ros           +no  +(-|—) +Security Updates for the Robot Operating System
             ros-updates   +no  +(-|—) +All Updates for the Robot Operating System
             """
+        When I run `systemctl start ua-auto-attach.service` with sudo
+        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
+        Then stdout matches regexp:
+        """
+        .*status=0\/SUCCESS.*
+        """
+        And stdout matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
+        When I run `ua auto-attach` with sudo
+        Then stderr matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
         """
@@ -372,6 +402,21 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             ros           +no  +(-|—) +Security Updates for the Robot Operating System
             ros-updates   +no  +(-|—) +All Updates for the Robot Operating System
             """
+        When I run `systemctl start ua-auto-attach.service` with sudo
+        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
+        Then stdout matches regexp:
+        """
+        .*status=0\/SUCCESS.*
+        """
+        And stdout matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
+        When I run `ua auto-attach` with sudo
+        Then stderr matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
         """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1036,6 +1036,9 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
 
     :param cfg: a ``config.UAConfig`` instance
 
+    :raise AlreadyAttachedError: When attached on a non-Pro Image
+    :raise AlreadyAttachedOnPROError: When attached on a Pro Image with the
+        same current instance ID
     :raise NonAutoAttachImageError: When not on an auto-attach image type.
     :raise UrlError: On unexpected connectivity issues to contract
         server or inability to access identity doc from metadata service.
@@ -1058,7 +1061,7 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
     if cfg.is_attached:
         prev_iid = cfg.read_cache("instance-id")
         if str(current_iid) == str(prev_iid):
-            raise exceptions.AlreadyAttachedError(cfg)
+            raise exceptions.AlreadyAttachedOnPROError(str(current_iid))
         print("Re-attaching Ubuntu Advantage subscription on new instance")
         if _detach(cfg, assume_yes=True) != 0:
             raise exceptions.UserFacingError(

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -38,7 +38,7 @@ class NonAutoAttachImageError(UserFacingError):
 class AlreadyAttachedError(UserFacingError):
     """An exception to be raised when a command needs an unattached system."""
 
-    exit_code = 0
+    exit_code = 2
 
     def __init__(self, cfg):
         super().__init__(

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -35,6 +35,19 @@ class NonAutoAttachImageError(UserFacingError):
     exit_code = 0
 
 
+class AlreadyAttachedOnPROError(UserFacingError):
+    """Raised when a PRO machine retries attaching with the same instance-id"""
+
+    exit_code = 0
+
+    def __init__(self, instance_id: str):
+        super().__init__(
+            status.MESSAGE_ALREADY_ATTACHED_ON_PRO.format(
+                instance_id=instance_id
+            )
+        )
+
+
 class AlreadyAttachedError(UserFacingError):
     """An exception to be raised when a command needs an unattached system."""
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -227,6 +227,8 @@ MESSAGE_ENABLED_TMPL = "{title} enabled"
 MESSAGE_ALREADY_ATTACHED = """\
 This machine is already attached to '{account_name}'
 To use a different subscription first run: sudo ua detach."""
+MESSAGE_ALREADY_ATTACHED_ON_PRO = """\
+Skipping attach: Instance '{instance_id}' is already attached."""
 MESSAGE_ALREADY_ENABLED_TMPL = """\
 {title} is already enabled.\nSee: sudo ua status"""
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -527,7 +527,7 @@ class TestMain:
         "exception,expected_exit_code",
         [
             (UserFacingError("You need to know about this."), 1),
-            (AlreadyAttachedError(mock.MagicMock()), 0),
+            (AlreadyAttachedError(mock.MagicMock()), 2),
             (
                 LockHeldError(
                     pid="123",

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -14,6 +14,7 @@ from uaclient.cli import (
 from uaclient.contract import ContractAPIError
 from uaclient.exceptions import (
     AlreadyAttachedError,
+    AlreadyAttachedOnPROError,
     LockHeldError,
     NonAutoAttachImageError,
     NonRootUserError,
@@ -200,7 +201,7 @@ class TestGetContractTokenFromCloudIdentity:
                 )
             assert [mock.call(cfg, assume_yes=True)] == m_detach.call_args_list
         else:
-            with pytest.raises(AlreadyAttachedError):
+            with pytest.raises(AlreadyAttachedOnPROError):
                 _get_contract_token_from_cloud_identity(cfg)
         # current instance-id is persisted for next auto-attach call
         assert iid_response == cfg.read_cache("instance-id")
@@ -256,7 +257,7 @@ class TestGetContractTokenFromCloudIdentity:
         iid_old,
         FakeConfig,
     ):
-        """When instance-id changes since last attach, call detach."""
+        """Treat numeric and string values for instance ID as the same."""
 
         get_instance_id.return_value = iid_curr
         cloud_instance_factory.side_effect = self.fake_instance_factory
@@ -271,7 +272,7 @@ class TestGetContractTokenFromCloudIdentity:
         # persist old instance-id value
         cfg.write_cache("instance-id", iid_old)
 
-        with pytest.raises(AlreadyAttachedError):
+        with pytest.raises(AlreadyAttachedOnPROError):
             _get_contract_token_from_cloud_identity(cfg)
         assert str(iid_curr) == str(cfg.read_cache("instance-id"))
 

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -31,6 +31,11 @@ The optional \fI--no-auto-enable\fR flag will disable the automatic
 enablement of recommended entitlements which usually happens immediately
 after a successful attach.
 
+The exit code can be:
+    0: on successful attach
+    1: in case of any error while trying to attach
+    2: if the machine is already attached
+
 .TP
 .B collect-logs [-o <file>| --output <file>]
 Create a tarball with all relevant UA logs and debug data.


### PR DESCRIPTION
No attach for the attached.

Consider attaching a machine that is already attached to an UA subscription as an error, and return `2` as a specific error code. More context in the bug.

Fixes: #1867

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
