### PR TITLE
fix: only run the status job on attached machines

### DIFF
--- a/uaclient/jobs/update_state.py
+++ b/uaclient/jobs/update_state.py
@@ -6,5 +6,6 @@ from uaclient.config import UAConfig
 
 
 def update_status(cfg: UAConfig) -> bool:
-    cfg.status()
+    if cfg.is_attached:
+        cfg.status()
     return True


### PR DESCRIPTION
If a machine is not attached, there is no need to query for the UA status to update the data.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
