### PR TITLE
drop dh-systemd from build-depends on ubuntu-16.04+

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: bash-completion,
                debhelper (>=9),
                dh-python,
-               dh-systemd,
+               debhelper (>= 9.20160709~) | dh-systemd,
                gettext,
                git,
                libapt-pkg-dev,


### PR DESCRIPTION
The dh-systemd functionality got merged into debhelper with
version 9.20160709. So this commit expresses this by changing
the build-depends on `debhelper (>= 9.20160709~) | dh-systemd`
