### PR TITLE
fips: avoid writing to real file when testing

### DIFF
--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -936,8 +936,9 @@ class TestFipsEntitlementInstallPackages:
         self, m_run_apt, entitlement
     ):
         m_run_apt.side_effect = exceptions.UserFacingError("error")
-        with pytest.raises(exceptions.UserFacingError):
-            entitlement.install_packages()
+        with mock.patch.object(entitlement, "_cleanup"):
+            with pytest.raises(exceptions.UserFacingError):
+                entitlement.install_packages()
 
     @mock.patch(M_PATH + "apt.get_installed_packages")
     @mock.patch(M_PATH + "apt.run_apt_command")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

fips: avoid writing to real file when testing

Tests were failing when some services when enabled and mainly because they, tests, are writing to a real life i.e. **/etc/apt/auth.conf.d/90ubuntu-advantage** resulting to **PermissionError**


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Enable services e.g. esm-infra or cis and run the tests. 
## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
