### PR TITLE
status: show only entitlements which exist in the server

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -183,8 +183,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             fips          +yes +<fips-s> +NIST-certified core packages
             fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
             livepatch     +yes +enabled  +Canonical Livepatch service
-            ros           +no  +(-|—) +Security Updates for the Robot Operating System
-            ros-updates   +no  +(-|—) +All Updates for the Robot Operating System
             """
         When I run `systemctl start ua-auto-attach.service` with sudo
         And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
@@ -291,8 +289,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             fips          +yes +<fips-s> +NIST-certified core packages
             fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
             livepatch     +yes +<livepatch>  +Canonical Livepatch service
-            ros           +no  +(-|—) +Security Updates for the Robot Operating System
-            ros-updates   +no  +(-|—) +All Updates for the Robot Operating System
             """
         When I run `systemctl start ua-auto-attach.service` with sudo
         And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
@@ -399,8 +395,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             fips          +yes +<fips-s> +NIST-certified core packages
             fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
             livepatch     +yes +<livepatch>  +Canonical Livepatch service
-            ros           +no  +(-|—) +Security Updates for the Robot Operating System
-            ros-updates   +no  +(-|—) +All Updates for the Robot Operating System
             """
         When I run `systemctl start ua-auto-attach.service` with sudo
         And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -19,10 +19,19 @@ M_PATH = "uaclient.cli."
 RESPONSE_AVAILABLE_SERVICES = [
     {"name": "livepatch", "available": True},
     {"name": "fips", "available": False},
+    {"name": "esm-infra", "available": False},
+    {"name": "esm-apps", "available": False},
+    {"name": "fips-updates", "available": False},
+    {"name": "ros", "available": False},
+    {"name": "ros-updates", "available": False},
 ]
+
 UNATTACHED_STATUS = """\
 SERVICE       AVAILABLE  DESCRIPTION
+esm-infra     no         UA Infra: Extended Security Maintenance (ESM)
 fips          no         NIST-certified core packages
+fips-updates  no         NIST-certified core packages with priority\
+ security updates
 livepatch     yes        Canonical Livepatch service
 
 This machine is not attached to a UA subscription.
@@ -31,9 +40,6 @@ See https://ubuntu.com/advantage
 
 ATTACHED_STATUS = """\
 SERVICE       ENTITLED  STATUS    DESCRIPTION
-cc-eal        no        {dash}         Common Criteria EAL2 Provisioning\
- Packages
-cis           no        {dash}         Center for Internet Security Audit Tools
 esm-apps      no        {dash}         UA Apps: Extended Security Maintenance\
  (ESM)
 esm-infra     no        {dash}         UA Infra: Extended Security Maintenance\
@@ -58,9 +64,6 @@ Technical support level: n/a
 # Omit beta services from status
 ATTACHED_STATUS_NOBETA = """\
 SERVICE       ENTITLED  STATUS    DESCRIPTION
-cc-eal        no        {dash}         Common Criteria EAL2 Provisioning\
- Packages
-cis           no        {dash}         Center for Internet Security Audit Tools
 esm-infra     no        {dash}         UA Infra: Extended Security Maintenance\
  (ESM)
 fips          no        {dash}         NIST-certified core packages
@@ -79,24 +82,6 @@ Technical support level: n/a
 BETA_SVC_NAMES = ["esm-apps", "ros", "ros-updates"]
 
 SERVICES_JSON_ALL = [
-    {
-        "description": "Common Criteria EAL2 Provisioning Packages",
-        "description_override": None,
-        "entitled": "no",
-        "name": "cc-eal",
-        "status": "—",
-        "status_details": "",
-        "available": "yes",
-    },
-    {
-        "description": "Center for Internet Security Audit Tools",
-        "description_override": None,
-        "entitled": "no",
-        "name": "cis",
-        "status": "—",
-        "status_details": "",
-        "available": "yes",
-    },
     {
         "description": "UA Apps: Extended Security Maintenance (ESM)",
         "description_override": None,


### PR DESCRIPTION
If an entitlement does not exist in the Contracts Server, then we don't need to surface it.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
