### PR TITLE
tests: add dpkg-query check for version test

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -12,10 +12,18 @@ Feature: UA is expected version
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Check ua version
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua version` with sudo
-        Then I will see the following on stdout
+        When I run `dpkg-query --showformat='${Version}' --show ubuntu-advantage-tools` with sudo
+        Then stdout matches regexp:
         """
         {UACLIENT_BEHAVE_CHECK_VERSION}
+        """
+        When I run `ua version` with sudo
+        Then stdout matches regexp:
+        # We are adding that regex here to match possible config overrides
+        # we add. For example, on PRO machines we add a config override to
+        # disable auto-attach on boot
+        """
+        {UACLIENT_BEHAVE_CHECK_VERSION}.*
         """
         Examples: version
             | release |
@@ -31,10 +39,18 @@ Feature: UA is expected version
     @upgrade
     Scenario Outline: Check ua version
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `ua version` with sudo
+        When I run `dpkg-query --showformat='${Version}' --show ubuntu-advantage-tools` with sudo
         Then I will see the following on stdout
         """
         {UACLIENT_BEHAVE_CHECK_VERSION}
+        """
+        When I run `ua version` with sudo
+        Then stdout matches regexp:
+        # We are adding that regex here to match possible config overrides
+        # we add. For example, on PRO machines we add a config override to
+        # disable auto-attach on boot
+        """
+        {UACLIENT_BEHAVE_CHECK_VERSION}.*
         """
         Examples: version
             | release |


### PR DESCRIPTION
## Proposed Commit Message
tests: add dpkg-query check for version test

Add dpkg-query check to verify the package version.
We cannot compare if the ua version is equal to the dpkg-query output because of our config overrides on some tests (PRO instances)

However, we now also don't need to provide the package version if the config overrides details on it, which I think is an improvement

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
Run the modified integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
