### PR TITLE
postinst: fix service check for unattached machine

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -147,9 +147,9 @@ from uaclient.config import UAConfig
 cfg = UAConfig()
 status = cfg.read_cache('status-cache')
 if status:
-    for service in status['services']:
-       if service['name'] == '${service_name}':
-           print(service['status'])
+    for service in status.get('services', []):
+       if service.get('name', '') == '${service_name}':
+           print(service.get('status', ''))
 ")
    if [ "${_RET}" = "enabled" ]; then
        return  0


### PR DESCRIPTION
## Proposed Commit Message
postinst: fix service check for unattached machine

When running in a LTS machine with an architecture that is different from i386 and amd64 we will try to unconfigure esm services on these non-supported architectures. Before we unconfigure those services, we check to see if they are enabled. However, the code that performs that check is looking for a key in the status cache that is only present when machine is attached to a subscription. We are now updating the code to not fail if the machine is unattached.

LP: #1951705
Fixes: #1888

## Test Steps
To reproduce that error:

1. Launch an ubuntu machine:
     `lxc launch ubuntu-daily:xenial dev-x`
2. SSH into the machine and update ubuntu-advantage-tools to 27.4.1
3. Run `ua status`
4. Go into `/var/lib/dpkg/info/ubuntu-advantage-tools.postinst` and change the `ESM_SUPPORTED_ARCHS` variable to be empty
5. Run `dpkg-reconfigure ubuntu-advantage-tools`
6. Confirm that the expected error is there
7. Apply this change into the postint
8. Run the command again and verify that no errors are shown


## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
