### PR TITLE
enable: show incompatible services message on json (SC-734)

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -657,11 +657,14 @@ Feature: Enable command behaviour when attached to an UA subscription
         And I will see the following on stdout
             """
             One moment, checking your subscription first
-            """
-        And I will see the following on stderr
-            """
             Cannot enable FIPS when Livepatch is enabled.
             """
+        Then I verify that running `ua enable fips --assume-yes --format json` `with sudo` exits `1`
+        And stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable FIPS when Livepatch is enabled.", "service": "fips", "type": "service"}], "failed_services": ["fips"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
 
     @slow
     @series.xenial

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -523,6 +523,7 @@ class TestUaEntitlement:
     ):
         """When can_enable returns False enable returns False."""
         m_can_enable.return_value = (False, can_enable_fail)
+        m_handle_incompat.return_value = (False, None)
         entitlement = concrete_entitlement_factory(entitled=True)
         entitlement._perform_enable = mock.Mock()
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -500,12 +500,11 @@ class TestFIPSEntitlementEnable:
                     status.ApplicationStatus.ENABLED,
                     "",
                 )
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    fips_ent.enable()
+                ret, fail = fips_ent.enable()
 
-        expected_msg = "Cannot enable FIPS when Livepatch is enabled"
-        assert expected_msg in fake_stdout.getvalue().strip()
+        assert not ret
+        expected_msg = "Cannot enable FIPS when Livepatch is enabled."
+        assert expected_msg == fail.message
 
     @mock.patch("uaclient.util.handle_message_operations")
     @mock.patch(

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -456,8 +456,8 @@ Disable {dependent_service} and proceed to disable {service_being_disabled}? \
 (y/N) """
 
 MESSAGE_INCOMPATIBLE_SERVICE_STOPS_ENABLE = """\
-Cannot enable {service_being_enabled} when {incompatible_service} is enabled.
-"""
+Cannot enable {service_being_enabled} when \
+{incompatible_service} is enabled."""
 
 MESSAGE_REQUIRED_SERVICE_STOPS_ENABLE = """\
 Cannot enable {service_being_enabled} when {required_service} is disabled.


### PR DESCRIPTION
## Proposed Commit Message
enable: show incompatible services message on json

We are now adding the incompatible services message to the json output of the enable command

## Test Steps
Run the modified integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
