### PR TITLE
tests: fix tests for jammy

### DIFF
--- a/uaclient/tests/test_cli_collect_logs.py
+++ b/uaclient/tests/test_cli_collect_logs.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 
 import mock
@@ -15,16 +16,16 @@ M_PATH = "uaclient.cli."
 
 HELP_OUTPUT = textwrap.dedent(
     """\
-usage: ua collect-logs [flags]
+usage: ua collect-logs \[flags\]
 
 Collect UA logs and relevant system information into a tarball.
 
-optional arguments:
+(optional arguments|options):
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
-                        tarball where the logs will be stored. (Defaults to
-                        ./ua_logs.tar.gz)
-"""
+                        tarball where the logs will be stored. \(Defaults to
+                        ./ua_logs.tar.gz\)
+"""  # noqa
 )
 
 
@@ -48,7 +49,7 @@ class TestActionCollectLogs:
             ):
                 main()
         out, _err = capsys.readouterr()
-        assert HELP_OUTPUT == out
+        assert re.match(HELP_OUTPUT, out)
 
     @mock.patch(M_PATH + "tarfile.open")
     @mock.patch("builtins.open")

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 
 import mock
@@ -14,17 +15,17 @@ M_PATH = "uaclient.cli."
 
 HELP_OUTPUT = textwrap.dedent(
     """\
-usage: security-status [-h] --format {json,yaml} --beta
+usage: security-status \[-h\] --format {json,yaml} --beta
 
 Show security updates for packages in the system, including all available ESM
 related content.
 
-optional arguments:
+(optional arguments|options):
   -h, --help            show this help message and exit
-  --format {json,yaml}  Format for the output (json or yaml)
+  --format {json,yaml}  Format for the output \(json or yaml\)
   --beta                Acknowledge that this output is not final and may
                         change in the next version
-"""
+"""  # noqa
 )
 
 
@@ -41,7 +42,7 @@ class TestActionSecurityStatus:
                 main()
 
         out, _err = capsys.readouterr()
-        assert HELP_OUTPUT == out
+        assert re.match(HELP_OUTPUT, out)
 
     @pytest.mark.parametrize("output_format", ("json", "yaml"))
     @mock.patch(M_PATH + "yaml.safe_dump")

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -666,7 +666,7 @@ class TestUASecurityClient:
                 client.get_cves(**m_kwargs)
             assert (
                 "get_cves() got an unexpected keyword argument 'invalidparam'"
-            ) == str(exc.value)
+            ) in str(exc.value)
             assert 0 == request_url.call_count
         else:
             for key in SAMPLE_GET_CVES_QUERY_PARAMS:
@@ -716,7 +716,7 @@ class TestUASecurityClient:
             assert (
                 "get_notices() got an unexpected keyword argument"
                 " 'invalidparam'"
-            ) == str(exc.value)
+            ) in str(exc.value)
             assert 0 == request_url.call_count
         else:
             for key in SAMPLE_GET_NOTICES_QUERY_PARAMS:
@@ -790,7 +790,7 @@ class TestUASecurityClient:
                 client.get_cve(**m_kwargs)
             assert (
                 "get_cve() missing 1 required positional argument: 'cve_id'"
-            ) == str(exc.value)
+            ) in str(exc.value)
             assert 0 == request_url.call_count
         else:
             request_url.return_value = ("body", "headers")
@@ -830,7 +830,7 @@ class TestUASecurityClient:
             assert (
                 "get_notice() missing 1 required positional argument:"
                 " 'notice_id'"
-            ) == str(exc.value)
+            ) in str(exc.value)
             assert 0 == request_url.call_count
         else:
             request_url.return_value = ("body", "headers")


### PR DESCRIPTION
## Proposed Commit Message
tests: fix tests for jammy

On jammy, we are using new versions of the libraries and also Python 3.10. That means that some of our tests are making assumptions with old libraries. We have updated the tests to behave properly on jammy

## Test Steps
Build a jammy package without the fix applied and see that it fails
Apply the test fix and run the build again

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
