### PR TITLE
fips: allow enabling FIPS on focal clouds

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -141,18 +141,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
         :return: False when this cloud, series or config override allows FIPS.
         """
-
-        # There is no cloud optimized FIPS kernel for the supported
-        # clouds. Because of that, we are blocking enabling FIPS
-        # on them by default.
-        if series == "focal" and cloud_id in ("azure", "aws"):
-            cfg_path = "features.allow_default_fips_metapackage_on_focal_cloud"
-            if util.is_config_value_true(
-                config=self.cfg.cfg, path_to_value=cfg_path
-            ):
-                return True
-            return False
-
         if cloud_id not in ("azure", "gce"):
             return True
 
@@ -163,8 +151,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             ):
                 return True
 
-            # GCE only has FIPS support for bionic machines
-            if series == "bionic":
+            # GCE only has FIPS support for bionic and focal machines
+            if series in ("bionic", "focal"):
                 return True
 
             return bool("ubuntu-gcp-fips" in super().packages)
@@ -227,7 +215,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             return packages
 
         series = util.get_platform_info().get("series")
-        if series != "bionic":
+        if series not in ("bionic", "focal"):
             return packages
 
         cloud_id, _ = get_cloud_type()

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -699,35 +699,12 @@ class TestFIPSEntitlementEnable:
             [
                 not cfg_allow_default_fips_metapkg_on_gcp,
                 "ubuntu-gcp-fips" not in additional_pkgs,
-                series != "bionic",
+                series not in ("bionic", "focal"),
             ]
         ):
             assert not actual_value
         else:
             assert actual_value
-
-    @pytest.mark.parametrize(
-        "cfg_fips_metapkg_on_focal_cloud", ((True), (False))
-    )
-    @pytest.mark.parametrize("cloud_id", (("azure"), ("aws")))
-    @mock.patch("uaclient.util.is_config_value_true")
-    def test_prevent_enabling_fips_on_focal_cloud(
-        self,
-        m_is_config_value,
-        cloud_id,
-        cfg_fips_metapkg_on_focal_cloud,
-        entitlement,
-    ):
-        series = "focal"
-        m_is_config_value.return_value = cfg_fips_metapkg_on_focal_cloud
-        actual_value = entitlement._allow_fips_on_cloud_instance(
-            series=series, cloud_id=cloud_id
-        )
-
-        if cfg_fips_metapkg_on_focal_cloud:
-            assert actual_value
-        else:
-            assert not actual_value
 
     @pytest.mark.parametrize("caplog_text", [logging.WARNING], indirect=True)
     @mock.patch(
@@ -1120,7 +1097,7 @@ class TestFipsEntitlementPackages:
     @mock.patch(M_PATH + "get_cloud_type")
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.apt.get_installed_packages")
-    def test_packages_are_override_when_bionic_cloud_instance(
+    def test_packages_are_override_on_cloud_instance(
         self,
         m_installed_packages,
         m_platform_info,
@@ -1148,7 +1125,7 @@ class TestFipsEntitlementPackages:
 
         if all(
             [
-                series == "bionic",
+                series in ("bionic", "focal"),
                 cloud_id
                 in (
                     "azure",


### PR DESCRIPTION
## Proposed Commit Message
fips: allow enabling FIPS on focal clouds

The focal clouds now possess fips optimized kernel on the focal release. We are now allowing FIPS to be enabled on those
clouds

## Test Steps
Run the modified integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
