### PR TITLE
refactor: decouple cloud factory from cli

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1056,12 +1056,28 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
     """
     try:
         instance = identity.cloud_instance_factory()
-    except exceptions.UserFacingError as e:
+    except exceptions.CloudFactoryError as e:
         if cfg.is_attached:
             # We are attached on non-Pro Image, just report already attached
             raise exceptions.AlreadyAttachedError(cfg)
-        # Unattached on non-Pro return UserFacing error msg details
-        raise e
+        if isinstance(e, exceptions.CloudFactoryNoCloudError):
+            raise exceptions.UserFacingError(
+                ua_status.MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE
+            )
+        if isinstance(e, exceptions.CloudFactoryNonViableCloudError):
+            raise exceptions.UserFacingError(
+                ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
+            )
+        if isinstance(e, exceptions.CloudFactoryUnsupportedCloudError):
+            raise exceptions.NonAutoAttachImageError(
+                ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(
+                    cloud_type=e.cloud_type
+                )
+            )
+        # we shouldn't get here, but this is a reasonable default just in case
+        raise exceptions.UserFacingError(
+            ua_status.MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE
+        )
     current_iid = identity.get_instance_id()
     if cfg.is_attached:
         prev_iid = cfg.read_cache("instance-id")

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from uaclient import status
 
 
@@ -115,3 +117,20 @@ class SecurityAPIMetadataError(UserFacingError):
             + "\n"
             + status.MESSAGE_SECURITY_ISSUE_NOT_RESOLVED.format(issue=issue_id)
         )
+
+
+class CloudFactoryError(Exception):
+    def __init__(self, cloud_type: Optional[str]) -> None:
+        self.cloud_type = cloud_type
+
+
+class CloudFactoryNoCloudError(CloudFactoryError):
+    pass
+
+
+class CloudFactoryUnsupportedCloudError(CloudFactoryError):
+    pass
+
+
+class CloudFactoryNonViableCloudError(CloudFactoryError):
+    pass


### PR DESCRIPTION
## Notes
This is part of a series of PRs to support migrating the gcp auto attach job to the daemon. They should be reviewed/merged in the following order:

- [ ] #1894 (this one)
- [ ] #1895 
- [ ] #1896 
- [ ] #1887

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
refactor: decouple cloud factory from cli
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Ensure auto-attach still works correctly

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
