### PR TITLE
cli: add mechanism to ignore print events

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 from typing import Dict, List, Optional
 
+from uaclient import event_logger as event
 from uaclient import exceptions, gpg, status, util
 
 APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
@@ -403,7 +404,7 @@ def setup_apt_proxy(
     :return: None
     """
     if http_proxy or https_proxy:
-        print(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"))
+        event.info(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"))
 
     apt_proxy_config = ""
     if http_proxy:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -11,7 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
 
-from uaclient import apt, exceptions, snap, status, util, version
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import exceptions, snap, status, util, version
 from uaclient.defaults import (
     BASE_CONTRACT_URL,
     BASE_SECURITY_URL,
@@ -1031,7 +1033,7 @@ class UAConfig:
 
         if len(services_with_proxies) > 0:
             services = ", ".join(services_with_proxies)
-            print(
+            event.info(
                 status.MESSAGE_PROXY_DETECTED_BUT_NOT_CONFIGURED.format(
                     services=services
                 )

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -4,7 +4,9 @@ import re
 from itertools import groupby
 from typing import Callable, Dict, List, Tuple, Union
 
-from uaclient import apt, exceptions, status, util
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import exceptions, status, util
 from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient.entitlements import repo
 from uaclient.types import StaticAffordance
@@ -68,7 +70,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         :param verbose: If true, print messages to stdout
         """
         if verbose:
-            print("Installing {title} packages".format(title=self.title))
+            event.info("Installing {title} packages".format(title=self.title))
 
         # We need to guarantee that the metapackage is installed.
         # While the other packages should still be installed, if they
@@ -97,7 +99,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     package_list=[pkg], cleanup_on_failure=False, verbose=False
                 )
             except exceptions.UserFacingError:
-                print(
+                event.info(
                     status.MESSAGE_FIPS_PACKAGE_NOT_AVAILABLE.format(
                         service=self.title, pkg=pkg
                     )
@@ -109,7 +111,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         @param operation: The operation being executed.
         """
         if util.should_reboot():
-            print(
+            event.info(
                 status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
                     operation=operation
                 )

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -2,7 +2,9 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from uaclient import apt, exceptions, snap, status, util
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import exceptions, snap, status, util
 from uaclient.entitlements import base
 from uaclient.status import ApplicationStatus
 from uaclient.types import StaticAffordance
@@ -55,7 +57,7 @@ def configure_livepatch_proxy(
                                snap calls
     """
     if http_proxy or https_proxy:
-        print(
+        event.info(
             status.MESSAGE_SETTING_SERVICE_PROXY.format(
                 service=LivepatchEntitlement.title
             )
@@ -126,8 +128,8 @@ class LivepatchEntitlement(base.UAEntitlement):
         @return: True on success, False otherwise.
         """
         if not util.which(snap.SNAP_CMD):
-            print("Installing snapd")
-            print(status.MESSAGE_APT_UPDATING_LISTS)
+            event.info("Installing snapd")
+            event.info(status.MESSAGE_APT_UPDATING_LISTS)
             try:
                 apt.run_apt_command(
                     ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
@@ -172,7 +174,7 @@ class LivepatchEntitlement(base.UAEntitlement):
         )
 
         if not util.which(LIVEPATCH_CMD):
-            print("Installing canonical-livepatch snap")
+            event.info("Installing canonical-livepatch snap")
             try:
                 util.subp(
                     [snap.SNAP_CMD, "install", "canonical-livepatch"],
@@ -205,7 +207,7 @@ class LivepatchEntitlement(base.UAEntitlement):
                 process_config_directives(entitlement_cfg)
             except util.ProcessExecutionError as e:
                 msg = "Unable to configure Livepatch: " + str(e)
-                print(msg)
+                event.info(msg)
                 logging.error(msg)
                 return False
         if process_token:
@@ -240,9 +242,9 @@ class LivepatchEntitlement(base.UAEntitlement):
                         break
                 if msg == "Unable to enable Livepatch: ":
                     msg += str(e)
-                print(msg)
+                event.info(msg)
                 return False
-            print("Canonical livepatch enabled.")
+            event.info("Canonical livepatch enabled.")
         return True
 
     def _perform_disable(self, silent=False):

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -5,7 +5,9 @@ import os
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
-from uaclient import apt, contract, exceptions, status, util
+from uaclient import apt, contract
+from uaclient import event_logger as event
+from uaclient import exceptions, status, util
 from uaclient.entitlements import base
 from uaclient.status import ApplicationStatus
 
@@ -73,7 +75,7 @@ class RepoEntitlement(base.UAEntitlement):
             if not util.handle_message_operations(msg_ops):
                 return False
             self.install_packages()
-        print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
+        event.info(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         self._check_for_reboot_msg(operation="install")
         return True
 
@@ -214,7 +216,7 @@ class RepoEntitlement(base.UAEntitlement):
         """
 
         if verbose:
-            print("Installing {title} packages".format(title=self.title))
+            event.info("Installing {title} packages".format(title=self.title))
 
         if self.apt_noninteractive:
             env = {"DEBIAN_FRONTEND": "noninteractive"}
@@ -327,7 +329,7 @@ class RepoEntitlement(base.UAEntitlement):
 
         if prerequisite_pkgs:
             if not silent:
-                print(
+                event.info(
                     "Installing prerequisites: {}".format(
                         ", ".join(prerequisite_pkgs)
                     )
@@ -348,7 +350,7 @@ class RepoEntitlement(base.UAEntitlement):
         # Side-effect is that apt policy will now report the repo as accessible
         # which allows ua status to report correct info
         if not silent:
-            print(status.MESSAGE_APT_UPDATING_LISTS)
+            event.info(status.MESSAGE_APT_UPDATING_LISTS)
         try:
             apt.run_apt_command(
                 ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
@@ -398,7 +400,7 @@ class RepoEntitlement(base.UAEntitlement):
 
         if run_apt_update:
             if not silent:
-                print(status.MESSAGE_APT_UPDATING_LISTS)
+                event.info(status.MESSAGE_APT_UPDATING_LISTS)
             apt.run_apt_command(
                 ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
             )

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -170,8 +170,6 @@ class TestESMDisableAptAuthOnly:
 
         inst = ESMAppsEntitlement(cfg)
         with mock.patch.object(ESMAppsEntitlement, "is_beta", is_beta):
-            print(is_beta, cfg_allow_beta)
-            print(inst.valid_service)
             assert disable_apt_auth_only is inst.disable_apt_auth_only
         is_lts_calls = []
         if series != "trusty":

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -505,7 +505,6 @@ class TestFIPSEntitlementEnable:
                     fips_ent.enable()
 
         expected_msg = "Cannot enable FIPS when Livepatch is enabled"
-        print(fake_stdout.getvalue())
         assert expected_msg in fake_stdout.getvalue().strip()
 
     @mock.patch("uaclient.util.handle_message_operations")

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+"""
+This module is responsible for handling all events
+that must be raised to the user somehow. The main idea
+behind this module is to centralize all events that happens
+during the execution of UA commands and allows us to report
+those events in real time or through a machine-readable format.
+"""
+
+import enum
+
+
+@enum.unique
+class EventLoggerMode(enum.Enum):
+    """
+    Defines event logger supported modes.
+    Currently, we only support the cli and machine-readable
+    mode. On cli mode, we will print to stdout/stderr any
+    event that we receive. On machine-readable mode, we will
+    store those events and parse them for an specified
+    format.
+    """
+
+    CLI_MODE = object()
+    MACHINE_READABLE_MODE = object()
+
+
+# By default, the event logger will be on CLI mode,
+# printing every event it receives.
+_event_logger_mode = EventLoggerMode.CLI_MODE
+
+
+def info(info_msg: str):
+    if _event_logger_mode == EventLoggerMode.CLI_MODE:
+        print(info_msg)

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -1,7 +1,9 @@
 import logging
 from typing import List, Optional
 
-from uaclient import apt, status, util
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import status, util
 
 SNAP_CMD = "/usr/bin/snap"
 SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
@@ -40,7 +42,7 @@ def configure_snap_proxy(
         return
 
     if http_proxy or https_proxy:
-        print(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="snap"))
+        event.info(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="snap"))
 
     if http_proxy:
         util.subp(

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -620,8 +620,6 @@ class TestMain:
         assert "{}\n".format(status.MESSAGE_CONNECTIVITY_ERROR) == err
         error_log = caplog_text()
 
-        print(expected_log)
-        print(error_log)
         assert expected_log in error_log
         assert "Traceback (most recent call last):" in error_log
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1741,8 +1741,6 @@ class TestMachineTokenOverlay:
         )
 
         cfg = UAConfig(cfg=user_cfg)
-        print(expected)
-        print(cfg.machine_token)
         assert expected == cfg.machine_token
 
     @mock.patch("uaclient.config.UAConfig.read_cache")

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -27,6 +27,7 @@ from typing import (
 from urllib import error, request
 from urllib.parse import urlparse
 
+from uaclient import event_logger as event
 from uaclient import exceptions, status
 
 REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
@@ -470,11 +471,11 @@ def prompt_choices(msg: str = "", valid_choices: List[str] = []) -> str:
         value, ", ".join([choice.upper() for choice in valid_choices])
     )
     while True:
-        print(msg)
+        event.info(msg)
         value = input("> ").lower()
         if value in valid_choices:
             break
-        print(error_msg)
+        event.info(error_msg)
     return value
 
 
@@ -855,7 +856,7 @@ def handle_message_operations(
     """
     for msg_op in msg_ops:
         if isinstance(msg_op, str):
-            print(msg_op)
+            event.info(msg_op)
         else:  # Then we are a callable and dict of args
             functor, args = msg_op
             if not functor(**args):


### PR DESCRIPTION
## Proposed Commit Message
cli: add mechanism to ignore print events

When running some UA commands, we will be required to provide their
output in a machine-readable way. When that happens, we don't to print
anything to stdout. We are now adding a mechanism that allows us to
achieve that

PS: This is an alternative for #1904 

## Test Steps
Run the unittests and any integration test that is printing to stdout

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
