### PR TITLE
fix update apt and motd messages call

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -16,6 +16,8 @@ def attach_with_token(
     :raise ContractAPIError: On unexpected errors when talking to the contract
         server.
     """
+    from uaclient.jobs.update_messaging import update_apt_and_motd_messages
+
     try:
         contract.request_updated_contract(
             cfg, token, allow_enable=allow_enable
@@ -24,15 +26,15 @@ def attach_with_token(
         with util.disable_log_to_console():
             LOG.exception(exc)
         cfg.status()  # Persist updated status in the event of partial attach
-        config.update_ua_messages(cfg)
+        update_apt_and_motd_messages(cfg)
         raise exc
     except exceptions.UserFacingError as exc:
         LOG.warning(exc.msg)
         cfg.status()  # Persist updated status in the event of partial attach
-        config.update_ua_messages(cfg)
+        update_apt_and_motd_messages(cfg)
         raise exc
 
-    config.update_ua_messages(cfg)
+    update_apt_and_motd_messages(cfg)
 
 
 def auto_attach(

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -46,6 +46,7 @@ from uaclient.defaults import (
 # It is not ideal for us to import an entitlement directly on the cli module.
 # We need to refactor this to avoid that type of coupling in the code.
 from uaclient.entitlements.livepatch import LIVEPATCH_CMD
+from uaclient.jobs.update_messaging import update_apt_and_motd_messages
 
 NAME = "ua"
 
@@ -1021,7 +1022,7 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     contract_client.detach_machine_from_contract(machine_token, contract_id)
     cfg.delete_cache()
     jobs.enable_license_check_if_applicable(cfg)
-    config.update_ua_messages(cfg)
+    update_apt_and_motd_messages(cfg)
     print(ua_status.MESSAGE_DETACH_SUCCESS)
     return 0
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import re
-import sys
 from collections import OrderedDict, namedtuple
 from datetime import datetime
 from functools import wraps
@@ -1221,25 +1220,3 @@ def depth_first_merge_overlay_dict(base_dict, overlay_dict):
                 base_dict[key] = value
         else:
             base_dict[key] = value
-
-
-def update_ua_messages(cfg: UAConfig):
-    """Helper to load and run ua_update_messaging.
-
-    This is needed because we don't have /usr/lib/ubuntu-advantage
-    python scripts in our path and we don't want to shell out with
-    subp to call python3 /path/to/ua_update_messaging.py.
-    """
-    sys.path.append("/usr/lib/ubuntu-advantage")
-    try:
-        __import__("ua_update_messaging")
-        update_msgs = getattr(
-            sys.modules["ua_update_messaging"], "update_apt_and_motd_messages"
-        )
-        update_msgs(cfg)
-    except ImportError:
-        logging.debug(
-            "Unable to update UA messages. Cannot import ua_update_messaging."
-        )
-    finally:
-        sys.path.pop()

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -1,8 +1,8 @@
 from typing import Optional, Tuple  # noqa: F401
 
 from uaclient import util
-from uaclient.config import update_ua_messages
 from uaclient.entitlements import repo
+from uaclient.jobs.update_messaging import update_apt_and_motd_messages
 
 
 class ESMBaseEntitlement(repo.RepoEntitlement):
@@ -12,13 +12,13 @@ class ESMBaseEntitlement(repo.RepoEntitlement):
     def _perform_enable(self, silent: bool = False) -> bool:
         enable_performed = super()._perform_enable(silent=silent)
         if enable_performed:
-            update_ua_messages(self.cfg)
+            update_apt_and_motd_messages(self.cfg)
         return enable_performed
 
     def disable(self, silent=False) -> bool:
         disable_performed = super().disable(silent=silent)
         if disable_performed:
-            update_ua_messages(self.cfg)
+            update_apt_and_motd_messages(self.cfg)
         return disable_performed
 
 

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -179,7 +179,7 @@ class TestESMDisableAptAuthOnly:
 
 
 @mock.patch("uaclient.util.validate_proxy", side_effect=lambda x, y, z: y)
-@mock.patch("uaclient.entitlements.esm.update_ua_messages")
+@mock.patch("uaclient.entitlements.esm.update_apt_and_motd_messages")
 @mock.patch("uaclient.apt.setup_apt_proxy")
 class TestESMInfraEntitlementEnable:
     @pytest.mark.parametrize(
@@ -188,7 +188,7 @@ class TestESMInfraEntitlementEnable:
     def test_enable_configures_apt_sources_and_auth_files(
         self,
         m_setup_apt_proxy,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         m_validate_proxy,
         esm_cls,
         entitlement_factory,
@@ -302,12 +302,12 @@ class TestESMInfraEntitlementEnable:
         assert unlink_calls == m_unlink.call_args_list
         assert [
             mock.call(entitlement.cfg)
-        ] == update_ua_messages.call_args_list
+        ] == m_update_apt_and_motd_msgs.call_args_list
 
     def test_enable_cleans_up_apt_sources_and_auth_files_on_error(
         self,
         _m_setup_apt_proxy,
-        _update_ua_messages,
+        _m_update_apt_and_motd_msg,
         m_validate_proxy,
         entitlement,
         caplog_text,
@@ -407,13 +407,17 @@ class TestESMInfraEntitlementEnable:
         ] == m_remove_apt_config.call_args_list
 
 
-@mock.patch("uaclient.entitlements.esm.update_ua_messages")
+@mock.patch("uaclient.entitlements.esm.update_apt_and_motd_messages")
 class TestESMEntitlementDisable:
     @pytest.mark.parametrize("silent", [False, True])
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch(M_PATH + "can_disable", return_value=False)
     def test_disable_returns_false_on_can_disable_false_and_does_nothing(
-        self, m_can_disable, m_platform_info, _update_ua_messages, silent
+        self,
+        m_can_disable,
+        m_platform_info,
+        _m_update_apt_and_motd_msgs,
+        silent,
     ):
         """When can_disable is false disable returns false and noops."""
         entitlement = ESMInfraEntitlement({})
@@ -427,7 +431,7 @@ class TestESMEntitlementDisable:
         "uaclient.util.get_platform_info", return_value={"series": "trusty"}
     )
     def test_disable_on_can_disable_true_removes_apt_config(
-        self, _m_platform_info, update_ua_messages, entitlement, tmpdir
+        self, _m_platform_info, m_update_apt_and_motd_msgs, entitlement, tmpdir
     ):
         """When can_disable, disable removes apt configuration"""
 
@@ -439,4 +443,4 @@ class TestESMEntitlementDisable:
         assert [mock.call(silent=True)] == m_remove_apt_config.call_args_list
         assert [
             mock.call(entitlement.cfg)
-        ] == update_ua_messages.call_args_list
+        ] == m_update_apt_and_motd_msgs.call_args_list

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -24,14 +24,14 @@ class TestAttachWithToken:
             ),
         ],
     )
-    @mock.patch(M_PATH + "config.update_ua_messages")
+    @mock.patch("uaclient.jobs.update_messaging.update_apt_and_motd_messages")
     @mock.patch(M_PATH + "config.UAConfig.status")
     @mock.patch(M_PATH + "contract.request_updated_contract")
     def test_attach_with_token(
         self,
         m_request_updated_contract,
         m_status,
-        m_update_ua_messages,
+        m_update_apt_and_motd_msgs,
         request_updated_contract_side_effect,
         expected_error_class,
         expect_status_call,
@@ -48,7 +48,7 @@ class TestAttachWithToken:
             attach_with_token(cfg, "token", False)
         if expect_status_call:
             assert [mock.call()] == m_status.call_args_list
-        assert [mock.call(cfg)] == m_update_ua_messages.call_args_list
+        assert [mock.call(cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
 
 class TestAutoAttach:
@@ -59,12 +59,10 @@ class TestAutoAttach:
         + "contract.UAContractClient.request_auto_attach_contract_token",
         return_value={"contractToken": "token"},
     )
-    @mock.patch(M_PATH + "config.update_ua_messages")
     @mock.patch(M_PATH + "config.UAConfig.write_cache")
     def test_happy_path_on_auto_attach(
         self,
         m_write_cache,
-        m_update_ua_messages,
         m_request_auto_attach_contract_token,
         m_get_instance_id,
         m_attach_with_token,

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -128,12 +128,12 @@ class TestActionAttach:
     @mock.patch("uaclient.util.should_reboot", return_value=False)
     @mock.patch("uaclient.config.UAConfig.remove_notice")
     @mock.patch("uaclient.contract.get_available_resources")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.jobs.update_messaging.update_apt_and_motd_messages")
     @mock.patch(M_PATH + "contract.request_updated_contract")
     def test_status_updated_when_auto_enable_fails(
         self,
         request_updated_contract,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         _m_get_available_resources,
         _m_should_reboot,
         _m_remove_notice,
@@ -166,11 +166,11 @@ class TestActionAttach:
         ), "Did not persist on disk status during attach failure"
         logs = caplog_text()
         assert expected_log in logs
-        assert [mock.call(cfg)] == update_ua_messages.call_args_list
+        assert [mock.call(cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @mock.patch("uaclient.util.should_reboot", return_value=False)
     @mock.patch("uaclient.config.UAConfig.remove_notice")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.jobs.update_messaging.update_apt_and_motd_messages")
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_contract_machine_attach"
     )
@@ -179,7 +179,7 @@ class TestActionAttach:
         self,
         action_status,
         contract_machine_attach,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         _m_should_reboot,
         _m_remove_notice,
         _m_getuid,
@@ -204,16 +204,16 @@ class TestActionAttach:
         assert 1 == action_status.call_count
         expected_calls = [mock.call(contract_token=token)]
         assert expected_calls == contract_machine_attach.call_args_list
-        assert [mock.call(cfg)] == update_ua_messages.call_args_list
+        assert [mock.call(cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @pytest.mark.parametrize("auto_enable", (True, False))
     @mock.patch("uaclient.util.should_reboot", return_value=False)
     @mock.patch("uaclient.config.UAConfig.remove_notice")
     @mock.patch("uaclient.contract.get_available_resources")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.jobs.update_messaging.update_apt_and_motd_messages")
     def test_auto_enable_passed_through_to_request_updated_contract(
         self,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         _m_get_available_resources,
         _m_should_reboot,
         _m_remove_notice,
@@ -234,7 +234,7 @@ class TestActionAttach:
 
         expected_call = mock.call(mock.ANY, mock.ANY, allow_enable=auto_enable)
         assert [expected_call] == m_ruc.call_args_list
-        assert [mock.call(cfg)] == update_ua_messages.call_args_list
+        assert [mock.call(cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
 
 @mock.patch(M_PATH + "contract.get_available_resources")

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -60,10 +60,10 @@ class TestActionDetach:
     )
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.cli.update_apt_and_motd_messages")
     def test_entitlements_disabled_appropriately(
         self,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         m_client,
         m_entitlements,
         m_getuid,
@@ -122,13 +122,17 @@ class TestActionDetach:
             assert 0 == disabled_cls.return_value.disable.call_count
             assert 1 == return_code
         assert [mock.call(assume_yes=assume_yes)] == m_prompt.call_args_list
+        if expect_disable:
+            assert [
+                mock.call(cfg)
+            ] == m_update_apt_and_motd_msgs.call_args_list
 
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.cli.update_apt_and_motd_messages")
     def test_config_cache_deleted(
         self,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         m_client,
         m_entitlements,
         m_getuid,
@@ -148,14 +152,14 @@ class TestActionDetach:
         action_detach(mock.MagicMock(), m_cfg)
 
         assert [mock.call()] == m_cfg.delete_cache.call_args_list
-        assert [mock.call(m_cfg)] == update_ua_messages.call_args_list
+        assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.cli.update_apt_and_motd_messages")
     def test_correct_message_emitted(
         self,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         m_client,
         m_entitlements,
         m_getuid,
@@ -178,14 +182,14 @@ class TestActionDetach:
         out, _err = capsys.readouterr()
 
         assert status.MESSAGE_DETACH_SUCCESS + "\n" == out
-        assert [mock.call(m_cfg)] == update_ua_messages.call_args_list
+        assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.cli.update_apt_and_motd_messages")
     def test_returns_zero(
         self,
-        update_ua_messages,
+        m_update_apt_and_motd_msgs,
         m_client,
         m_entitlements,
         m_getuid,
@@ -205,7 +209,7 @@ class TestActionDetach:
         ret = action_detach(mock.MagicMock(), m_cfg)
 
         assert 0 == ret
-        assert [mock.call(m_cfg)] == update_ua_messages.call_args_list
+        assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @pytest.mark.parametrize(
         "classes,expected_message",
@@ -238,10 +242,10 @@ class TestActionDetach:
     )
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
-    @mock.patch("uaclient.config.update_ua_messages")
+    @mock.patch("uaclient.cli.update_apt_and_motd_messages")
     def test_informational_message_emitted(
         self,
-        m_update_ua_messages,
+        m_update_apt_and_motd_msgs,
         m_client,
         m_entitlements,
         m_getuid,
@@ -267,6 +271,7 @@ class TestActionDetach:
         out, _err = capsys.readouterr()
 
         assert expected_message in out
+        assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
 
 class TestParser:


### PR DESCRIPTION
## Proposed Commit Message
fix update apt and motd messages call

When performing some operations, we want to call the code that update both apt and motd messages. However, the code that does that is importing a module that doesn't exist anymore. We are correctly calling the function that updates those messages directly

## Test Steps
Run the modified unit tests.
Run any integration test that performs an operation that requires updating messages, like disabling esm-infra, and verify that it has occurred

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
