### PR TITLE
fips: update prompt messages

### DIFF
--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -11,8 +11,13 @@ Feature: FIPS enablement in lxd VMs
         And I run `ua disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
-        And I run `ua enable <fips-service> --assume-yes` with sudo
+        And I run `ua enable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
+            """
+            This will install the FIPS packages. The Livepatch service will be unavailable.
+            Warning: This action can take some time and cannot be undone.
+            """
+        And stdout matches regexp:
             """
             Updating package lists
             Installing <fips-name> packages
@@ -51,8 +56,12 @@ Feature: FIPS enablement in lxd VMs
             """
             FIPS support requires system reboot to complete configuration
             """
-        When I run `ua disable <fips-service> --assume-yes` with sudo
+        When I run `ua disable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
+            """
+            This will disable the FIPS entitlement but the FIPS packages will remain installed.
+            """
+        And stdout matches regexp:
             """
             Updating package lists
             A reboot is required to complete disable operation
@@ -105,8 +114,13 @@ Feature: FIPS enablement in lxd VMs
         When I attach `contract_token` with sudo
         And I run `ua disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
-        When I run `ua enable <fips-service> --assume-yes` with sudo
+        When I run `ua enable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
+            """
+            This will install the FIPS packages including security updates.
+            Warning: This action can take some time and cannot be undone.
+            """
+        And stdout matches regexp:
             """
             Updating package lists
             Installing <fips-name> packages
@@ -136,8 +150,12 @@ Feature: FIPS enablement in lxd VMs
         """
         1
         """
-        When I run `ua disable <fips-service> --assume-yes` with sudo
+        When I run `ua disable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
+            """
+            This will disable the FIPS entitlement but the FIPS packages will remain installed.
+            """
+        And stdout matches regexp:
             """
             Updating package lists
             A reboot is required to complete disable operation

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -317,21 +317,22 @@ To fix it, run the following commands:
 """
 PROMPT_FIPS_PRE_ENABLE = (
     """\
-This will install the FIPS core packages.
+This will install the FIPS packages. The Livepatch service will be unavailable.
+Warning: This action can take some time and cannot be undone.
 """
     + PROMPT_YES_NO
 )
 PROMPT_FIPS_UPDATES_PRE_ENABLE = (
     """\
-This will install the FIPS core packages and will include priority updates
-with security fixes.
+This will install the FIPS packages including security updates.
+Warning: This action can take some time and cannot be undone.
 """
     + PROMPT_YES_NO
 )
 PROMPT_FIPS_PRE_DISABLE = (
     """\
-This will disable access to certified FIPS packages.
-"""
+This will disable the FIPS entitlement but the FIPS packages will remain installed.
+"""  # noqa
     + PROMPT_YES_NO
 )
 


### PR DESCRIPTION
## Proposed Commit Message
fips: update prompt messages

Update FIPS enable/disable prompt messages to better inform the user of what will happen on the system after the operation is completed.

## Test Steps
Run the modified integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
