### PR TITLE
cli: add mechanism to ignore print events

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -25,6 +25,7 @@ from uaclient import (
     config,
     contract,
     entitlements,
+    event_logger,
     exceptions,
     jobs,
     lock,
@@ -807,6 +808,7 @@ def action_config_unset(args, *, cfg, **kwargs):
     return 0
 
 
+@event_logger.capture_info_events
 @assert_root
 @assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 @assert_lock_file("ua disable")
@@ -850,6 +852,7 @@ def action_disable(args, *, cfg, **kwargs):
     return 0 if ret else 1
 
 
+@event_logger.capture_info_events
 @assert_root
 @assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 @assert_lock_file("ua enable")
@@ -922,6 +925,7 @@ def action_enable(args, *, cfg, **kwargs):
     return 0 if ret else 1
 
 
+@event_logger.capture_info_events
 @assert_root
 @assert_attached()
 @assert_lock_file("ua detach")
@@ -1070,6 +1074,7 @@ def action_auto_attach(args, *, cfg):
         return 0
 
 
+@event_logger.capture_info_events
 @assert_not_attached
 @assert_root
 @assert_lock_file("ua attach")
@@ -1374,6 +1379,7 @@ def _action_refresh_contract(_args, cfg: config.UAConfig):
     print(ua_status.MESSAGE_REFRESH_CONTRACT_SUCCESS)
 
 
+@event_logger.capture_info_events
 @assert_root
 @assert_lock_file("ua refresh")
 def action_refresh(args, *, cfg: config.UAConfig):

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""
+This module is responsible for handling all events
+that must be raised to the user somehow. The main idea
+behind this module is to centralize all events that happens
+during the execution of UA commands and allows us to report
+those events in real time or through a machine-readable format.
+"""
+
+import enum
+import io
+import sys
+from functools import wraps
+
+
+@enum.unique
+class EventLoggerMode(enum.Enum):
+    """
+    Defines event logger supported modes.
+    Currently, we only support the cli and machine-readable
+    mode. On cli mode, we will print to stdout/stderr any
+    event that we receive. On machine-readable mode, we will
+    store those events and parse them for an specified
+    format.
+    """
+
+    CLI_MODE = object()
+    MACHINE_READABLE_MODE = object()
+
+
+class StringEvent(io.StringIO):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._stdout = sys.stdout
+
+    def write(self, message: str):
+        if message.strip():
+            sys.stdout = self._stdout
+            report_info_event(message)
+            sys.stdout = self
+
+
+class CaptureInfoEvents(list):
+    def __enter__(self):
+        self._stdout = sys.stdout
+        sys.stdout = self._string_object = StringEvent()
+        return self
+
+    def __exit__(self, *args):
+        sys.stdout = self._stdout
+
+
+def capture_info_events(f):
+    @wraps(f)
+    def new_f(*args, **kwargs):
+        with CaptureInfoEvents():
+            return f(*args, **kwargs)
+
+    return new_f
+
+
+# By default, the event logger will be on CLI mode,
+# printing every event it receives.
+_event_logger_mode = EventLoggerMode.CLI_MODE
+
+
+def report_info_event(info_msg: str):
+    if _event_logger_mode == EventLoggerMode.CLI_MODE:
+        print(info_msg)


### PR DESCRIPTION
## Proposed Commit Message
cli: add mechanism to ignore print events

When running some UA commands, we will be required to provide their output in a machine-readable way. When that happens, we don't to print anything to stdout. We are now adding a mechanism that allows us to achieve that

## Test Steps
Run any integration tests that print to stdout and verify that it still works

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
