### PR TITLE
cli: add json output for enable command (SC-699)

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -60,6 +60,16 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             This command must be run as root (try using sudo).
             """
+        And I verify that running `ua enable foobar --format json` `as non-root` exits `1`
+        And stdout is formatted as `json` and has keys:
+            """
+            result processed_services failed_services needs_reboot
+            errors warnings _schema_version
+            """
+        And I will see the following on stdout:
+            """
+            {"_schema_version": 0.1, "errors": [{"message": "This command must be run as root (try using sudo).", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
         And I verify that running `ua enable foobar` `with sudo` exits `1`
         And I will see the following on stdout:
             """
@@ -69,6 +79,11 @@ Feature: Enable command behaviour when attached to an UA subscription
             """
             Cannot enable unknown service 'foobar'.
             Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch.
+            """
+        And I verify that running `ua enable foobar --format json` `with sudo` exits `1`
+        And I will see the following on stdout:
+            """
+            {"_schema_version": 0.1, "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry cc-eal, cis, esm-infra, fips, fips-updates, livepatch.", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
         And I verify that running `ua enable ros foobar` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -80,12 +95,22 @@ Feature: Enable command behaviour when attached to an UA subscription
             Cannot enable unknown service 'foobar, ros'.
             Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch.
             """
+        And I verify that running `ua enable ros foobar --format json` `with sudo` exits `1`
+        And I will see the following on stdout:
+        """
+        {"_schema_version": 0.1, "errors": [{"message": "Cannot enable unknown service 'foobar, ros'.\nTry cc-eal, cis, esm-infra, fips, fips-updates, livepatch.", "service": null, "type": "system"}], "failed_services": ["foobar", "ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
         And I verify that running `ua enable esm-infra` `with sudo` exits `1`
-        Then I will see the following on stdout:
+        And I will see the following on stdout:
             """
             One moment, checking your subscription first
             UA Infra: ESM is already enabled.
             See: sudo ua status
+            """
+        And I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
+        Then I will see the following on stdout:
+            """
+            {"_schema_version": 0.1, "errors": [{"message": "UA Infra: ESM is already enabled.\nSee: sudo ua status", "service": "esm-infra", "type": "service"}], "failed_services": ["esm-infra"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -51,6 +51,63 @@ Feature: Enable command behaviour when attached to an UA subscription
 
     @series.xenial
     @series.bionic
+    @series.focal
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached enable of different services using json format
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        Then I verify that running `ua enable foobar --format json` `as non-root` exits `1`
+        And stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+            """
+            {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+        And I verify that running `ua enable foobar --format json` `with sudo` exits `1`
+        And stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+            """
+            {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry <valid_services>", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+        And I verify that running `ua enable ros foobar --format json` `with sudo` exits `1`
+        And stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar, ros'.\nTry <valid_services>", "service": null, "type": "system"}], "failed_services": ["foobar", "ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
+        And I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
+        Then I will see the following on stdout:
+            """
+            {"_schema_version": "0.1", "errors": [{"message": "UA Infra: ESM is already enabled.\nSee: sudo ua status", "service": "esm-infra", "type": "service"}], "failed_services": ["esm-infra"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+        When I run `ua disable esm-infra` with sudo
+        And I run `ua enable esm-infra --format json` with sudo
+        Then stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-infra"], "result": "success", "warnings": []}
+        """
+        When I run `ua disable esm-infra` with sudo
+        And I verify that running `ua enable esm-infra foobar --format json` `with sudo` exits `1`
+        Then stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry <valid_services>", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": ["esm-infra"], "result": "failure", "warnings": []}
+        """
+        When I run `ua disable esm-infra esm-apps` with sudo
+        And I run `ua enable esm-infra esm-apps --beta --format json` with sudo
+        Then stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-apps", "esm-infra"], "result": "success", "warnings": []}
+        """
+
+        Examples: ubuntu release
+           | release | valid_services                                         |
+           | xenial  | cc-eal, cis, esm-infra, fips, fips-updates, livepatch. |
+           | bionic  | cc-eal, cis, esm-infra, fips, fips-updates, livepatch. |
+           | focal   | cc-eal, esm-infra, fips, fips-updates, livepatch, usg. |
+
+    @series.lts
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable of a service in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -59,16 +116,6 @@ Feature: Enable command behaviour when attached to an UA subscription
         And I will see the following on stderr:
             """
             This command must be run as root (try using sudo).
-            """
-        And I verify that running `ua enable foobar --format json` `as non-root` exits `1`
-        And stdout is formatted as `json` and has keys:
-            """
-            result processed_services failed_services needs_reboot
-            errors warnings _schema_version
-            """
-        And I will see the following on stdout:
-            """
-            {"_schema_version": 0.1, "errors": [{"message": "This command must be run as root (try using sudo).", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
         And I verify that running `ua enable foobar` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -80,11 +127,6 @@ Feature: Enable command behaviour when attached to an UA subscription
             Cannot enable unknown service 'foobar'.
             Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch.
             """
-        And I verify that running `ua enable foobar --format json` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            {"_schema_version": 0.1, "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry cc-eal, cis, esm-infra, fips, fips-updates, livepatch.", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-            """
         And I verify that running `ua enable ros foobar` `with sudo` exits `1`
         And I will see the following on stdout:
             """
@@ -95,22 +137,12 @@ Feature: Enable command behaviour when attached to an UA subscription
             Cannot enable unknown service 'foobar, ros'.
             Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch.
             """
-        And I verify that running `ua enable ros foobar --format json` `with sudo` exits `1`
-        And I will see the following on stdout:
-        """
-        {"_schema_version": 0.1, "errors": [{"message": "Cannot enable unknown service 'foobar, ros'.\nTry cc-eal, cis, esm-infra, fips, fips-updates, livepatch.", "service": null, "type": "system"}], "failed_services": ["foobar", "ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-        """
         And I verify that running `ua enable esm-infra` `with sudo` exits `1`
         And I will see the following on stdout:
             """
             One moment, checking your subscription first
             UA Infra: ESM is already enabled.
             See: sudo ua status
-            """
-        And I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
-        Then I will see the following on stdout:
-            """
-            {"_schema_version": 0.1, "errors": [{"message": "UA Infra: ESM is already enabled.\nSee: sudo ua status", "service": "esm-infra", "type": "service"}], "failed_services": ["esm-infra"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -99,6 +99,12 @@ Feature: FIPS enablement in lxd VMs
             """
             Disabling FIPS requires system reboot to complete operation
             """
+        When I run `ua enable <fips-service> --assume-yes --format json` with sudo
+        Then stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": 0.1, "errors": [], "failed_services": [], "needs_reboot": true, "processed_services": ["<fips-service>"], "result": "success", "warnings": []}
+        """
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                |
@@ -207,6 +213,13 @@ Feature: FIPS enablement in lxd VMs
             """
             livepatch +yes +enabled
             """
+        When I run `ua disable <fips-service> --assume-yes` with sudo
+        And I run `ua enable <fips-service> --assume-yes --format json` with sudo
+        Then stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": 0.1, "errors": [], "failed_services": [], "needs_reboot": true, "processed_services": ["<fips-service>"], "result": "success", "warnings": []}
+        """
 
         Examples: ubuntu release
            | release | fips-name    | fips-service |fips-apt-source                                                |

--- a/features/schemas/enable.json
+++ b/features/schemas/enable.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "properties": {
+    "_schema_version": {
+       "type": "string"
+    },
+    "result": {
+       "type": "string",
+       "enum": ["success", "failure"]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "message", "service", "type" ],
+        "properties": {
+          "message": {
+            "type": "string"
+           },
+           "service": {
+             "type": ["null", "string"]
+           }
+        },
+        "patternProperties": {
+           "^type$": {
+             "type": "string",
+             "enum": ["service", "system"]
+          }
+        }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "message", "service", "type" ],
+        "properties": {
+          "message": {
+            "type": "string"
+           },
+           "service": {
+             "type": ["null", "string"]
+           }
+        },
+        "patternProperties": {
+           "^type$": {
+             "type": "string",
+             "enum": ["service", "system"]
+          }
+        }
+      }
+    },
+    "failed_services": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "processed_services": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "needs_reboot": {
+      "type": "boolean"
+    }
+  }
+}

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import time
 
+import jsonschema  # type: ignore
 import yaml
 from behave import given, then, when
 from hamcrest import (
@@ -778,6 +779,15 @@ def i_restore_the_saved_key_value_on_contract(context, key):
         contract_field=key.split(".")[-1],
         new_value=saved_value,
     )
+
+
+@then("stdout is a json matching the `{schema}` schema")
+def stdout_matches_the_json_schema(context, schema):
+    with open("features/schemas/{}.json".format(schema), "r") as schema_file:
+        jsonschema.validate(
+            instance=json.loads(context.process.stdout.strip()),
+            schema=json.load(schema_file),
+        )
 
 
 def get_command_prefix_for_user_spec(user_spec):

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -538,3 +538,29 @@ Feature: Command behaviour when unattached
           | hirsute |
           | impish  |
           | jammy   |
+
+    @series.all
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Unattached enable fails in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I verify that running `ua enable esm-infra` `with sudo` exits `1`
+        Then I will see the following on stderr:
+          """
+          To use 'esm-infra' you need an Ubuntu Advantage subscription
+          Personal and community subscriptions are available at no charge
+          See https://ubuntu.com/advantage
+          """
+        When I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
+        Then I will see the following on stdout:
+          """
+          {"_schema_version": 0.1, "errors": [{"message": "To use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+          """
+        
+        Examples: ubuntu release
+          | release |
+          | xenial  |
+          | bionic  |
+          | focal   |
+          | hirsute |
+          | impish  |
+          | jammy   |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -551,9 +551,10 @@ Feature: Command behaviour when unattached
           See https://ubuntu.com/advantage
           """
         When I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
-        Then I will see the following on stdout:
+        Then stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
           """
-          {"_schema_version": 0.1, "errors": [{"message": "To use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+          {"_schema_version": "0.1", "errors": [{"message": "To use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
           """
         
         Examples: ubuntu release

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,6 @@
 # Integration testing
 behave
+jsonschema
 PyHamcrest
 pycloudlib @ git+https://github.com/canonical/pycloudlib.git@756a2c2de044ca60eaa7cdc76653d23a1339dc0a
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -6,8 +6,7 @@ import subprocess
 import tempfile
 from typing import Dict, List, Optional
 
-from uaclient import event_logger as event
-from uaclient import exceptions, gpg, status, util
+from uaclient import event_logger, exceptions, gpg, status, util
 
 APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
 APT_AUTH_COMMENT = "  # ubuntu-advantage-tools"
@@ -27,6 +26,8 @@ APT_PROXY_CONF_FILE = "/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy"
 # resolve to apt conflict or try again.
 # Hope for an optimal first try.
 APT_RETRIES = [1.0, 5.0, 10.0]
+
+event = event_logger.get_event_logger()
 
 
 def assert_valid_apt_credentials(repo_url, username, password):

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 from typing import Dict, List, Optional
 
+from uaclient import event_logger as event
 from uaclient import exceptions, gpg, status, util
 
 APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
@@ -403,7 +404,7 @@ def setup_apt_proxy(
     :return: None
     """
     if http_proxy or https_proxy:
-        print(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"))
+        event.info(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="APT"))
 
     apt_proxy_config = ""
     if http_proxy:

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -31,6 +31,7 @@ from uaclient import (
     security,
     security_status,
 )
+from uaclient import event_logger as event
 from uaclient import status as ua_status
 from uaclient import util, version
 from uaclient.clouds import AutoAttachCloudInstance  # noqa: F401
@@ -859,7 +860,7 @@ def action_enable(args, *, cfg, **kwargs):
 
     @return: 0 on success, 1 otherwise
     """
-    print(ua_status.MESSAGE_REFRESH_CONTRACT_ENABLE)
+    event.info(ua_status.MESSAGE_REFRESH_CONTRACT_ENABLE)
     try:
         contract.request_updated_contract(cfg)
     except (util.UrlError, exceptions.UserFacingError):
@@ -892,7 +893,7 @@ def action_enable(args, *, cfg, **kwargs):
                 and isinstance(reason, ua_status.CanEnableFailure)
             ):
                 if reason.message is not None:
-                    print(reason.message)
+                    event.info(reason.message)
                 if reason.reason == ua_status.CanEnableFailureReason.IS_BETA:
                     # if we failed because ent is in beta and there was no
                     # allow_beta flag/config, pretend it doesn't exist
@@ -900,7 +901,7 @@ def action_enable(args, *, cfg, **kwargs):
 
             ret &= ent_ret
         except exceptions.UserFacingError as e:
-            print(e)
+            event.info(e)
             ret = False
 
     if entitlements_not_found:
@@ -971,7 +972,9 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
 
     if to_disable:
         suffix = "s" if len(to_disable) > 1 else ""
-        print("Detach will disable the following service{}:".format(suffix))
+        event.info(
+            "Detach will disable the following service{}:".format(suffix)
+        )
         for ent in to_disable:
             print("    {}".format(ent.name))
     if not util.prompt_for_confirmation(assume_yes=assume_yes):
@@ -995,13 +998,13 @@ def _post_cli_attach(cfg: config.UAConfig) -> None:
     ]
 
     if contract_name:
-        print(
+        event.info(
             ua_status.MESSAGE_ATTACH_SUCCESS_TMPL.format(
                 contract_name=contract_name
             )
         )
     else:
-        print(ua_status.MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME)
+        event.info(ua_status.MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME)
 
     action_status(args=None, cfg=cfg)
 
@@ -1064,7 +1067,7 @@ def action_auto_attach(args, *, cfg):
     try:
         actions.auto_attach(cfg, instance)
     except util.UrlError:
-        print(ua_status.MESSAGE_ATTACH_FAILURE)
+        event.info(ua_status.MESSAGE_ATTACH_FAILURE)
         return 1
     except exceptions.UserFacingError:
         return 1
@@ -1086,7 +1089,7 @@ def action_attach(args, *, cfg):
             cfg, token=args.token, allow_enable=args.auto_enable
         )
     except util.UrlError:
-        print(ua_status.MESSAGE_ATTACH_FAILURE)
+        event.info(ua_status.MESSAGE_ATTACH_FAILURE)
         return 1
     except exceptions.UserFacingError:
         return 1

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -130,13 +130,9 @@ def assert_lock_file(lock_holder=None):
     def wrapper(f):
         @wraps(f)
         def new_f(*args, cfg, **kwargs):
-            try:
-                with lock.SingleAttemptLock(cfg=cfg, lock_holder=lock_holder):
-                    retval = f(*args, cfg=cfg, **kwargs)
-                return retval
-            except exceptions.LockHeldError as e:
-                event.raise_error_and_finish(exception=e)
-                return 1
+            with lock.SingleAttemptLock(cfg=cfg, lock_holder=lock_holder):
+                retval = f(*args, cfg=cfg, **kwargs)
+            return retval
 
         return new_f
 
@@ -149,10 +145,7 @@ def assert_root(f):
     @wraps(f)
     def new_f(*args, **kwargs):
         if os.getuid() != 0:
-            event.raise_error_and_finish(
-                exception=exceptions.NonRootUserError()
-            )
-            return 1
+            raise exceptions.NonRootUserError()
         else:
             return f(*args, **kwargs)
 
@@ -160,7 +153,7 @@ def assert_root(f):
 
 
 def set_event_mode(f):
-    """Decorator asserting root user"""
+    """Decorator setting the right event logger mode"""
 
     @wraps(f)
     def new_f(cmd_args, *args, **kwargs):
@@ -190,8 +183,7 @@ def assert_attached(unattached_msg_tmpl=None):
                     exception = exceptions.UnattachedError(msg)
                 else:
                     exception = exceptions.UnattachedError()
-                event.raise_error_and_finish(exception=exception)
-                return 1
+                raise exception
             return f(args, cfg=cfg, **kwargs)
 
         return new_f
@@ -205,7 +197,7 @@ def assert_not_attached(f):
     @wraps(f)
     def new_f(args, cfg):
         if cfg.is_attached:
-            event.raise_error(exception=exceptions.AlreadyAttachedError(cfg))
+            raise exceptions.AlreadyAttachedError(cfg)
         return f(args, cfg=cfg)
 
     return new_f
@@ -940,10 +932,9 @@ def action_enable(args, *, cfg, **kwargs):
 
             ret &= ent_ret
         except exceptions.UserFacingError as e:
-            event.raise_error(exception=e, service=ent_name)
+            event.info(e.msg)
+            event.error(error_msg=e.msg, service=ent_name)
             ret = False
-        except Exception as e:
-            event.raise_error(exception=e, service=ent_name)
 
     if entitlements_not_found:
         valid_names = ", ".join(valid_services_names)
@@ -956,20 +947,16 @@ def action_enable(args, *, cfg, **kwargs):
             )
         )
         tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
-        not_found_exception = exceptions.UserFacingError(
+        event.services_failed(entitlements_not_found)
+        raise exceptions.UserFacingError(
             tmpl.format(
                 operation="enable",
                 name=", ".join(entitlements_not_found),
                 service_msg=service_msg,
             )
         )
-        event.services_failed(entitlements_not_found)
-        event.raise_error(exception=not_found_exception)
-        ret = False
 
-    if args and args.format == "json":
-        print(event.process_events())
-
+    event.process_events()
     return 0 if ret else 1
 
 
@@ -1520,7 +1507,10 @@ def main_error_handler(func):
                     tmpl = (
                         ua_status.MESSAGE_SSL_VERIFICATION_ERROR_OPENSSL_CONFIG
                     )
-                print(tmpl.format(url=exc.url), file=sys.stderr)
+                event.error(error_msg=tmpl.format(url=exc.url))
+                event.info(
+                    info_msg=tmpl.format(url=exc.url), file_type=sys.stderr
+                )
             else:
                 with util.disable_log_to_console():
                     msg_args = {"url": exc.url, "error": exc}
@@ -1531,22 +1521,37 @@ def main_error_handler(func):
                     else:
                         msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_TMPL
                     logging.exception(msg_tmpl.format(**msg_args))
-                print(ua_status.MESSAGE_CONNECTIVITY_ERROR, file=sys.stderr)
+
+                event.error(error_msg=ua_status.MESSAGE_CONNECTIVITY_ERROR)
+                event.info(
+                    info_msg=ua_status.MESSAGE_CONNECTIVITY_ERROR,
+                    file_type=sys.stderr,
+                )
             lock.clear_lock_file_if_present()
+            event.process_events()
             sys.exit(1)
         except exceptions.UserFacingError as exc:
             with util.disable_log_to_console():
                 logging.error(exc.msg)
-            print("{}".format(exc.msg), file=sys.stderr)
+            event.error(error_msg=exc.msg)
+            event.info(info_msg="{}".format(exc.msg), file_type=sys.stderr)
             if not isinstance(exc, exceptions.LockHeldError):
                 # Only clear the lock if it is ours.
                 lock.clear_lock_file_if_present()
+            event.process_events()
             sys.exit(exc.exit_code)
-        except Exception:
+        except Exception as e:
             with util.disable_log_to_console():
                 logging.exception("Unhandled exception, please file a bug")
             lock.clear_lock_file_if_present()
-            print(ua_status.MESSAGE_UNEXPECTED_ERROR, file=sys.stderr)
+            event.info(
+                info_msg=ua_status.MESSAGE_UNEXPECTED_ERROR,
+                file_type=sys.stderr,
+            )
+            event.error(
+                error_msg=getattr(e, "msg", str(e)), error_type="exception"
+            )
+            event.process_events()
             sys.exit(1)
 
     return wrapper

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -11,7 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
 
-from uaclient import apt, exceptions, snap, status, util, version
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import exceptions, snap, status, util, version
 from uaclient.defaults import (
     BASE_CONTRACT_URL,
     BASE_SECURITY_URL,
@@ -1027,7 +1029,7 @@ class UAConfig:
 
         if len(services_with_proxies) > 0:
             services = ", ".join(services_with_proxies)
-            print(
+            event.info(
                 status.MESSAGE_PROXY_DETECTED_BUT_NOT_CONFIGURED.format(
                     services=services
                 )

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -11,9 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
 
-from uaclient import apt
-from uaclient import event_logger as event
-from uaclient import exceptions, snap, status, util, version
+from uaclient import apt, event_logger, exceptions, snap, status, util, version
 from uaclient.defaults import (
     BASE_CONTRACT_URL,
     BASE_SECURITY_URL,
@@ -86,11 +84,12 @@ VALID_UA_CONFIG_KEYS = (
     "ua_config",
 )
 
-
 # A data path is a filename, an attribute ("private") indicating whether it
 # should only be readable by root, and an attribute ("permanent") indicating
 # whether it should stick around even when detached.
 DataPath = namedtuple("DataPath", ("filename", "private", "permanent"))
+
+event = event_logger.get_event_logger()
 
 
 class UAConfig:

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import mock
 import pytest
 
+from uaclient import event_logger
 from uaclient.config import UAConfig
 
 # We are doing this because we are sure that python3-apt comes with the distro,
@@ -126,3 +127,11 @@ def FakeConfig(tmpdir):
                 self.cfg.update({"features": features_override})
 
     return _FakeConfig
+
+
+@pytest.fixture
+def event():
+    event = event_logger.get_event_logger()
+    event.reset()
+
+    return event

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -4,7 +4,9 @@ import re
 from itertools import groupby
 from typing import Callable, Dict, List, Tuple, Union
 
-from uaclient import apt, exceptions, status, util
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import exceptions, status, util
 from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient.entitlements import repo
 from uaclient.types import StaticAffordance
@@ -68,7 +70,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         :param verbose: If true, print messages to stdout
         """
         if verbose:
-            print("Installing {title} packages".format(title=self.title))
+            event.info("Installing {title} packages".format(title=self.title))
 
         # We need to guarantee that the metapackage is installed.
         # While the other packages should still be installed, if they
@@ -97,7 +99,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     package_list=[pkg], cleanup_on_failure=False, verbose=False
                 )
             except exceptions.UserFacingError:
-                print(
+                event.info(
                     status.MESSAGE_FIPS_PACKAGE_NOT_AVAILABLE.format(
                         service=self.title, pkg=pkg
                     )
@@ -109,7 +111,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         @param operation: The operation being executed.
         """
         if util.should_reboot():
-            print(
+            event.info(
                 status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
                     operation=operation
                 )

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -4,12 +4,12 @@ import re
 from itertools import groupby
 from typing import Callable, Dict, List, Tuple, Union
 
-from uaclient import apt
-from uaclient import event_logger as event
-from uaclient import exceptions, status, util
+from uaclient import apt, event_logger, exceptions, status, util
 from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient.entitlements import repo
 from uaclient.types import StaticAffordance
+
+event = event_logger.get_event_logger()
 
 
 class FIPSCommonEntitlement(repo.RepoEntitlement):
@@ -110,7 +110,9 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
         @param operation: The operation being executed.
         """
-        if util.should_reboot():
+        reboot_required = util.should_reboot()
+        event.needs_reboot(reboot_required)
+        if reboot_required:
             event.info(
                 status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
                     operation=operation

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -2,7 +2,9 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from uaclient import apt, exceptions, snap, status, util
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import exceptions, snap, status, util
 from uaclient.entitlements import base
 from uaclient.status import ApplicationStatus
 from uaclient.types import StaticAffordance
@@ -55,7 +57,7 @@ def configure_livepatch_proxy(
                                snap calls
     """
     if http_proxy or https_proxy:
-        print(
+        event.info(
             status.MESSAGE_SETTING_SERVICE_PROXY.format(
                 service=LivepatchEntitlement.title
             )
@@ -126,8 +128,8 @@ class LivepatchEntitlement(base.UAEntitlement):
         @return: True on success, False otherwise.
         """
         if not util.which(snap.SNAP_CMD):
-            print("Installing snapd")
-            print(status.MESSAGE_APT_UPDATING_LISTS)
+            event.info("Installing snapd")
+            event.info(status.MESSAGE_APT_UPDATING_LISTS)
             try:
                 apt.run_apt_command(
                     ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
@@ -172,7 +174,7 @@ class LivepatchEntitlement(base.UAEntitlement):
         )
 
         if not util.which(LIVEPATCH_CMD):
-            print("Installing canonical-livepatch snap")
+            event.info("Installing canonical-livepatch snap")
             try:
                 util.subp(
                     [snap.SNAP_CMD, "install", "canonical-livepatch"],
@@ -205,7 +207,7 @@ class LivepatchEntitlement(base.UAEntitlement):
                 process_config_directives(entitlement_cfg)
             except util.ProcessExecutionError as e:
                 msg = "Unable to configure Livepatch: " + str(e)
-                print(msg)
+                event.info(msg)
                 logging.error(msg)
                 return False
         if process_token:
@@ -240,9 +242,9 @@ class LivepatchEntitlement(base.UAEntitlement):
                         break
                 if msg == "Unable to enable Livepatch: ":
                     msg += str(e)
-                print(msg)
+                event.info(msg)
                 return False
-            print("Canonical livepatch enabled.")
+            event.info("Canonical livepatch enabled.")
         return True
 
     def _perform_disable(self, silent=False):

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -2,9 +2,7 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from uaclient import apt
-from uaclient import event_logger as event
-from uaclient import exceptions, snap, status, util
+from uaclient import apt, event_logger, exceptions, snap, status, util
 from uaclient.entitlements import base
 from uaclient.status import ApplicationStatus
 from uaclient.types import StaticAffordance
@@ -19,6 +17,8 @@ ERROR_MSG_MAP = {
 }
 
 LIVEPATCH_CMD = "/snap/bin/canonical-livepatch"
+
+event = event_logger.get_event_logger()
 
 
 def unconfigure_livepatch_proxy(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -5,13 +5,13 @@ import os
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
-from uaclient import apt, contract
-from uaclient import event_logger as event
-from uaclient import exceptions, status, util
+from uaclient import apt, contract, event_logger, exceptions, status, util
 from uaclient.entitlements import base
 from uaclient.status import ApplicationStatus
 
 APT_DISABLED_PIN = "-32768"
+
+event = event_logger.get_event_logger()
 
 
 class RepoEntitlement(base.UAEntitlement):
@@ -56,7 +56,9 @@ class RepoEntitlement(base.UAEntitlement):
 
     def _check_for_reboot(self) -> bool:
         """Check if system needs to be rebooted."""
-        return util.should_reboot(installed_pkgs=set(self.packages))
+        reboot_required = util.should_reboot(installed_pkgs=set(self.packages))
+        event.needs_reboot(reboot_required)
+        return reboot_required
 
     @property
     @abc.abstractmethod

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -5,7 +5,9 @@ import os
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
-from uaclient import apt, contract, exceptions, status, util
+from uaclient import apt, contract
+from uaclient import event_logger as event
+from uaclient import exceptions, status, util
 from uaclient.entitlements import base
 from uaclient.status import ApplicationStatus
 
@@ -73,7 +75,7 @@ class RepoEntitlement(base.UAEntitlement):
             if not util.handle_message_operations(msg_ops):
                 return False
             self.install_packages()
-        print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
+        event.info(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         self._check_for_reboot_msg(operation="install")
         return True
 
@@ -214,7 +216,7 @@ class RepoEntitlement(base.UAEntitlement):
         """
 
         if verbose:
-            print("Installing {title} packages".format(title=self.title))
+            event.info("Installing {title} packages".format(title=self.title))
 
         if self.apt_noninteractive:
             env = {"DEBIAN_FRONTEND": "noninteractive"}
@@ -327,7 +329,7 @@ class RepoEntitlement(base.UAEntitlement):
 
         if prerequisite_pkgs:
             if not silent:
-                print(
+                event.info(
                     "Installing prerequisites: {}".format(
                         ", ".join(prerequisite_pkgs)
                     )
@@ -348,7 +350,7 @@ class RepoEntitlement(base.UAEntitlement):
         # Side-effect is that apt policy will now report the repo as accessible
         # which allows ua status to report correct info
         if not silent:
-            print(status.MESSAGE_APT_UPDATING_LISTS)
+            event.info(status.MESSAGE_APT_UPDATING_LISTS)
         try:
             apt.run_apt_command(
                 ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
@@ -398,7 +400,7 @@ class RepoEntitlement(base.UAEntitlement):
 
         if run_apt_update:
             if not silent:
-                print(status.MESSAGE_APT_UPDATING_LISTS)
+                event.info(status.MESSAGE_APT_UPDATING_LISTS)
             apt.run_apt_command(
                 ["apt-get", "update"], status.MESSAGE_APT_UPDATE_FAILED
             )

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -170,8 +170,6 @@ class TestESMDisableAptAuthOnly:
 
         inst = ESMAppsEntitlement(cfg)
         with mock.patch.object(ESMAppsEntitlement, "is_beta", is_beta):
-            print(is_beta, cfg_allow_beta)
-            print(inst.valid_service)
             assert disable_apt_auth_only is inst.disable_apt_auth_only
         is_lts_calls = []
         if series != "trusty":

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -505,7 +505,6 @@ class TestFIPSEntitlementEnable:
                     fips_ent.enable()
 
         expected_msg = "Cannot enable FIPS when Livepatch is enabled"
-        print(fake_stdout.getvalue())
         assert expected_msg in fake_stdout.getvalue().strip()
 
     @mock.patch("uaclient.util.handle_message_operations")

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+"""
+This module is responsible for handling all events
+that must be raised to the user somehow. The main idea
+behind this module is to centralize all events that happens
+during the execution of UA commands and allows us to report
+those events in real time or through a machine-readable format.
+"""
+
+import enum
+
+
+@enum.unique
+class EventLoggerMode(enum.Enum):
+    """
+    Defines event logger supported modes.
+    Currently, we only support the cli and machine-readable
+    mode. On cli mode, we will print to stdout/stderr any
+    event that we receive. On machine-readable mode, we will
+    store those events and parse them for an specified
+    format.
+    """
+
+    CLI_MODE = object()
+    MACHINE_READABLE_MODE = object()
+
+
+# By default, the event logger will be on CLI mode,
+# printing every event it receives.
+_event_logger_mode = EventLoggerMode.CLI_MODE
+
+
+def info(info_msg: str):
+    if _event_logger_mode == EventLoggerMode.CLI_MODE:
+        print(info_msg)

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -9,6 +9,20 @@ those events in real time or through a machine-readable format.
 """
 
 import enum
+import json
+from typing import Dict, List, Optional, Set  # noqa: F401
+
+JSON_SCHEMA_VERSION = 0.1
+_event_logger = None
+
+
+def get_event_logger():
+    global _event_logger
+
+    if _event_logger is None:
+        _event_logger = EventLogger()
+
+    return _event_logger
 
 
 @enum.unique
@@ -22,15 +36,102 @@ class EventLoggerMode(enum.Enum):
     format.
     """
 
-    CLI_MODE = object()
-    MACHINE_READABLE_MODE = object()
+    CLI = object()
+    MACHINE_READABLE = object()
 
 
-# By default, the event logger will be on CLI mode,
-# printing every event it receives.
-_event_logger_mode = EventLoggerMode.CLI_MODE
+class EventLogger:
+    def __init__(self):
+        self._error_events = []  # type: List[Dict[str, Optional[str]]]
+        self._warning_events = []  # type: List[Dict[str, Optional[str]]]
+        self._processed_services = []  # type: List[str]
+        self._failed_services = set()  # type: Set[str]
+        self._needs_reboot = False
 
+        # By default, the event logger will be on CLI mode,
+        # printing every event it receives.
+        self._event_logger_mode = EventLoggerMode.CLI
 
-def info(info_msg: str):
-    if _event_logger_mode == EventLoggerMode.CLI_MODE:
-        print(info_msg)
+    def reset(self):
+        self._error_events = []
+        self._warning_events = []
+        self._processed_services = []
+        self._failed_services = set()
+        self._needs_reboot = False
+
+    def set_event_mode(self, event_mode: EventLoggerMode):
+        self._event_logger_mode = event_mode
+
+    def info(self, info_msg: str):
+        if self._event_logger_mode == EventLoggerMode.CLI:
+            print(info_msg)
+
+    def _record_dict_event(
+        self,
+        msg: str,
+        service: Optional[str],
+        event_dict: List[Dict[str, Optional[str]]],
+    ):
+        event_type = "service" if service else "system"
+        event_dict.append(
+            {"type": event_type, "service": service, "message": msg}
+        )
+
+    def error(self, error_msg: str, service: Optional[str] = None):
+        if self._event_logger_mode == EventLoggerMode.MACHINE_READABLE:
+            self._record_dict_event(
+                msg=error_msg, service=service, event_dict=self._error_events
+            )
+
+    def warning(self, warning_msg: str, service: Optional[str] = None):
+        if self._event_logger_mode == EventLoggerMode.MACHINE_READABLE:
+            self._record_dict_event(
+                msg=warning_msg,
+                service=service,
+                event_dict=self._warning_events,
+            )
+
+    def raise_error(self, exception: Exception, service: Optional[str] = None):
+        if self._event_logger_mode == EventLoggerMode.CLI:
+            raise exception
+        else:
+            error_msg = getattr(exception, "msg") or str(exception)
+            self.error(error_msg=error_msg, service=service)
+
+    def raise_error_and_finish(
+        self, exception: Exception, service: Optional[str] = None
+    ):
+        self.raise_error(exception=exception, service=service)
+
+        if self._event_logger_mode == EventLoggerMode.MACHINE_READABLE:
+            print(self.process_events())
+
+    def service_processed(self, service: str):
+        self._processed_services.append(service)
+
+    def services_failed(self, services: List[str]):
+        self._failed_services.update(services)
+
+    def needs_reboot(self, reboot_required: bool):
+        self._needs_reboot = reboot_required
+
+    def _generate_failed_services(self):
+        services_with_error = {
+            error["service"]
+            for error in self._error_events
+            if error["service"]
+        }
+        return list(set.union(self._failed_services, services_with_error))
+
+    def process_events(self) -> str:
+        response = {
+            "_schema_version": JSON_SCHEMA_VERSION,
+            "result": "success" if not self._error_events else "failure",
+            "processed_services": sorted(self._processed_services),
+            "failed_services": sorted(self._generate_failed_services()),
+            "errors": self._error_events,
+            "warnings": self._warning_events,
+            "needs_reboot": self._needs_reboot,
+        }
+
+        return json.dumps(response, sort_keys=True)

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -11,7 +11,7 @@ import json
 import sys
 from typing import Dict, List, Optional, Set  # noqa: F401
 
-JSON_SCHEMA_VERSION = 0.1
+JSON_SCHEMA_VERSION = "0.1"
 _event_logger = None
 
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -72,14 +72,11 @@ class LockHeldError(UserFacingError):
     """
 
     def __init__(self, lock_request: str, lock_holder: str, pid: int):
-        lock_request = lock_request
-        msg = "Unable to perform: {lock_request}.\n".format(
-            lock_request=lock_request
+        super().__init__(
+            status.MESSAGE_LOCK_HELD_ERROR.format(
+                lock_request=lock_request, lock_holder=lock_holder, pid=pid
+            )
         )
-        msg += status.MESSAGE_LOCK_HELD.format(
-            pid=pid, lock_holder=lock_holder
-        )
-        super().__init__(msg)
 
 
 class MissingAptURLDirective(UserFacingError):

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -1,7 +1,9 @@
 import logging
 from typing import List, Optional
 
-from uaclient import apt, status, util
+from uaclient import apt
+from uaclient import event_logger as event
+from uaclient import status, util
 
 SNAP_CMD = "/usr/bin/snap"
 SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
@@ -40,7 +42,7 @@ def configure_snap_proxy(
         return
 
     if http_proxy or https_proxy:
-        print(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="snap"))
+        event.info(status.MESSAGE_SETTING_SERVICE_PROXY.format(service="snap"))
 
     if http_proxy:
         util.subp(

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -1,14 +1,14 @@
 import logging
 from typing import List, Optional
 
-from uaclient import apt
-from uaclient import event_logger as event
-from uaclient import status, util
+from uaclient import apt, event_logger, status, util
 
 SNAP_CMD = "/usr/bin/snap"
 SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
 HTTP_PROXY_OPTION = "proxy.http"
 HTTPS_PROXY_OPTION = "proxy.https"
+
+event = event_logger.get_event_logger()
 
 
 def is_installed() -> bool:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -278,6 +278,12 @@ MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
 Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 MESSAGE_NO_ACTIVE_OPERATIONS = """No Ubuntu Advantage operations are running"""
 MESSAGE_LOCK_HELD = """Operation in progress: {lock_holder} (pid:{pid})"""
+MESSAGE_LOCK_HELD_ERROR = (
+    """\
+Unable to perform: {lock_request}.
+"""
+    + MESSAGE_LOCK_HELD
+)
 PROMPT_YES_NO = """Are you sure? (y/N) """
 MESSAGE_REBOOT_SCRIPT_FAILED = (
     "Failed running reboot_cmds script. See: /var/log/ubuntu-advantage.log"

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -636,8 +636,6 @@ class TestMain:
         assert "{}\n".format(status.MESSAGE_CONNECTIVITY_ERROR) == err
         error_log = caplog_text()
 
-        print(expected_log)
-        print(error_log)
         assert expected_log in error_log
         assert "Traceback (most recent call last):" in error_log
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1755,8 +1755,6 @@ class TestMachineTokenOverlay:
         )
 
         cfg = UAConfig(cfg=user_cfg)
-        print(expected)
-        print(cfg.machine_token)
         assert expected == cfg.machine_token
 
     @mock.patch("uaclient.config.UAConfig.read_cache")

--- a/uaclient/tests/test_event_logger.py
+++ b/uaclient/tests/test_event_logger.py
@@ -1,0 +1,62 @@
+import contextlib
+import io
+import json
+
+import mock
+import pytest
+
+from uaclient.event_logger import JSON_SCHEMA_VERSION, EventLoggerMode
+
+
+class TestEventLogger:
+    @pytest.mark.parametrize(
+        "event_mode",
+        ((EventLoggerMode.CLI), (EventLoggerMode.MACHINE_READABLE)),
+    )
+    def test_process_events(self, event_mode, event):
+        with mock.patch.object(event, "_event_logger_mode", event_mode):
+            fake_stdout = io.StringIO()
+            with contextlib.redirect_stdout(fake_stdout):
+                event.info(info_msg="test")
+                event.needs_reboot(reboot_required=True)
+                event.service_processed("test")
+                event.services_failed(["esm"])
+                event.error(error_msg="error1")
+                event.error(error_msg="error2", service="esm")
+                event.error(error_msg="error3", error_type="exception")
+                event.warning(warning_msg="warning1")
+                event.warning(warning_msg="warning2", service="esm")
+                event.process_events()
+
+            expected_cli_out = "test"
+            expected_machine_out = {
+                "_schema_version": JSON_SCHEMA_VERSION,
+                "result": "failure",
+                "errors": [
+                    {"message": "error1", "service": None, "type": "system"},
+                    {"message": "error2", "service": "esm", "type": "service"},
+                    {
+                        "message": "error3",
+                        "service": None,
+                        "type": "exception",
+                    },
+                ],
+                "warnings": [
+                    {"message": "warning1", "service": None, "type": "system"},
+                    {
+                        "message": "warning2",
+                        "service": "esm",
+                        "type": "service",
+                    },
+                ],
+                "failed_services": ["esm"],
+                "needs_reboot": True,
+                "processed_services": ["test"],
+            }
+
+        if event_mode == EventLoggerMode.CLI:
+            assert expected_cli_out == fake_stdout.getvalue().strip()
+        else:
+            assert expected_machine_out == json.loads(
+                fake_stdout.getvalue().strip()
+            )

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -27,8 +27,7 @@ from typing import (
 from urllib import error, request
 from urllib.parse import urlparse
 
-from uaclient import event_logger as event
-from uaclient import exceptions, status
+from uaclient import event_logger, exceptions, status
 
 REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
 REBOOT_PKGS_FILE_PATH = "/var/run/reboot-required.pkgs"
@@ -44,6 +43,8 @@ PROXY_VALIDATION_APT_HTTP_URL = "http://archive.ubuntu.com"
 PROXY_VALIDATION_APT_HTTPS_URL = "https://esm.ubuntu.com"
 PROXY_VALIDATION_SNAP_HTTP_URL = "http://api.snapcraft.io"
 PROXY_VALIDATION_SNAP_HTTPS_URL = "https://api.snapcraft.io"
+
+event = event_logger.get_event_logger()
 
 
 class LogFormatter(logging.Formatter):

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -27,6 +27,7 @@ from typing import (
 from urllib import error, request
 from urllib.parse import urlparse
 
+from uaclient import event_logger as event
 from uaclient import exceptions, status
 
 REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
@@ -464,11 +465,11 @@ def prompt_choices(msg: str = "", valid_choices: List[str] = []) -> str:
         value, ", ".join([choice.upper() for choice in valid_choices])
     )
     while True:
-        print(msg)
+        event.info(msg)
         value = input("> ").lower()
         if value in valid_choices:
             break
-        print(error_msg)
+        event.info(error_msg)
     return value
 
 
@@ -851,7 +852,7 @@ def handle_message_operations(
     """
     for msg_op in msg_ops:
         if isinstance(msg_op, str):
-            print(msg_op)
+            event.info(msg_op)
         else:  # Then we are a callable and dict of args
             functor, args = msg_op
             if not functor(**args):


### PR DESCRIPTION
## Proposed Commit Message
cli: add json output for enable command

We are now allowing users to modify the output of enable to a machine readable json format. This format will include
all the error and warnings that were generated during the command, while also pointing to which services succeeded and failed during the execution of the command.

## Test Steps
Run the modified integration test.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
