### PR TITLE
purge: Remove all gpg files during apt purge (SC-537)

### DIFF
--- a/debian/ubuntu-advantage-tools.postrm
+++ b/debian/ubuntu-advantage-tools.postrm
@@ -19,9 +19,7 @@ remove_logs(){
 }
 
 remove_gpg_files(){
-    rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-infra-trusty.gpg
-    rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-esm-apps.gpg
-    rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-fips.gpg
+    rm -f /etc/apt/trusted.gpg.d/ubuntu-advantage-*.gpg
 }
 
 case "$1" in


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->


purge: remove all the gpg files during apt purge

Now we can delete the gpg files in **/etc/apt/trusted.gpg.d/** folder belonging to ubuntu-advantage-tools.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
