### PR TITLE
livepatch: Add full path to all cmds (SC-627)

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -37,6 +37,11 @@ from uaclient.defaults import (
     DEFAULT_CONFIG_FILE,
 )
 
+# TODO: Better address service commands running on cli
+# It is not ideal for us to import an entitlement directly on the cli module.
+# We need to refactor this to avoid that type of coupling in the code.
+from uaclient.entitlements.livepatch import LIVEPATCH_CMD
+
 NAME = "ua"
 
 USAGE_TMPL = "{name} {command} [flags]"
@@ -1143,7 +1148,7 @@ def action_collect_logs(args, *, cfg: config.UAConfig):
             "ua status --format json", "{}/ua-status.json".format(output_dir)
         )
         _write_command_output_to_file(
-            "canonical-livepatch status",
+            "{} status".format(LIVEPATCH_CMD),
             "{}/livepatch-status.txt".format(output_dir),
         )
         _write_command_output_to_file(

--- a/uaclient/tests/test_cli_collect_logs.py
+++ b/uaclient/tests/test_cli_collect_logs.py
@@ -75,7 +75,7 @@ class TestActionAutoAttach:
         assert m_subp.call_args_list == [
             mock.call(["cloud-id"], rcs=None),
             mock.call(["ua", "status", "--format", "json"], rcs=None),
-            mock.call(["canonical-livepatch", "status"], rcs=None),
+            mock.call(["/snap/bin/canonical-livepatch", "status"], rcs=None),
             mock.call(["systemctl", "list-timers", "--all"], rcs=None),
             mock.call(
                 [


### PR DESCRIPTION
## Proposed Commit Message
livepatch: Add full path to all cmds

When interacting with livepatch, if the user does not have /snap/bin in the PATH, the pure canonical-livepatch command
will fail. We are now specifying the full path for all livepatch commands we are running.

LP: #1951954

## Test Steps
Run any integration test that enable/disables livepatch

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
