### PR TITLE
Add status endpoint to execute a preflight check of a specific token (SC-623)

### DIFF
--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -11,14 +11,14 @@ Feature: Attached status
             """
             _doc _schema_version account attached config config_path contract effective
             environment_vars execution_details execution_status expires machine_id notices
-            services version
+            services version simulated
             """
         When I run `ua status --format yaml` as non-root
         Then stdout is formatted as `yaml` and has keys:
             """
             _doc _schema_version account attached config config_path contract effective
             environment_vars execution_details execution_status expires machine_id notices
-            services version
+            services version simulated
             """
 
         Examples: ubuntu release

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -230,6 +230,20 @@ def when_i_run_command_with_stdin(
     )
 
 
+@when("I do a preflight check for `{contract_token}` {user_spec}")
+def when_i_preflight(context, contract_token, user_spec):
+    token = getattr(context.config, contract_token)
+    command = "ua status --simulate-with-token {}".format(token)
+    if user_spec == "with the all flag":
+        command += " --all"
+    if "formatted as" in user_spec:
+        output_format = user_spec.split()[2]
+        command += " --format {}".format(output_format)
+    when_i_run_command(
+        context=context, command=command, user_spec="as non-root"
+    )
+
+
 @when("I run `{command}` {user_spec}")
 def when_i_run_command(
     context,

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -9,14 +9,14 @@ Feature: Unattached status
             """
             _doc _schema_version account attached config config_path contract effective
             environment_vars execution_details execution_status expires machine_id notices
-            services version
+            services version simulated
             """
         When I run `ua status --format yaml` as non-root
         Then stdout is formatted as `yaml` and has keys:
             """
             _doc _schema_version account attached config config_path contract effective
             environment_vars execution_details execution_status expires machine_id notices
-            services version
+            services version simulated
             """
 
         Examples: ubuntu release
@@ -123,3 +123,58 @@ Feature: Unattached status
            | focal   | yes      | no     | yes | yes  | yes         | yes   | no  | yes       |
            | hirsute | no       | no     | no  | no   | no          | no    | no  | no        |
            | impish  | no       | no     | no  | no   | no          | no    | no  | no        |
+
+
+    @series.all
+    @uses.config.machine_type.lxd.container
+    @uses.config.contract_token
+    Scenario Outline: Simulate status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I do a preflight check for `contract_token` without the all flag
+        Then stdout matches regexp:
+        """
+        SERVICE       AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
+        cc-eal        <cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
+        cis           <cis>       +yes  +no   +Center for Internet Security Audit Tools
+        esm-infra     <esm-infra> +yes  +yes  +UA Infra: Extended Security Maintenance \(ESM\)
+        fips          <fips>      +yes  +no   +NIST-certified core packages
+        fips-updates  <fips>      +yes  +no   +NIST-certified core packages with priority security updates
+        livepatch     <livepatch> +yes  +yes  +Canonical Livepatch service
+        """
+        When I do a preflight check for `contract_token` with the all flag
+        Then stdout matches regexp:
+        """
+        SERVICE       AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
+        cc-eal        <cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
+        cis           <cis>       +yes  +no   +Center for Internet Security Audit Tools
+        esm-apps      <esm-apps>  +yes  +yes  +UA Apps: Extended Security Maintenance \(ESM\)
+        esm-infra     <esm-infra> +yes  +yes  +UA Infra: Extended Security Maintenance \(ESM\)
+        fips          <fips>      +yes  +no   +NIST-certified core packages
+        fips-updates  <fips>      +yes  +no   +NIST-certified core packages with priority security updates
+        livepatch     <livepatch> +yes  +yes  +Canonical Livepatch service
+        ros           <ros>       +yes  +no   +Security Updates for the Robot Operating System
+        ros-updates   <ros>       +yes  +no   +All Updates for the Robot Operating System
+        """
+        When I do a preflight check for `contract_token` formatted as json
+        Then stdout is formatted as `json` and has keys:
+        """
+        _doc _schema_version account attached config config_path contract effective
+        environment_vars execution_details execution_status expires machine_id notices
+        services version simulated
+        """
+        When I do a preflight check for `contract_token` formatted as yaml
+        Then stdout is formatted as `yaml` and has keys:
+        """
+        _doc _schema_version account attached config config_path contract effective
+        environment_vars execution_details execution_status expires machine_id notices
+        services version simulated
+        """
+
+
+        Examples: ubuntu release
+           | release | esm-apps | cc-eal | cis | fips | esm-infra | ros | livepatch |
+           | xenial  | yes      | yes    | yes | yes  | yes       | yes | yes       |
+           | bionic  | yes      | no     | yes | yes  | yes       | yes | yes       |
+           | focal   | yes      | no     | yes | yes  | yes       | no  | yes       |
+           | hirsute | no       | no     | no  | no   | no        | no  | no        |
+           | impish  | no       | no     | no  | no   | no        | no  | no        |

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -585,6 +585,14 @@ def status_parser(parser):
 
         * AVAILABLE: whether this service would be available if this machine
           were attached. The possible values are yes or no.
+
+        If --simulate-with-token is used, then the output has five
+        columns. SERVICE, AVAILABLE, ENTITLED and DESCRIPTION are the same
+        as mentioned above, and AUTO_ENABLED shows whether the service is set
+        to be enabled when that token is attached.
+
+        If the --all flag is set, beta and unavailable services are also
+        listed in the output.
         """
     )
 
@@ -604,6 +612,12 @@ def status_parser(parser):
                 STATUS_FORMATS[0]
             )
         ),
+    )
+    parser.add_argument(
+        "--simulate-with-token",
+        metavar="TOKEN",
+        action="store",
+        help=("simulate the output status using a provided token"),
     )
     parser.add_argument(
         "--all",
@@ -1332,7 +1346,11 @@ def action_status(args, *, cfg):
     if not cfg:
         cfg = config.UAConfig()
     show_beta = args.all if args else False
-    status = cfg.status(show_beta=show_beta)
+    token = args.simulate_with_token if args else None
+    if token:
+        status = cfg.simulate_status(token=token, show_beta=show_beta)
+    else:
+        status = cfg.status(show_beta=show_beta)
     active_value = ua_status.UserFacingConfigStatus.ACTIVE.value
     config_active = bool(status["execution_status"] == active_value)
     if args and args.wait and config_active:

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -13,6 +13,7 @@ API_V1_TMPL_RESOURCE_MACHINE_ACCESS = (
 )
 API_V1_AUTO_ATTACH_CLOUD_TOKEN = "/v1/clouds/{cloud_type}/token"
 API_V1_MACHINE_ACTIVITY = "/v1/contracts/{contract}/machine-activity/{machine}"
+API_V1_CONTRACT_INFORMATION = "/v1/contract"
 ATTACH_FAIL_DATE_FORMAT = "%B %d, %Y"
 
 
@@ -99,6 +100,16 @@ class UAContractClient(serviceclient.UAServiceClient):
             API_V1_RESOURCES, query_params=query_params
         )
         return resource_response
+
+    def request_contract_information(
+        self, contract_token: str
+    ) -> Dict[str, Any]:
+        headers = self.headers()
+        headers.update({"Authorization": "Bearer {}".format(contract_token)})
+        response_data, _response_headers = self.request_url(
+            API_V1_CONTRACT_INFORMATION, headers=headers
+        )
+        return response_data
 
     def request_auto_attach_contract_token(
         self, *, instance: clouds.AutoAttachCloudInstance
@@ -470,7 +481,13 @@ def request_updated_contract(
 
 
 def get_available_resources(cfg) -> List[Dict]:
-    """Query available resources from the contrct server for this machine."""
+    """Query available resources from the contract server for this machine."""
     client = UAContractClient(cfg)
     resources = client.request_resources()
     return resources.get("resources", [])
+
+
+def get_contract_information(cfg, token: str) -> Dict[str, Any]:
+    """Query contract information for a specific token"""
+    client = UAContractClient(cfg)
+    return client.request_contract_information(token)

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -80,7 +80,7 @@ Show security updates for packages in the system, including all
 available ESM related content.
 
 .TP
-.BR "status" " [--format=tabular|json|yaml]"
+.BR "status" " [--format=tabular|json|yaml] [--simulate-with-token TOKEN] [--all]"
 Report current status of Ubuntu Advantage services on system.
 
 This shows whether this machine is attached to an Ubuntu Advantage
@@ -113,6 +113,14 @@ of:
 .BR "AVAILABLE" ":"
 whether this service would be available if this machine were attached.
 The possible values are \fIyes\fR or \fIno\fR.
+
+If --simulate-with-token is used, then the output has five columns.
+\fBSERVICE\fR, \fBAVAILABLE\fR, \fBENTITLED\fR and \fBDESCRIPTION\fR are the
+same as mentioned above, and \fBAUTO_ENABLED\fR shows whether the service is
+set to be enabled when that token is attached.
+
+If the --all flag is set, beta and unavailable services are also listed in the
+output.
 
 .TP
 .B version


### PR DESCRIPTION
This adds the `--simulate-with-token` option to the `status` command.
Using it requires a valid UA token, and will output information about services, as: 
- service name and description
- availability of the service for the archuitecture/series/kernel
- entitlement status from the contract perspective
- whether the service is marked to be enabled automatically.

This would give all information needed to execute a preflight check before users attach during installation time, as well as provide token information for any attached/unattached user.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
