### PR TITLE
refactor: decouple attach from cli

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -1,0 +1,66 @@
+import logging
+
+from uaclient import clouds, config, contract, exceptions, status, util
+from uaclient.clouds import identity
+
+LOG = logging.getLogger("ua.actions")
+
+
+def attach_with_token(
+    cfg: config.UAConfig, token: str, allow_enable: bool
+) -> None:
+    """
+    Common functionality to take a token and attach via contract backend
+    :raise UrlError: On unexpected connectivity issues to contract
+        server or inability to access identity doc from metadata service.
+    :raise ContractAPIError: On unexpected errors when talking to the contract
+        server.
+    """
+    try:
+        contract.request_updated_contract(
+            cfg, token, allow_enable=allow_enable
+        )
+    except util.UrlError as exc:
+        with util.disable_log_to_console():
+            LOG.exception(exc)
+        cfg.status()  # Persist updated status in the event of partial attach
+        config.update_ua_messages(cfg)
+        raise exc
+    except exceptions.UserFacingError as exc:
+        LOG.warning(exc.msg)
+        cfg.status()  # Persist updated status in the event of partial attach
+        config.update_ua_messages(cfg)
+        raise exc
+
+    config.update_ua_messages(cfg)
+
+
+def auto_attach(
+    cfg: config.UAConfig, cloud: clouds.AutoAttachCloudInstance
+) -> None:
+    """
+    :raise UrlError: On unexpected connectivity issues to contract
+        server or inability to access identity doc from metadata service.
+    :raise ContractAPIError: On unexpected errors when talking to the contract
+        server.
+    :raise NonAutoAttachImageError: If this cloud type does not have
+        auto-attach support.
+    """
+    contract_client = contract.UAContractClient(cfg)
+    try:
+        tokenResponse = contract_client.request_auto_attach_contract_token(
+            instance=cloud
+        )
+    except contract.ContractAPIError as e:
+        if e.code and 400 <= e.code < 500:
+            raise exceptions.NonAutoAttachImageError(
+                status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
+            )
+        raise e
+    current_iid = identity.get_instance_id()
+    if current_iid:
+        cfg.write_cache("instance-id", current_iid)
+
+    token = tokenResponse["contractToken"]
+
+    attach_with_token(cfg, token=token, allow_enable=True)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -15,11 +15,13 @@ import tempfile
 import textwrap
 import time
 from functools import wraps
+from typing import Optional  # noqa: F401
 from typing import List
 
 import yaml
 
 from uaclient import (
+    actions,
     config,
     contract,
     entitlements,
@@ -31,6 +33,7 @@ from uaclient import (
 )
 from uaclient import status as ua_status
 from uaclient import util, version
+from uaclient.clouds import AutoAttachCloudInstance  # noqa: F401
 from uaclient.clouds import identity
 from uaclient.defaults import (
     CLOUD_BUILD_INFO,
@@ -964,27 +967,7 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     return 0
 
 
-def _attach_with_token(
-    cfg: config.UAConfig, token: str, allow_enable: bool
-) -> int:
-    """Common functionality to take a token and attach via contract backend"""
-    try:
-        contract.request_updated_contract(
-            cfg, token, allow_enable=allow_enable
-        )
-    except util.UrlError as exc:
-        with util.disable_log_to_console():
-            logging.exception(exc)
-        print(ua_status.MESSAGE_ATTACH_FAILURE)
-        cfg.status()  # Persist updated status in the event of partial attach
-        config.update_ua_messages(cfg)
-        return 1
-    except exceptions.UserFacingError as exc:
-        logging.warning(exc.msg)
-        cfg.status()  # Persist updated status in the event of partial attach
-        config.update_ua_messages(cfg)
-        return 1
-
+def _post_cli_attach(cfg: config.UAConfig) -> None:
     contract_name = cfg.machine_token["machineTokenInfo"]["contractInfo"][
         "name"
     ]
@@ -998,30 +981,22 @@ def _attach_with_token(
     else:
         print(ua_status.MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME)
 
-    config.update_ua_messages(cfg)
-    jobs.disable_license_check_if_applicable(cfg)
     action_status(args=None, cfg=cfg)
-    return 0
 
 
-def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
-    """Detect cloud_type and request a contract token from identity info.
+@assert_root
+@assert_lock_file("ua auto-attach")
+def action_auto_attach(args, *, cfg):
+    disable_auto_attach = util.is_config_value_true(
+        config=cfg.cfg, path_to_value="features.disable_auto_attach"
+    )
+    if disable_auto_attach:
+        msg = "Skipping auto-attach. Config disable_auto_attach is set."
+        logging.debug(msg)
+        print(msg)
+        return 0
 
-    :param cfg: a ``config.UAConfig`` instance
-
-    :raise AlreadyAttachedError: When attached on a non-Pro Image
-    :raise AlreadyAttachedOnPROError: When attached on a Pro Image with the
-        same current instance ID
-    :raise NonAutoAttachImageError: When not on an auto-attach image type.
-    :raise UrlError: On unexpected connectivity issues to contract
-        server or inability to access identity doc from metadata service.
-    :raise ContractAPIError: On unexpected errors when talking to the contract
-        server.
-    :raise NonAutoAttachImageError: If this cloud type does not have
-        auto-attach support.
-
-    :return: contract token obtained from identity doc
-    """
+    instance = None  # type: Optional[AutoAttachCloudInstance]
     try:
         instance = identity.cloud_instance_factory()
     except exceptions.CloudFactoryError as e:
@@ -1046,6 +1021,13 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
         raise exceptions.UserFacingError(
             ua_status.MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE
         )
+
+    if not instance:
+        # we shouldn't get here, but this is a reasonable default just in case
+        raise exceptions.UserFacingError(
+            ua_status.MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE
+        )
+
     current_iid = identity.get_instance_id()
     if cfg.is_attached:
         prev_iid = cfg.read_cache("instance-id")
@@ -1056,36 +1038,17 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
             raise exceptions.UserFacingError(
                 ua_status.MESSAGE_DETACH_AUTOMATION_FAILURE
             )
-    contract_client = contract.UAContractClient(cfg)
+
     try:
-        tokenResponse = contract_client.request_auto_attach_contract_token(
-            instance=instance
-        )
-    except contract.ContractAPIError as e:
-        if e.code and 400 <= e.code < 500:
-            raise exceptions.NonAutoAttachImageError(
-                ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
-            )
-        raise e
-    if current_iid:
-        cfg.write_cache("instance-id", current_iid)
-
-    return tokenResponse["contractToken"]
-
-
-@assert_root
-@assert_lock_file("ua auto-attach")
-def action_auto_attach(args, *, cfg):
-    disable_auto_attach = util.is_config_value_true(
-        config=cfg.cfg, path_to_value="features.disable_auto_attach"
-    )
-    if disable_auto_attach:
-        msg = "Skipping auto-attach. Config disable_auto_attach is set."
-        logging.debug(msg)
-        print(msg)
+        actions.auto_attach(cfg, instance)
+    except util.UrlError:
+        print(ua_status.MESSAGE_ATTACH_FAILURE)
+        return 1
+    except exceptions.UserFacingError:
+        return 1
+    else:
+        _post_cli_attach(cfg)
         return 0
-    token = _get_contract_token_from_cloud_identity(cfg)
-    return _attach_with_token(cfg, token=token, allow_enable=True)
 
 
 @assert_not_attached
@@ -1096,9 +1059,18 @@ def action_attach(args, *, cfg):
         raise exceptions.UserFacingError(
             ua_status.MESSAGE_ATTACH_REQUIRES_TOKEN
         )
-    return _attach_with_token(
-        cfg, token=args.token, allow_enable=args.auto_enable
-    )
+    try:
+        actions.attach_with_token(
+            cfg, token=args.token, allow_enable=args.auto_enable
+        )
+    except util.UrlError:
+        print(ua_status.MESSAGE_ATTACH_FAILURE)
+        return 1
+    except exceptions.UserFacingError:
+        return 1
+    else:
+        _post_cli_attach(cfg)
+        return 0
 
 
 def _write_command_output_to_file(

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -1,0 +1,145 @@
+import mock
+import pytest
+
+from uaclient import exceptions, status, util
+from uaclient.actions import attach_with_token, auto_attach
+from uaclient.contract import ContractAPIError
+from uaclient.exceptions import NonAutoAttachImageError
+from uaclient.tests.test_cli_auto_attach import fake_instance_factory
+
+M_PATH = "uaclient.actions."
+
+
+class TestAttachWithToken:
+    @pytest.mark.parametrize(
+        "request_updated_contract_side_effect, expected_error_class,"
+        " expect_status_call",
+        [
+            (None, None, False),
+            (util.UrlError("cause"), util.UrlError, True),
+            (
+                exceptions.UserFacingError("test"),
+                exceptions.UserFacingError,
+                True,
+            ),
+        ],
+    )
+    @mock.patch(M_PATH + "config.update_ua_messages")
+    @mock.patch(M_PATH + "config.UAConfig.status")
+    @mock.patch(M_PATH + "contract.request_updated_contract")
+    def test_attach_with_token(
+        self,
+        m_request_updated_contract,
+        m_status,
+        m_update_ua_messages,
+        request_updated_contract_side_effect,
+        expected_error_class,
+        expect_status_call,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        m_request_updated_contract.side_effect = (
+            request_updated_contract_side_effect
+        )
+        if expected_error_class:
+            with pytest.raises(expected_error_class):
+                attach_with_token(cfg, "token", False)
+        else:
+            attach_with_token(cfg, "token", False)
+        if expect_status_call:
+            assert [mock.call()] == m_status.call_args_list
+        assert [mock.call(cfg)] == m_update_ua_messages.call_args_list
+
+
+class TestAutoAttach:
+    @mock.patch(M_PATH + "attach_with_token")
+    @mock.patch(M_PATH + "identity.get_instance_id", return_value="my-iid")
+    @mock.patch(
+        M_PATH
+        + "contract.UAContractClient.request_auto_attach_contract_token",
+        return_value={"contractToken": "token"},
+    )
+    @mock.patch(M_PATH + "config.update_ua_messages")
+    @mock.patch(M_PATH + "config.UAConfig.write_cache")
+    def test_happy_path_on_auto_attach(
+        self,
+        m_write_cache,
+        m_update_ua_messages,
+        m_request_auto_attach_contract_token,
+        m_get_instance_id,
+        m_attach_with_token,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+
+        auto_attach(cfg, fake_instance_factory())
+
+        assert [
+            mock.call(cfg, token="token", allow_enable=True)
+        ] == m_attach_with_token.call_args_list
+
+        assert [
+            mock.call("instance-id", "my-iid")
+        ] == m_write_cache.call_args_list
+
+    @pytest.mark.parametrize(
+        "http_msg,http_code,http_response",
+        (
+            ("Not found", 404, {"message": "missing instance information"}),
+            (
+                "Forbidden",
+                403,
+                {"message": "forbidden: cannot verify signing certificate"},
+            ),
+        ),
+    )
+    @mock.patch(
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
+    )
+    @mock.patch(M_PATH + "identity.get_instance_id", return_value="old-iid")
+    def test_handles_4XX_contract_errors(
+        self,
+        _m_get_instance_id,
+        m_request_auto_attach_contract_token,
+        http_msg,
+        http_code,
+        http_response,
+        FakeConfig,
+    ):
+        """VMs running on non-auto-attach images do not return a token."""
+        cfg = FakeConfig()
+        m_request_auto_attach_contract_token.side_effect = ContractAPIError(
+            util.UrlError(
+                http_msg, code=http_code, url="http://me", headers={}
+            ),
+            error_response=http_response,
+        )
+        with pytest.raises(NonAutoAttachImageError) as excinfo:
+            auto_attach(cfg, fake_instance_factory())
+        assert status.MESSAGE_UNSUPPORTED_AUTO_ATTACH == str(excinfo.value)
+
+    @mock.patch(
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
+    )
+    @mock.patch(M_PATH + "identity.get_instance_id", return_value="my-iid")
+    def test_raise_unexpected_errors(
+        self,
+        _m_get_instance_id,
+        m_request_auto_attach_contract_token,
+        FakeConfig,
+    ):
+        """Any unexpected errors will be raised."""
+        cfg = FakeConfig()
+
+        unexpected_error = ContractAPIError(
+            util.UrlError(
+                "Server error", code=500, url="http://me", headers={}
+            ),
+            error_response={"message": "something unexpected"},
+        )
+        m_request_auto_attach_contract_token.side_effect = unexpected_error
+
+        with pytest.raises(ContractAPIError) as excinfo:
+            auto_attach(cfg, fake_instance_factory())
+
+        assert unexpected_error == excinfo.value

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -3,15 +3,13 @@ import textwrap
 import mock
 import pytest
 
-from uaclient import status, util
+from uaclient import status
 from uaclient.cli import (
-    _get_contract_token_from_cloud_identity,
     action_auto_attach,
     auto_attach_parser,
     get_parser,
     main,
 )
-from uaclient.contract import ContractAPIError
 from uaclient.exceptions import (
     AlreadyAttachedError,
     AlreadyAttachedOnPROError,
@@ -24,7 +22,6 @@ from uaclient.exceptions import (
     NonRootUserError,
     UserFacingError,
 )
-from uaclient.tests.test_cli_attach import BASIC_MACHINE_TOKEN
 
 M_PATH = "uaclient.cli."
 M_ID_PATH = "uaclient.clouds.identity."
@@ -51,11 +48,76 @@ def test_non_root_users_are_rejected(getuid, FakeConfig):
         action_auto_attach(mock.MagicMock(), cfg=cfg)
 
 
-class TestGetContractTokenFromCloudIdentity:
-    def fake_instance_factory(self):
-        m_instance = mock.Mock()
-        m_instance.identity_doc = "pkcs7-validated-by-backend"
-        return m_instance
+def fake_instance_factory():
+    m_instance = mock.Mock()
+    m_instance.identity_doc = "pkcs7-validated-by-backend"
+    return m_instance
+
+
+# For all of these tests we want to appear as root, so mock on the class
+@mock.patch(M_PATH + "os.getuid", return_value=0)
+class TestActionAutoAttach:
+    def test_auto_attach_help(self, _getuid, capsys):
+        with pytest.raises(SystemExit):
+            with mock.patch(
+                "sys.argv", ["/usr/bin/ua", "auto-attach", "--help"]
+            ):
+                main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+
+    @mock.patch("uaclient.cli.util.subp")
+    def test_lock_file_exists(self, m_subp, _getuid, FakeConfig):
+        """Check inability to auto-attach if operation holds lock file."""
+        cfg = FakeConfig()
+        cfg.write_cache("lock", "123:ua disable")
+        with pytest.raises(LockHeldError) as err:
+            action_auto_attach(mock.MagicMock(), cfg=cfg)
+        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
+        assert (
+            "Unable to perform: ua auto-attach.\n"
+            "Operation in progress: ua disable (pid:123)"
+        ) == err.value.msg
+
+    @pytest.mark.parametrize(
+        "features_override", ((None), ({"disable_auto_attach": True}))
+    )
+    @mock.patch(M_PATH + "_post_cli_attach")
+    @mock.patch(M_PATH + "actions.auto_attach")
+    @mock.patch(
+        M_PATH + "identity.cloud_instance_factory",
+        side_effect=fake_instance_factory,
+    )
+    @mock.patch(M_ID_PATH + "get_instance_id", return_value="my-iid")
+    def test_disable_auto_attach_config(
+        self,
+        m_get_instance_id,
+        m_cloud_instance_factory,
+        m_auto_attach,
+        m_post_cli_attach,
+        _m_getuid,
+        features_override,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        if features_override:
+            cfg.override_features(features_override)
+
+        ret = action_auto_attach(mock.MagicMock(), cfg=cfg)
+
+        assert 0 == ret
+        if features_override:
+            assert [] == m_cloud_instance_factory.call_args_list
+            assert [] == m_get_instance_id.call_args_list
+            assert [] == m_auto_attach.call_args_list
+            assert [] == m_post_cli_attach.call_args_list
+        else:
+            assert [mock.call()] == m_cloud_instance_factory.call_args_list
+            assert [mock.call()] == m_get_instance_id.call_args_list
+            assert [
+                mock.call(mock.ANY, mock.ANY)
+            ] == m_auto_attach.call_args_list
+            assert [mock.call(mock.ANY)] == m_post_cli_attach.call_args_list
 
     @pytest.mark.parametrize(
         "cloud_factory_error, is_attached, expected_error_cls,"
@@ -100,13 +162,14 @@ class TestGetContractTokenFromCloudIdentity:
     def test_handle_cloud_factory_errors(
         self,
         m_cloud_instance_factory,
+        _m_getuid,
         cloud_factory_error,
         is_attached,
         expected_error_cls,
         expected_error_msg,
         FakeConfig,
     ):
-        """Non-aws clouds will error."""
+        """Non-supported clouds will error."""
         m_cloud_instance_factory.side_effect = cloud_factory_error
         if is_attached:
             cfg = FakeConfig.for_attached_machine()
@@ -114,305 +177,98 @@ class TestGetContractTokenFromCloudIdentity:
             cfg = FakeConfig()
 
         with pytest.raises(expected_error_cls) as excinfo:
-            _get_contract_token_from_cloud_identity(cfg)
+            action_auto_attach(mock.MagicMock(), cfg=cfg)
 
         if expected_error_msg:
             assert expected_error_msg == str(excinfo.value)
 
-    @pytest.mark.parametrize(
-        "http_msg,http_code,http_response",
-        (
-            ("Not found", 404, {"message": "missing instance information"}),
-            (
-                "Forbidden",
-                403,
-                {"message": "forbidden: cannot verify signing certificate"},
-            ),
-        ),
-    )
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
-    )
-    @mock.patch(M_ID_PATH + "get_instance_id", return_value="old-iid")
-    @mock.patch(M_ID_PATH + "cloud_instance_factory")
-    def test_aws_cloud_type_non_auto_attach_returns_no_token(
-        self,
-        cloud_instance_factory,
-        get_instance_id,
-        request_auto_attach_contract_token,
-        http_msg,
-        http_code,
-        http_response,
-        FakeConfig,
-    ):
-        """VMs running on non-auto-attach images do not return a token."""
-        cloud_instance_factory.side_effect = self.fake_instance_factory
-        request_auto_attach_contract_token.side_effect = ContractAPIError(
-            util.UrlError(
-                http_msg, code=http_code, url="http://me", headers={}
-            ),
-            error_response=http_response,
-        )
-        with pytest.raises(NonAutoAttachImageError) as excinfo:
-            _get_contract_token_from_cloud_identity(FakeConfig())
-        assert status.MESSAGE_UNSUPPORTED_AUTO_ATTACH == str(excinfo.value)
-
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
-    )
-    @mock.patch(M_ID_PATH + "get_instance_id", return_value="my-iid")
-    @mock.patch(M_ID_PATH + "cloud_instance_factory")
-    def test_raise_unexpected_errors(
-        self,
-        cloud_instance_factory,
-        _get_instance_id,
-        request_auto_attach_contract_token,
-        FakeConfig,
-    ):
-        """Any unexpected errors will be raised."""
-
-        cloud_instance_factory.side_effect = self.fake_instance_factory
-        unexpected_error = ContractAPIError(
-            util.UrlError(
-                "Server error", code=500, url="http://me", headers={}
-            ),
-            error_response={"message": "something unexpected"},
-        )
-        request_auto_attach_contract_token.side_effect = unexpected_error
-
-        with pytest.raises(ContractAPIError) as excinfo:
-            _get_contract_token_from_cloud_identity(FakeConfig())
-        assert unexpected_error == excinfo.value
-
-    @mock.patch(M_ID_PATH + "get_instance_id", return_value="my-iid")
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
-    )
-    @mock.patch(M_ID_PATH + "cloud_instance_factory")
-    def test_return_token_from_contract_server_using_identity_doc(
-        self,
-        cloud_instance_factory,
-        request_auto_attach_contract_token,
-        get_instance_id,
-        FakeConfig,
-    ):
-        """Return token from the contract server using the identity."""
-
-        cloud_instance_factory.side_effect = self.fake_instance_factory
-
-        def fake_contract_token(instance):
-            return {"contractToken": "myPKCS7-token"}
-
-        request_auto_attach_contract_token.side_effect = fake_contract_token
-
-        cfg = FakeConfig()
-        assert "myPKCS7-token" == _get_contract_token_from_cloud_identity(cfg)
-        # instance-id is persisted for next auto-attach call
-        assert 1 == get_instance_id.call_count
-        assert "my-iid" == cfg.read_cache("instance-id")
-
-    @pytest.mark.parametrize(
-        "iid_response,calls_detach", (("old-iid", False), ("new-iid", True))
-    )
-    @mock.patch(M_ID_PATH + "get_instance_id")
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
-    )
-    @mock.patch(M_ID_PATH + "cloud_instance_factory")
-    def test_delta_in_instance_id_forces_detach(
-        self,
-        cloud_instance_factory,
-        request_auto_attach_contract_token,
-        get_instance_id,
-        iid_response,
-        calls_detach,
-        FakeConfig,
-    ):
-        """When instance-id changes since last attach, call detach."""
-
-        get_instance_id.return_value = iid_response
-        cloud_instance_factory.side_effect = self.fake_instance_factory
-
-        def fake_contract_token(instance):
-            return {"contractToken": "myPKCS7-token"}
-
-        request_auto_attach_contract_token.side_effect = fake_contract_token
-
-        account_name = "test_account"
-        cfg = FakeConfig.for_attached_machine(account_name=account_name)
-        # persist old instance-id value
-        cfg.write_cache("instance-id", "old-iid")
-
-        if calls_detach:
-            with mock.patch(M_PATH + "_detach") as m_detach:
-                m_detach.return_value = 0
-                assert (
-                    "myPKCS7-token"
-                    == _get_contract_token_from_cloud_identity(cfg)
-                )
-            assert [mock.call(cfg, assume_yes=True)] == m_detach.call_args_list
-        else:
-            with pytest.raises(AlreadyAttachedOnPROError):
-                _get_contract_token_from_cloud_identity(cfg)
-        # current instance-id is persisted for next auto-attach call
-        assert iid_response == cfg.read_cache("instance-id")
-
-    @mock.patch(M_PATH + "_detach")
-    @mock.patch(M_ID_PATH + "get_instance_id")
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
-    )
-    @mock.patch(M_ID_PATH + "cloud_instance_factory")
-    def test_failed_detach_on_changed_instance_id_raises_errors(
-        self,
-        cloud_instance_factory,
-        request_auto_attach_contract_token,
-        get_instance_id,
-        m_detach,
-        FakeConfig,
-    ):
-        """When instance-id changes since last attach, call detach."""
-
-        get_instance_id.return_value = "new-iid"
-        cloud_instance_factory.side_effect = self.fake_instance_factory
-
-        def fake_contract_token(instance):
-            return {"contractToken": "myPKCS7-token"}
-
-        request_auto_attach_contract_token.side_effect = fake_contract_token
-        m_detach.return_value = 1  # Failure to auto-detach
-
-        account_name = "test_account"
-        cfg = FakeConfig.for_attached_machine(account_name=account_name)
-        # persist old instance-id value
-        cfg.write_cache("instance-id", "old-iid")
-
-        with pytest.raises(UserFacingError) as err:
-            assert "myPKCS7-token" == _get_contract_token_from_cloud_identity(
-                cfg
-            )
-        assert status.MESSAGE_DETACH_AUTOMATION_FAILURE == str(err.value)
-
     @pytest.mark.parametrize("iid_curr, iid_old", (("123", 123), (123, "123")))
     @mock.patch(M_ID_PATH + "get_instance_id")
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
+        M_ID_PATH + "cloud_instance_factory", side_effect=fake_instance_factory
     )
-    @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_numeric_iid_does_not_trigger_auto_attach(
         self,
-        cloud_instance_factory,
-        request_auto_attach_contract_token,
-        get_instance_id,
+        _m_cloud_instance_factory,
+        m_get_instance_id,
+        _m_getuid,
         iid_curr,
         iid_old,
         FakeConfig,
     ):
         """Treat numeric and string values for instance ID as the same."""
 
-        get_instance_id.return_value = iid_curr
-        cloud_instance_factory.side_effect = self.fake_instance_factory
+        m_get_instance_id.return_value = iid_curr
 
-        def fake_contract_token(instance):
-            return {"contractToken": "myPKCS7-token"}
-
-        request_auto_attach_contract_token.side_effect = fake_contract_token
-
-        account_name = "test_account"
-        cfg = FakeConfig.for_attached_machine(account_name=account_name)
+        cfg = FakeConfig.for_attached_machine()
         # persist old instance-id value
         cfg.write_cache("instance-id", iid_old)
 
         with pytest.raises(AlreadyAttachedOnPROError):
-            _get_contract_token_from_cloud_identity(cfg)
+            action_auto_attach(mock.MagicMock(), cfg=cfg)
+
         assert str(iid_curr) == str(cfg.read_cache("instance-id"))
 
-
-# For all of these tests we want to appear as root, so mock on the class
-@mock.patch(M_PATH + "os.getuid", return_value=0)
-class TestActionAutoAttach:
-    def test_auto_attach_help(self, _getuid, capsys):
-        with pytest.raises(SystemExit):
-            with mock.patch(
-                "sys.argv", ["/usr/bin/ua", "auto-attach", "--help"]
-            ):
-                main()
-        out, _err = capsys.readouterr()
-        assert HELP_OUTPUT == out
-
-    @mock.patch("uaclient.cli.util.subp")
-    def test_lock_file_exists(self, m_subp, _getuid, FakeConfig):
-        """Check inability to auto-attach if operation holds lock file."""
-        cfg = FakeConfig()
-        cfg.write_cache("lock", "123:ua disable")
-        with pytest.raises(LockHeldError) as err:
-            action_auto_attach(mock.MagicMock(), cfg=cfg)
-        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
-        assert (
-            "Unable to perform: ua auto-attach.\n"
-            "Operation in progress: ua disable (pid:123)"
-        ) == err.value.msg
-
-    @mock.patch("uaclient.util.should_reboot", return_value=False)
-    @mock.patch("uaclient.config.UAConfig.remove_notice")
-    @mock.patch(M_PATH + "contract.request_updated_contract")
-    @mock.patch(M_PATH + "_get_contract_token_from_cloud_identity")
-    def test_happy_path_on_aws_non_auto_attach(
-        self,
-        get_contract_token_from_cloud_identity,
-        request_updated_contract,
-        _m_should_reboot,
-        _m_remove_notice,
-        _m_getuid,
-        FakeConfig,
-    ):
-        """Noop when _get_contract_token_from_cloud_identity finds no token"""
-        exc = NonAutoAttachImageError("msg")
-        get_contract_token_from_cloud_identity.side_effect = exc
-
-        with pytest.raises(NonAutoAttachImageError):
-            action_auto_attach(mock.MagicMock(), cfg=FakeConfig())
-        assert 0 == request_updated_contract.call_count
-
     @pytest.mark.parametrize(
-        "features_override", ((None), ({"disable_auto_attach": True}))
+        "iid_response,calls_detach", (("old-iid", False), ("new-iid", True))
     )
-    @mock.patch(M_PATH + "contract.request_updated_contract")
-    @mock.patch(M_PATH + "_get_contract_token_from_cloud_identity")
-    @mock.patch(M_PATH + "action_status")
-    @mock.patch(M_PATH + "config.update_ua_messages")
-    def test_happy_path_on_aws_auto_attach(
+    @mock.patch(M_PATH + "_post_cli_attach")
+    @mock.patch(M_PATH + "actions.auto_attach")
+    @mock.patch(M_ID_PATH + "get_instance_id")
+    @mock.patch(
+        M_ID_PATH + "cloud_instance_factory", side_effect=fake_instance_factory
+    )
+    def test_delta_in_instance_id_forces_detach(
         self,
-        update_ua_messages,
-        action_status,
-        get_contract_token_from_cloud_identity,
-        request_updated_contract,
+        _m_cloud_instance_factory,
+        m_get_instance_id,
+        _m_auto_attach,
+        _m_post_cli_attach,
         _m_getuid,
-        features_override,
+        iid_response,
+        calls_detach,
         FakeConfig,
     ):
-        """A mock-heavy test for the happy path on auto attach AWS"""
-        # TODO: Improve this test with less general mocking and more
-        # post-conditions
-        cfg = FakeConfig()
-        if features_override:
-            cfg.override_features(features_override)
-            expected_calls = []
+        """When instance-id changes since last attach, call detach."""
+        m_get_instance_id.return_value = iid_response
+        cfg = FakeConfig.for_attached_machine()
+        # persist old instance-id value
+        cfg.write_cache("instance-id", "old-iid")
+
+        if calls_detach:
+            with mock.patch(M_PATH + "_detach") as m_detach:
+                m_detach.return_value = 0
+                action_auto_attach(mock.MagicMock(), cfg=cfg)
+            assert [mock.call(cfg, assume_yes=True)] == m_detach.call_args_list
         else:
-            expected_calls = [
-                mock.call(cfg, "myPKCS7-token", allow_enable=True)
-            ]
-        get_contract_token_from_cloud_identity.return_value = "myPKCS7-token"
+            with pytest.raises(AlreadyAttachedOnPROError):
+                action_auto_attach(mock.MagicMock(), cfg=cfg)
 
-        def fake_request_updated_contract(cfg, contract_token, allow_enable):
-            cfg.write_cache("machine-token", BASIC_MACHINE_TOKEN)
-            return BASIC_MACHINE_TOKEN
+    @mock.patch(M_PATH + "_detach")
+    @mock.patch(M_ID_PATH + "get_instance_id")
+    @mock.patch(
+        M_ID_PATH + "cloud_instance_factory", side_effect=fake_instance_factory
+    )
+    def test_failed_detach_on_changed_instance_id_raises_errors(
+        self,
+        _m_cloud_instance_factory,
+        m_get_instance_id,
+        m_detach,
+        _m_getuid,
+        FakeConfig,
+    ):
+        """When instance-id changes since last attach, call detach."""
 
-        request_updated_contract.side_effect = fake_request_updated_contract
+        m_get_instance_id.return_value = "new-iid"
+        m_detach.return_value = 1  # Failure to auto-detach
+        cfg = FakeConfig.for_attached_machine()
+        # persist old instance-id value
+        cfg.write_cache("instance-id", "old-iid")
 
-        ret = action_auto_attach(mock.MagicMock(), cfg=cfg)
-        assert 0 == ret
-        assert expected_calls == request_updated_contract.call_args_list
+        with pytest.raises(UserFacingError) as err:
+            action_auto_attach(mock.MagicMock(), cfg=cfg)
+
+        assert status.MESSAGE_DETACH_AUTOMATION_FAILURE == str(err.value)
 
 
 class TestParser:


### PR DESCRIPTION
## Notes
This is part of a series of PRs to support migrating the gcp auto attach job to the daemon. They should be reviewed/merged in the following order:

- [x] #1894
- [x] #1895
- [ ] #1896 (this one)
- [ ] #1887

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
refactor: decouple attach from cli
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Ensure attach and auto-attach still function properly

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
