### PR TITLE
jobs: disable jobs after attach/auto-attach

### DIFF
--- a/features/license_check.feature
+++ b/features/license_check.feature
@@ -14,8 +14,6 @@ Feature: License check timer only runs in environments where necessary
         # verify attach disables it
         When I wait `5` seconds
         When I attach `contract_token` with sudo
-        # The job will be automatically disabled after it runs once
-        And I wait `300` seconds
         Then I verify the `ua-license-check` systemd timer is disabled
         # verify detach enables it
         When I run `ua detach --assume-yes` with sudo
@@ -111,8 +109,6 @@ Feature: License check timer only runs in environments where necessary
         log_file: /var/log/ubuntu-advantage.log
         """
         When I run `ua auto-attach` with sudo
-        # The job will be automatically disabled after it runs once
-        And I wait `300` seconds
         Then I verify the `ua-license-check` systemd timer is disabled
         # verify creating marker file enables it, but it disables itself
         When I run `touch /var/lib/ubuntu-advantage/marker-license-check` with sudo

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1076,6 +1076,7 @@ def _post_cli_attach(cfg: config.UAConfig) -> None:
     else:
         event.info(ua_status.MESSAGE_ATTACH_SUCCESS_NO_CONTRACT_NAME)
 
+    jobs.disable_license_check_if_applicable(cfg)
     action_status(args=None, cfg=cfg)
 
 


### PR DESCRIPTION
## Proposed Commit Message
jobs: disable jobs after attach/auto-attach

After a attach/auto-attach opeartion, we are now disabling jobs if necessary, for example, the license check job for GCP


## Test Steps
Run the license check integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
