### PR TITLE
enable: show required services message on json

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -798,6 +798,12 @@ Feature: Enable command behaviour when attached to an UA subscription
         ROS ESM Security Updates cannot be enabled with UA Apps: ESM disabled.
         Enable UA Apps: ESM and proceed to enable ROS ESM Security Updates\? \(y\/N\) Cannot enable ROS ESM Security Updates when UA Apps: ESM is disabled.
         """
+        When I verify that running `ua enable ros --beta --format json` `with sudo` and stdin `N` exits `1`
+        Then I will see the following on stdout:
+        """
+        ROS ESM Security Updates cannot be enabled with UA Apps: ESM disabled.
+        Enable UA Apps: ESM and proceed to enable ROS ESM Security Updates? (y/N) {"_schema_version": "0.1", "errors": [{"message": "Cannot enable ROS ESM Security Updates when UA Apps: ESM is disabled.\n", "service": "ros", "type": "service"}], "failed_services": ["ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
 
         When I run `ua enable ros --beta` `with sudo` and stdin `y`
         Then stdout matches regexp

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -63,41 +63,53 @@ Feature: Enable command behaviour when attached to an UA subscription
         And stdout is a json matching the `enable` schema
         And I will see the following on stdout:
             """
+            {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+        Then I verify that running `ua enable foobar --format json` `with sudo` exits `1`
+        And stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+            """
+            {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+        Then I verify that running `ua enable foobar --format json --assume-yes` `as non-root` exits `1`
+        And stdout is a json matching the `enable` schema
+        And I will see the following on stdout:
+            """
             {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
-        And I verify that running `ua enable foobar --format json` `with sudo` exits `1`
+        And I verify that running `ua enable foobar --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `enable` schema
         And I will see the following on stdout:
             """
             {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry <valid_services>", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
-        And I verify that running `ua enable ros foobar --format json` `with sudo` exits `1`
+        And I verify that running `ua enable ros foobar --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `enable` schema
         And I will see the following on stdout:
         """
         {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar, ros'.\nTry <valid_services>", "service": null, "type": "system"}], "failed_services": ["foobar", "ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
         """
-        And I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
+        And I verify that running `ua enable esm-infra --format json --assume-yes` `with sudo` exits `1`
         Then I will see the following on stdout:
             """
             {"_schema_version": "0.1", "errors": [{"message": "UA Infra: ESM is already enabled.\nSee: sudo ua status", "service": "esm-infra", "type": "service"}], "failed_services": ["esm-infra"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
         When I run `ua disable esm-infra` with sudo
-        And I run `ua enable esm-infra --format json` with sudo
+        And I run `ua enable esm-infra --format json --assume-yes` with sudo
         Then stdout is a json matching the `enable` schema
         And I will see the following on stdout:
         """
         {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-infra"], "result": "success", "warnings": []}
         """
         When I run `ua disable esm-infra` with sudo
-        And I verify that running `ua enable esm-infra foobar --format json` `with sudo` exits `1`
+        And I verify that running `ua enable esm-infra foobar --format json --assume-yes` `with sudo` exits `1`
         Then stdout is a json matching the `enable` schema
         And I will see the following on stdout:
         """
         {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry <valid_services>", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": ["esm-infra"], "result": "failure", "warnings": []}
         """
         When I run `ua disable esm-infra esm-apps` with sudo
-        And I run `ua enable esm-infra esm-apps --beta --format json` with sudo
+        And I run `ua enable esm-infra esm-apps --beta --format json --assume-yes` with sudo
         Then stdout is a json matching the `enable` schema
         And I will see the following on stdout:
         """
@@ -745,7 +757,8 @@ Feature: Enable command behaviour when attached to an UA subscription
            | bionic  |
            | xenial  |
 
-    @series.lts
+    @series.xenial
+    @series.bionic
     @uses.config.contract_token
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable ros on a machine
@@ -798,13 +811,6 @@ Feature: Enable command behaviour when attached to an UA subscription
         ROS ESM Security Updates cannot be enabled with UA Apps: ESM disabled.
         Enable UA Apps: ESM and proceed to enable ROS ESM Security Updates\? \(y\/N\) Cannot enable ROS ESM Security Updates when UA Apps: ESM is disabled.
         """
-        When I verify that running `ua enable ros --beta --format json` `with sudo` and stdin `N` exits `1`
-        Then I will see the following on stdout:
-        """
-        ROS ESM Security Updates cannot be enabled with UA Apps: ESM disabled.
-        Enable UA Apps: ESM and proceed to enable ROS ESM Security Updates? (y/N) {"_schema_version": "0.1", "errors": [{"message": "Cannot enable ROS ESM Security Updates when UA Apps: ESM is disabled.\n", "service": "ros", "type": "service"}], "failed_services": ["ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-        """
-
         When I run `ua enable ros --beta` `with sudo` and stdin `y`
         Then stdout matches regexp
         """

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -99,7 +99,7 @@ Feature: FIPS enablement in lxd VMs
             """
             Disabling FIPS requires system reboot to complete operation
             """
-        When I run `ua enable <fips-service> --assume-yes --format json` with sudo
+        When I run `ua enable <fips-service> --assume-yes --format json --assume-yes` with sudo
         Then stdout is a json matching the `enable` schema
         And I will see the following on stdout:
         """
@@ -214,7 +214,7 @@ Feature: FIPS enablement in lxd VMs
             livepatch +yes +enabled
             """
         When I run `ua disable <fips-service> --assume-yes` with sudo
-        And I run `ua enable <fips-service> --assume-yes --format json` with sudo
+        And I run `ua enable <fips-service> --assume-yes --format json --assume-yes` with sudo
         Then stdout is a json matching the `enable` schema
         And I will see the following on stdout:
         """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -550,7 +550,7 @@ Feature: Command behaviour when unattached
           Personal and community subscriptions are available at no charge
           See https://ubuntu.com/advantage
           """
-        When I verify that running `ua enable esm-infra --format json` `with sudo` exits `1`
+        When I verify that running `ua enable esm-infra --format json --assume-yes` `with sudo` exits `1`
         Then stdout is a json matching the `enable` schema
         And I will see the following on stdout:
           """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -167,6 +167,24 @@ def set_event_mode(f):
     return new_f
 
 
+def verify_json_format_args(f):
+    """Decorator to verify if correct params are used for json format"""
+
+    @wraps(f)
+    def new_f(cmd_args, *args, **kwargs):
+        if not cmd_args:
+            return f(cmd_args, *args, **kwargs)
+
+        if cmd_args.format == "json" and not cmd_args.assume_yes:
+            raise exceptions.UserFacingError(
+                ua_status.MESSAGE_JSON_FORMAT_REQUIRE_ASSUME_YES
+            )
+        else:
+            return f(cmd_args, *args, **kwargs)
+
+    return new_f
+
+
 def assert_attached(unattached_msg_tmpl=None):
     """Decorator asserting attached config.
 
@@ -878,6 +896,7 @@ def action_disable(args, *, cfg, **kwargs):
 
 
 @set_event_mode
+@verify_json_format_args
 @assert_root
 @assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 @assert_lock_file("ua enable")

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -58,6 +58,7 @@ class EventLogger:
         self._processed_services = set()
         self._failed_services = set()
         self._needs_reboot = False
+        self._event_logger_mode = EventLoggerMode.CLI
 
     def set_event_mode(self, event_mode: EventLoggerMode):
         """Set the event logger mode.

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -408,6 +408,9 @@ MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME = """\
 This machine is now successfully attached'
 """
 
+MESSAGE_JSON_FORMAT_REQUIRE_ASSUME_YES = """\
+json formatted response requires --assume-yes flag."""
+
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} unknown service '{name}'.
 {service_msg}"""


### PR DESCRIPTION
## Proposed Commit Message
enable: show required services message on json

We are now adding the required services message to the json output
of the enable command

## Test Steps
Run the modified integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
