### PR TITLE
refactor: decouple lock from cli

### DIFF
--- a/uaclient/lock.py
+++ b/uaclient/lock.py
@@ -1,0 +1,106 @@
+import functools
+import logging
+import os
+import time
+
+from uaclient import config, exceptions
+
+LOG = logging.getLogger("ua.lock")
+
+# Set a module-level callable here so we don't have to reinstantiate
+# UAConfig in order to determine dynamic data_path exception handling of
+# main_error_handler
+clear_lock_file = None
+
+
+def clear_lock_file_if_present():
+    global clear_lock_file
+    if clear_lock_file:
+        clear_lock_file()
+
+
+class SingleAttemptLock:
+    """
+    Context manager for gaining exclusive access to the lock file.
+    Create a lock file if absent. The lock file will contain a pid of the
+    running process, and a customer-visible description of the lock holder.
+
+    :param lock_holder: String with the service name or command which is
+        holding the lock. This lock_holder string will be customer visible in
+        status.json.
+    :raises: LockHeldError if lock is held.
+    """
+
+    def __init__(self, *_args, cfg: config.UAConfig, lock_holder: str):
+        self.cfg = cfg
+        self.lock_holder = lock_holder
+
+    def __enter__(self):
+        global clear_lock_file
+        (lock_pid, cur_lock_holder) = self.cfg.check_lock_info()
+        if lock_pid > 0:
+            raise exceptions.LockHeldError(
+                lock_request=self.lock_holder,
+                lock_holder=cur_lock_holder,
+                pid=lock_pid,
+            )
+        self.cfg.write_cache(
+            "lock", "{}:{}".format(os.getpid(), self.lock_holder)
+        )
+        notice_msg = "Operation in progress: {}".format(self.lock_holder)
+        self.cfg.add_notice("", notice_msg)
+        clear_lock_file = functools.partial(self.cfg.delete_cache_key, "lock")
+
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        global clear_lock_file
+        self.cfg.delete_cache_key("lock")
+        clear_lock_file = None  # Unset due to successful lock delete
+
+
+class SpinLock(SingleAttemptLock):
+    """
+    Context manager for gaining exclusive access to the lock file. In contrast
+    to the SingleAttemptLock, the SpinLock will try several times to acquire
+    the lock before giving up. The number of times to try and how long to sleep
+    in between tries is configurable.
+
+    :param lock_holder: String with the service name or command which is
+        holding the lock. This lock_holder string will be customer visible in
+        status.json.
+    :param sleep_time: Number of seconds to sleep before retrying if the lock
+        is already held.
+    :param max_retries: Maximum number of times to try to grab the lock before
+        giving up and raising a LockHeldError.
+    :raises: LockHeldError if lock is held after (sleep_time * max_retries)
+    """
+
+    def __init__(
+        self,
+        *_args,
+        cfg: config.UAConfig,
+        lock_holder: str,
+        sleep_time: int = 10,
+        max_retries: int = 12
+    ):
+        super().__init__(cfg=cfg, lock_holder=lock_holder)
+        self.sleep_time = sleep_time
+        self.max_retries = max_retries
+
+    def __enter__(self):
+        LOG.debug("spin lock starting for {}".format(self.lock_holder))
+        tries = 0
+        while True:
+            try:
+                super().__enter__()
+                break
+            except exceptions.LockHeldError as e:
+                LOG.debug(
+                    "SpinLock Attempt {}. {}. Spinning...".format(
+                        tries + 1, e.msg
+                    )
+                )
+                tries += 1
+                if tries >= self.max_retries:
+                    raise e
+                else:
+                    time.sleep(self.sleep_time)

--- a/uaclient/tests/test_lock.py
+++ b/uaclient/tests/test_lock.py
@@ -1,0 +1,166 @@
+import mock
+import pytest
+
+from uaclient.exceptions import LockHeldError
+from uaclient.lock import SingleAttemptLock, SpinLock
+from uaclient.status import MESSAGE_LOCK_HELD
+
+M_PATH = "uaclient.lock."
+M_PATH_UACONFIG = "uaclient.config.UAConfig."
+
+
+@pytest.mark.parametrize("lock_cls", (SingleAttemptLock, SpinLock))
+@mock.patch("os.getpid", return_value=123)
+@mock.patch(M_PATH_UACONFIG + "delete_cache_key")
+@mock.patch(M_PATH_UACONFIG + "add_notice")
+@mock.patch(M_PATH_UACONFIG + "write_cache")
+class TestLockCommon:
+    def test_creates_and_releases_lock(
+        self,
+        m_write_cache,
+        m_add_notice,
+        m_delete_cache_key,
+        _m_getpid,
+        lock_cls,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        arg = mock.sentinel.arg
+
+        def test_function(arg):
+            assert arg == mock.sentinel.arg
+            return mock.sentinel.success
+
+        with lock_cls(cfg=cfg, lock_holder="some operation"):
+            ret = test_function(arg)
+
+        assert mock.sentinel.success == ret
+        assert [
+            mock.call("lock", "123:some operation")
+        ] == m_write_cache.call_args_list
+        lock_msg = "Operation in progress: some operation"
+        assert [mock.call("", lock_msg)] == m_add_notice.call_args_list
+        assert [mock.call("lock")] == m_delete_cache_key.call_args_list
+
+    def test_creates_and_releases_lock_when_error_occurs(
+        self,
+        m_write_cache,
+        m_add_notice,
+        m_delete_cache_key,
+        _m_getpid,
+        lock_cls,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+
+        def test_function():
+            raise RuntimeError("test")
+
+        with pytest.raises(RuntimeError) as exc:
+            with lock_cls(cfg=cfg, lock_holder="some operation"):
+                test_function()
+
+        assert "test" == str(exc.value)
+        assert [
+            mock.call("lock", "123:some operation")
+        ] == m_write_cache.call_args_list
+        lock_msg = "Operation in progress: some operation"
+        assert [mock.call("", lock_msg)] == m_add_notice.call_args_list
+        assert [mock.call("lock")] == m_delete_cache_key.call_args_list
+
+
+@mock.patch("os.getpid", return_value=123)
+@mock.patch(M_PATH_UACONFIG + "delete_cache_key")
+@mock.patch(M_PATH_UACONFIG + "add_notice")
+@mock.patch(M_PATH_UACONFIG + "write_cache")
+class TestSingleAttemptLock:
+    @mock.patch(M_PATH_UACONFIG + "check_lock_info", return_value=(10, "held"))
+    def test_raises_lock_held_when_held(
+        self,
+        _m_check_lock_info,
+        m_write_cache,
+        m_add_notice,
+        m_delete_cache_key,
+        _m_getpid,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        arg = mock.sentinel.arg
+
+        def test_function(args, cfg):
+            assert arg == mock.sentinel.arg
+            return mock.sentinel.success
+
+        with pytest.raises(LockHeldError) as exc:
+            with SingleAttemptLock(cfg=cfg, lock_holder="some operation"):
+                test_function(arg, cfg=cfg)
+
+        assert (
+            "Unable to perform: some operation.\n"
+            + MESSAGE_LOCK_HELD.format(lock_holder="held", pid=10)
+            == exc.value.msg
+        )
+
+        assert [] == m_write_cache.call_args_list
+        assert [] == m_add_notice.call_args_list
+        assert [] == m_delete_cache_key.call_args_list
+
+
+class TestSpinLock:
+    @mock.patch(M_PATH + "time.sleep")
+    @mock.patch(
+        M_PATH + "SingleAttemptLock.__enter__",
+        side_effect=[
+            LockHeldError("request", "holder", 10),
+            LockHeldError("request", "holder", 10),
+            None,
+        ],
+    )
+    def test_spins_when_lock_held(
+        self, m_single_attempt_lock_enter, m_sleep, FakeConfig
+    ):
+        cfg = FakeConfig()
+
+        with SpinLock(
+            cfg=cfg, lock_holder="request", sleep_time=1, max_retries=3
+        ):
+            pass
+
+        assert [
+            mock.call(),
+            mock.call(),
+            mock.call(),
+        ] == m_single_attempt_lock_enter.call_args_list
+        assert [mock.call(1), mock.call(1)] == m_sleep.call_args_list
+
+    @mock.patch(M_PATH + "time.sleep")
+    @mock.patch(
+        M_PATH + "SingleAttemptLock.__enter__",
+        side_effect=[
+            LockHeldError("request", "holder", 10),
+            LockHeldError("request", "holder", 10),
+            None,
+        ],
+    )
+    def test_raises_lock_held_after_max_retries(
+        self, m_single_attempt_lock_enter, m_sleep, FakeConfig
+    ):
+        cfg = FakeConfig()
+
+        with pytest.raises(LockHeldError) as exc:
+            with SpinLock(
+                cfg=cfg, lock_holder="request", sleep_time=1, max_retries=2
+            ):
+                pass
+
+        assert (
+            "Unable to perform: request.\n"
+            + MESSAGE_LOCK_HELD.format(lock_holder="holder", pid=10)
+            == exc.value.msg
+        )
+
+        assert [
+            mock.call(),
+            mock.call(),
+        ] == m_single_attempt_lock_enter.call_args_list
+        assert [mock.call(1)] == m_sleep.call_args_list

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -24,12 +24,15 @@ class TestMain:
                 "uaclient.config.UAConfig.check_lock_info"
             ) as m_check_lock:
                 m_check_lock.return_value = (123, "ua auto-attach")
-                with mock.patch("lib.reboot_cmds.time.sleep") as m_sleep:
+                with mock.patch("time.sleep") as m_sleep:
                     main(cfg=cfg)
         assert [
             mock.call(1),
             mock.call(1),
-            mock.call(5),
+            mock.call(1),
+            mock.call(1),
+            mock.call(1),
+            mock.call(1),
         ] == m_sleep.call_args_list
         assert 1 == excinfo.value.code
         assert (
@@ -154,10 +157,7 @@ class TestProcessRebootOperations:
             with mock.patch("uaclient.config.UAConfig.write_cache"):
                 process_reboot_operations(cfg=cfg)
 
-        expected_calls = [
-            mock.call("", "Operation in progress: ua-reboot-cmds"),
-            mock.call("", MESSAGE_REBOOT_SCRIPT_FAILED),
-        ]
+        expected_calls = [mock.call("", MESSAGE_REBOOT_SCRIPT_FAILED)]
 
         assert expected_calls == m_add_notice.call_args_list
 


### PR DESCRIPTION
## Notes
This is part of a series of PRs to support migrating the gcp auto attach job to the daemon. They should be reviewed/merged in the following order:

- [x] #1894
- [ ] #1895 (this one)
- [ ] #1896 
- [ ] #1887

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
refactor: decouple lock from cli
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Ensure all locking cli commands still work and correctly conflict with each other.

Ensure trying to run an attach while a pro instance is auto-attaching fails

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
