### PR TITLE
status: blocked_by services

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -493,6 +493,12 @@ def then_stream_matches_regexp(context, stream):
     assert_that(content, matches_regexp(context.text))
 
 
+@then("{stream} contains substring")
+def then_stream_contains_substring(context, stream):
+    content = getattr(context.process, stream).strip()
+    assert_that(content, contains_string(context.text))
+
+
 @then("I will see the following on stderr")
 def then_i_will_see_on_stderr(context):
     assert_that(context.process.stderr.strip(), equal_to(context.text))

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -678,7 +678,7 @@ class UAConfig:
 
     def _attached_service_status(
         self, ent, inapplicable_resources
-    ) -> Dict[str, Optional[str]]:
+    ) -> Dict[str, Any]:
         details = ""
         description_override = None
         contract_status = ent.contract_status()
@@ -691,6 +691,15 @@ class UAConfig:
             else:
                 ent_status, details = ent.user_facing_status()
 
+        blocked_by = [
+            {
+                "name": service.entitlement.name,
+                "reason_code": service.named_msg.name,
+                "reason": service.named_msg.msg,
+            }
+            for service in ent.blocking_incompatible_services()
+        ]
+
         return {
             "name": ent.presentation_name,
             "description": ent.description,
@@ -701,6 +710,7 @@ class UAConfig:
             "available": "yes"
             if ent.name not in inapplicable_resources
             else "no",
+            "blocked_by": blocked_by,
         }
 
     def _attached_status(self) -> Dict[str, Any]:

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -14,6 +14,22 @@ from uaclient.config import UAConfig
 sys.modules["apt"] = mock.MagicMock()
 
 
+@pytest.yield_fixture(scope="session", autouse=True)
+def _subp():
+    """
+    A fixture that mocks util._subp for all tests.
+    If a test needs the actual _subp, this fixture yields it,
+    so just add an argument to the test named "_subp".
+    """
+    from uaclient.util import _subp
+
+    original = _subp
+    with mock.patch(
+        "uaclient.util._subp", return_value=("mockstdout", "mockstderr")
+    ):
+        yield original
+
+
 @pytest.fixture
 def caplog_text(request):
     """

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -7,6 +7,11 @@ from typing import List, Optional, Tuple  # noqa: F401
 from uaclient import apt, event_logger, exceptions, status, util
 from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient.entitlements import repo
+from uaclient.entitlements.base import IncompatibleService
+from uaclient.status import (
+    NAMED_MESSAGE_FIPS_UPDATES_INVALIDATES_FIPS,
+    NAMED_MESSAGE_LIVEPATCH_INVALIDATES_FIPS,
+)
 from uaclient.types import (  # noqa: F401
     MessagingOperations,
     MessagingOperationsDict,
@@ -361,7 +366,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     title = "FIPS"
     description = "NIST-certified core packages"
     origin = "UbuntuFIPS"
-    _incompatible_services = ("livepatch",)  # type: Tuple[str, ...]
 
     fips_pro_package_holds = [
         "fips-initramfs",
@@ -380,6 +384,20 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         "strongswan",
         "strongswan-hmac",
     ]
+
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        from uaclient.entitlements.livepatch import LivepatchEntitlement
+
+        return (
+            IncompatibleService(
+                LivepatchEntitlement, NAMED_MESSAGE_LIVEPATCH_INVALIDATES_FIPS
+            ),
+            IncompatibleService(
+                FIPSUpdatesEntitlement,
+                NAMED_MESSAGE_FIPS_UPDATES_INVALIDATES_FIPS,
+            ),
+        )
 
     @property
     def static_affordances(self) -> Tuple[StaticAffordance, ...]:

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -3,8 +3,11 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from uaclient import apt, event_logger, exceptions, snap, status, util
-from uaclient.entitlements import base
-from uaclient.status import ApplicationStatus
+from uaclient.entitlements.base import IncompatibleService, UAEntitlement
+from uaclient.status import (
+    NAMED_MESSAGE_LIVEPATCH_INVALIDATES_FIPS,
+    ApplicationStatus,
+)
 from uaclient.types import StaticAffordance
 
 LIVEPATCH_RETRIES = [0.5, 1.0]
@@ -91,12 +94,22 @@ def get_config_option_value(key: str) -> Optional[str]:
     return value.strip() if value else None
 
 
-class LivepatchEntitlement(base.UAEntitlement):
+class LivepatchEntitlement(UAEntitlement):
 
     help_doc_url = "https://ubuntu.com/security/livepatch"
     name = "livepatch"
     title = "Livepatch"
     description = "Canonical Livepatch service"
+
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        from uaclient.entitlements.fips import FIPSEntitlement
+
+        return (
+            IncompatibleService(
+                FIPSEntitlement, NAMED_MESSAGE_LIVEPATCH_INVALIDATES_FIPS
+            ),
+        )
 
     @property
     def static_affordances(self) -> Tuple[StaticAffordance, ...]:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -143,6 +143,12 @@ class CanDisableFailure:
         self.message = message
 
 
+class NamedMessage:
+    def __init__(self, name: str, msg: str):
+        self.name = name
+        self.msg = msg
+
+
 ESSENTIAL = "essential"
 STANDARD = "standard"
 ADVANCED = "advanced"
@@ -632,6 +638,20 @@ See {docs_url} for more information on ua proxy configuration.
     docs_url=DOCUMENTATION_URL
 )
 
+NAMED_MESSAGE_FIPS_UPDATES_INVALIDATES_FIPS = NamedMessage(
+    "fips-updates-invalidates-fips",
+    "FIPS cannot be enabled if FIPS Updates has ever been enabled because"
+    " FIPS Updates installs security patches that aren't officially"
+    " certified.",
+)
+NAMED_MESSAGE_LIVEPATCH_INVALIDATES_FIPS = NamedMessage(
+    "livepatch-invalidates-fips",
+    "Livepatch cannot be enabled while running the official FIPS"
+    " certified kernel. If you would like a FIPS compliant kernel"
+    " with additional bug fixes and security updates, you can use"
+    " the FIPS Updates service with Livepatch.",
+)
+
 
 def colorize(string: str) -> str:
     """Return colorized string if using a tty, else original string."""
@@ -786,7 +806,9 @@ def format_json_status(status: Dict[str, Any]) -> str:
     from uaclient.util import DatetimeAwareJSONEncoder
 
     return json.dumps(
-        _format_status_output(status), cls=DatetimeAwareJSONEncoder
+        _format_status_output(status),
+        cls=DatetimeAwareJSONEncoder,
+        sort_keys=True,
     )
 
 

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -139,6 +139,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "yes",
+        "blocked_by": [],
     },
     {
         "description": "UA Infra: Extended Security Maintenance (ESM)",
@@ -148,6 +149,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "yes",
+        "blocked_by": [],
     },
     {
         "description": "NIST-certified core packages",
@@ -157,6 +159,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "no",
+        "blocked_by": [],
     },
     {
         "description": (
@@ -168,6 +171,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "yes",
+        "blocked_by": [],
     },
     {
         "description": "Canonical Livepatch service",
@@ -177,6 +181,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "yes",
+        "blocked_by": [],
     },
     {
         "description": "Security Updates for the Robot Operating System",
@@ -186,6 +191,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "yes",
+        "blocked_by": [],
     },
     {
         "description": "All Updates for the Robot Operating System",
@@ -195,6 +201,7 @@ SERVICES_JSON_ALL = [
         "status": "—",
         "status_details": "",
         "available": "yes",
+        "blocked_by": [],
     },
 ]
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -776,6 +776,7 @@ class TestStatus:
             {"name": "ros", "available": False},
         ]
         expected = copy.deepcopy(DEFAULT_STATUS)
+        expected["version"] = mock.ANY
         expected["services"] = expected_services
         with mock.patch(
             "uaclient.config.UAConfig._get_config_status"
@@ -827,12 +828,17 @@ class TestStatus:
             ),
         ),
     )
+    @mock.patch(
+        M_PATH + "livepatch.LivepatchEntitlement.application_status",
+        return_value=(status.ApplicationStatus.DISABLED, ""),
+    )
     @mock.patch("uaclient.contract.get_available_resources")
     @mock.patch("uaclient.config.os.getuid", return_value=0)
     def test_root_attached(
         self,
         _m_getuid,
         m_get_avail_resources,
+        _m_livepatch_status,
         _m_should_reboot,
         _m_remove_notice,
         avail_res,
@@ -1059,6 +1065,10 @@ class TestStatus:
         M_PATH + "fips.FIPSCommonEntitlement.application_status",
         return_value=(status.ApplicationStatus.DISABLED, ""),
     )
+    @mock.patch(
+        M_PATH + "livepatch.LivepatchEntitlement.application_status",
+        return_value=(status.ApplicationStatus.DISABLED, ""),
+    )
     @mock.patch(M_PATH + "livepatch.LivepatchEntitlement.user_facing_status")
     @mock.patch(M_PATH + "livepatch.LivepatchEntitlement.contract_status")
     @mock.patch(M_PATH + "esm.ESMAppsEntitlement.user_facing_status")
@@ -1073,6 +1083,7 @@ class TestStatus:
         m_esm_uf_status,
         m_livepatch_contract_status,
         m_livepatch_uf_status,
+        _m_livepatch_status,
         _m_fips_status,
         _m_getuid,
         _m_should_reboot,

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -222,9 +222,10 @@ class TestVersionCmpLe:
             ("2.1", "2.0", False),
         ),
     )
-    def test_version_cmp_le(self, ver1, ver2, is_lessorequal):
+    def test_version_cmp_le(self, ver1, ver2, is_lessorequal, _subp):
         """version_cmp_le returns True when ver1 less than or equal to ver2."""
-        assert is_lessorequal is version_cmp_le(ver1, ver2)
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            assert is_lessorequal is version_cmp_le(ver1, ver2)
 
 
 class TestCVE:
@@ -1357,23 +1358,27 @@ A fix is available in Ubuntu standard updates.\n"""
         expected_ret,
         FakeConfig,
         capsys,
+        _subp,
     ):
         """Messaging is based on affected status and installed packages."""
         get_cloud_type.return_value = cloud_type
         m_user_facing_status.return_value = (UserFacingStatus.INACTIVE, "")
         cfg = FakeConfig()
-        with mock.patch("uaclient.util.sys") as m_sys:
-            m_stdout = mock.MagicMock()
-            type(m_sys).stdout = m_stdout
-            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
-            actual_ret = prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
-            assert expected_ret == actual_ret
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                actual_ret = prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
+                assert expected_ret == actual_ret
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1467,6 +1472,7 @@ A fix is available in Ubuntu standard updates.\n"""
         expected,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_for_service.return_value = True
@@ -1479,17 +1485,20 @@ A fix is available in Ubuntu standard updates.\n"""
         m_action_attach.side_effect = fake_attach
 
         cfg = FakeConfig()
-        with mock.patch("uaclient.util.sys") as m_sys:
-            m_stdout = mock.MagicMock()
-            type(m_sys).stdout = m_stdout
-            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1539,21 +1548,25 @@ A fix is available in Ubuntu standard updates.\n"""
         expected,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_upgrade_packages.return_value = False
 
         cfg = FakeConfig()
-        with mock.patch("uaclient.util.sys") as m_sys:
-            m_stdout = mock.MagicMock()
-            type(m_sys).stdout = m_stdout
-            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1620,6 +1633,7 @@ A fix is available in Ubuntu standard updates.\n"""
         should_reboot,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_should_reboot.return_value = should_reboot
         m_get_cloud_type.return_value = ("cloud", None)
@@ -1646,19 +1660,20 @@ A fix is available in Ubuntu standard updates.\n"""
             "uaclient.security.entitlement_factory",
             return_value=m_entitlement_cls,
         ):
-            with mock.patch("uaclient.util.sys") as m_sys:
-                m_stdout = mock.MagicMock()
-                type(m_sys).stdout = m_stdout
-                type(m_stdout).encoding = mock.PropertyMock(
-                    return_value="utf-8"
-                )
-                prompt_for_affected_packages(
-                    cfg=cfg,
-                    issue_id="USN-###",
-                    affected_pkg_status=affected_pkg_status,
-                    installed_packages=installed_packages,
-                    usn_released_pkgs=usn_released_pkgs,
-                )
+            with mock.patch("uaclient.util._subp", side_effect=_subp):
+                with mock.patch("uaclient.util.sys") as m_sys:
+                    m_stdout = mock.MagicMock()
+                    type(m_sys).stdout = m_stdout
+                    type(m_stdout).encoding = mock.PropertyMock(
+                        return_value="utf-8"
+                    )
+                    prompt_for_affected_packages(
+                        cfg=cfg,
+                        issue_id="USN-###",
+                        affected_pkg_status=affected_pkg_status,
+                        installed_packages=installed_packages,
+                        usn_released_pkgs=usn_released_pkgs,
+                    )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1714,6 +1729,7 @@ A fix is available in Ubuntu standard updates.\n"""
         expected,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_expired.return_value = False
@@ -1739,19 +1755,20 @@ A fix is available in Ubuntu standard updates.\n"""
             "uaclient.entitlements.entitlement_factory",
             return_value=m_entitlement_cls,
         ):
-            with mock.patch("uaclient.util.sys") as m_sys:
-                m_stdout = mock.MagicMock()
-                type(m_sys).stdout = m_stdout
-                type(m_stdout).encoding = mock.PropertyMock(
-                    return_value="utf-8"
-                )
-                prompt_for_affected_packages(
-                    cfg=cfg,
-                    issue_id="USN-###",
-                    affected_pkg_status=affected_pkg_status,
-                    installed_packages=installed_packages,
-                    usn_released_pkgs=usn_released_pkgs,
-                )
+            with mock.patch("uaclient.util._subp", side_effect=_subp):
+                with mock.patch("uaclient.util.sys") as m_sys:
+                    m_stdout = mock.MagicMock()
+                    type(m_sys).stdout = m_stdout
+                    type(m_stdout).encoding = mock.PropertyMock(
+                        return_value="utf-8"
+                    )
+                    prompt_for_affected_packages(
+                        cfg=cfg,
+                        issue_id="USN-###",
+                        affected_pkg_status=affected_pkg_status,
+                        installed_packages=installed_packages,
+                        usn_released_pkgs=usn_released_pkgs,
+                    )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1803,6 +1820,7 @@ A fix is available in Ubuntu standard updates.\n"""
         expected,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_expired.return_value = False
@@ -1828,19 +1846,20 @@ A fix is available in Ubuntu standard updates.\n"""
             "uaclient.entitlements.entitlement_factory",
             return_value=m_entitlement_cls,
         ):
-            with mock.patch("uaclient.util.sys") as m_sys:
-                m_stdout = mock.MagicMock()
-                type(m_sys).stdout = m_stdout
-                type(m_stdout).encoding = mock.PropertyMock(
-                    return_value="utf-8"
-                )
-                prompt_for_affected_packages(
-                    cfg=cfg,
-                    issue_id="USN-###",
-                    affected_pkg_status=affected_pkg_status,
-                    installed_packages=installed_packages,
-                    usn_released_pkgs=usn_released_pkgs,
-                )
+            with mock.patch("uaclient.util._subp", side_effect=_subp):
+                with mock.patch("uaclient.util.sys") as m_sys:
+                    m_stdout = mock.MagicMock()
+                    type(m_sys).stdout = m_stdout
+                    type(m_stdout).encoding = mock.PropertyMock(
+                        return_value="utf-8"
+                    )
+                    prompt_for_affected_packages(
+                        cfg=cfg,
+                        issue_id="USN-###",
+                        affected_pkg_status=affected_pkg_status,
+                        installed_packages=installed_packages,
+                        usn_released_pkgs=usn_released_pkgs,
+                    )
         out, err = capsys.readouterr()
         assert expected in out
 
@@ -1902,6 +1921,7 @@ A fix is available in Ubuntu standard updates.\n"""
         expected,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_get_cloud_type.return_value = ("cloud", None)
         m_check_subscription_for_service.return_value = True
@@ -1916,17 +1936,20 @@ A fix is available in Ubuntu standard updates.\n"""
                 }
             }
         )
-        with mock.patch("uaclient.util.sys") as m_sys:
-            m_stdout = mock.MagicMock()
-            type(m_sys).stdout = m_stdout
-            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
 
         out, err = capsys.readouterr()
         assert expected in out
@@ -1971,6 +1994,7 @@ A fix is available in Ubuntu standard updates.\n"""
         expected,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_get_cloud_type.return_value = ("cloud", None)
         m_is_pocket_beta_service.return_value = False
@@ -1984,17 +2008,20 @@ A fix is available in Ubuntu standard updates.\n"""
             }
         )
 
-        with mock.patch("uaclient.util.sys") as m_sys:
-            m_stdout = mock.MagicMock()
-            type(m_sys).stdout = m_stdout
-            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
-            prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_packages,
-                usn_released_pkgs=usn_released_pkgs,
-            )
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_packages,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
 
         out, err = capsys.readouterr()
         assert expected in out
@@ -2043,22 +2070,26 @@ A fix is available in Ubuntu standard updates.\n"""
         exp_ret,
         FakeConfig,
         capsys,
+        _subp,
     ):
         m_get_cloud_type.return_value = ("cloud", None)
 
         cfg = FakeConfig()
-        with mock.patch("uaclient.util.sys") as m_sys:
-            m_stdout = mock.MagicMock()
-            type(m_sys).stdout = m_stdout
-            type(m_stdout).encoding = mock.PropertyMock(return_value="utf-8")
-            actual_ret = prompt_for_affected_packages(
-                cfg=cfg,
-                issue_id="USN-###",
-                affected_pkg_status=affected_pkg_status,
-                installed_packages=installed_pkgs,
-                usn_released_pkgs=usn_released_pkgs,
-            )
-            assert exp_ret == actual_ret
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with mock.patch("uaclient.util.sys") as m_sys:
+                m_stdout = mock.MagicMock()
+                type(m_sys).stdout = m_stdout
+                type(m_stdout).encoding = mock.PropertyMock(
+                    return_value="utf-8"
+                )
+                actual_ret = prompt_for_affected_packages(
+                    cfg=cfg,
+                    issue_id="USN-###",
+                    affected_pkg_status=affected_pkg_status,
+                    installed_packages=installed_pkgs,
+                    usn_released_pkgs=usn_released_pkgs,
+                )
+                assert exp_ret == actual_ret
         out, err = capsys.readouterr()
         assert exp_msg in out
 
@@ -2159,7 +2190,10 @@ class TestFixSecurityIssueId:
     @pytest.mark.parametrize(
         "issue_id", (("CVE-1800-123456"), ("USN-12345-12"))
     )
-    def test_error_msg_when_issue_id_is_not_found(self, issue_id, FakeConfig):
+    @mock.patch("uaclient.security.query_installed_source_pkg_versions")
+    def test_error_msg_when_issue_id_is_not_found(
+        self, _m_query_versions, issue_id, FakeConfig
+    ):
         expected_message = "Error: {} not found.".format(issue_id)
         if "CVE" in issue_id:
             mock_func = "get_cve"
@@ -2342,7 +2376,7 @@ class TestMergeUSNReleasedBinaryPackageVersions:
         ),
     )
     def test_merge_usn_released_binary_package_versions(
-        self, usns_released_packages, expected_pkgs_dict
+        self, usns_released_packages, expected_pkgs_dict, _subp
     ):
         usns = []
         beta_packages = {"esm-infra": False, "esm-apps": True}
@@ -2354,9 +2388,10 @@ class TestMergeUSNReleasedBinaryPackageVersions:
             )
             usns.append(usn)
 
-        usn_pkgs_dict = merge_usn_released_binary_package_versions(
-            usns, beta_packages
-        )
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            usn_pkgs_dict = merge_usn_released_binary_package_versions(
+                usns, beta_packages
+            )
         assert expected_pkgs_dict == usn_pkgs_dict
 
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -280,18 +280,20 @@ class TestIsContainer:
 
 
 class TestSubp:
-    def test_raise_error_on_timeout(self):
+    def test_raise_error_on_timeout(self, _subp):
         """When cmd exceeds the timeout raises a TimeoutExpired error."""
-        with pytest.raises(subprocess.TimeoutExpired) as excinfo:
-            util.subp(["sleep", "2"], timeout=0)
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+                util.subp(["sleep", "2"], timeout=0)
         msg = "Command '[b'sleep', b'2']' timed out after 0 seconds"
         assert msg == str(excinfo.value)
 
     @mock.patch("uaclient.util.time.sleep")
-    def test_default_do_not_retry_on_failure_return_code(self, m_sleep):
+    def test_default_do_not_retry_on_failure_return_code(self, m_sleep, _subp):
         """When no retry_sleeps are specified, do not retry failures."""
-        with pytest.raises(util.ProcessExecutionError) as excinfo:
-            util.subp(["ls", "--bogus"])
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with pytest.raises(util.ProcessExecutionError) as excinfo:
+                util.subp(["ls", "--bogus"])
 
         expected_errors = [
             "Failed running command 'ls --bogus' [exit(2)].",
@@ -302,19 +304,21 @@ class TestSubp:
         assert 0 == m_sleep.call_count  # no retries
 
     @mock.patch("uaclient.util.time.sleep")
-    def test_no_error_on_accepted_return_codes(self, m_sleep):
+    def test_no_error_on_accepted_return_codes(self, m_sleep, _subp):
         """When rcs list includes the exit code, do not raise an error."""
-        out, err = util.subp(["ls", "--bogus"], rcs=[2])
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            out, err = util.subp(["ls", "--bogus"], rcs=[2])
 
         assert "" == out
         assert "ls: unrecognized option '--bogus'" in err
         assert 0 == m_sleep.call_count  # no retries
 
     @mock.patch("uaclient.util.time.sleep")
-    def test_retry_with_specified_sleeps_on_error(self, m_sleep):
+    def test_retry_with_specified_sleeps_on_error(self, m_sleep, _subp):
         """When retry_sleeps given, use defined sleeps between each retry."""
-        with pytest.raises(util.ProcessExecutionError) as excinfo:
-            util.subp(["ls", "--bogus"], retry_sleeps=[1, 3, 0.4])
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with pytest.raises(util.ProcessExecutionError) as excinfo:
+                util.subp(["ls", "--bogus"], retry_sleeps=[1, 3, 0.4])
 
         expected_error = "Failed running command 'ls --bogus' [exit(2)]"
         assert expected_error in str(excinfo.value)
@@ -322,12 +326,13 @@ class TestSubp:
         assert expected_sleeps == m_sleep.call_args_list
 
     @mock.patch("uaclient.util.time.sleep")
-    def test_retry_doesnt_consume_retry_sleeps(self, m_sleep):
+    def test_retry_doesnt_consume_retry_sleeps(self, m_sleep, _subp):
         """When retry_sleeps given, use defined sleeps between each retry."""
         sleeps = [1, 3, 0.4]
         expected_sleeps = sleeps.copy()
-        with pytest.raises(util.ProcessExecutionError):
-            util.subp(["ls", "--bogus"], retry_sleeps=sleeps)
+        with mock.patch("uaclient.util._subp", side_effect=_subp):
+            with pytest.raises(util.ProcessExecutionError):
+                util.subp(["ls", "--bogus"], retry_sleeps=sleeps)
 
         assert expected_sleeps == sleeps
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
status: include blocked_by for each service

blocked_by is a per-service field. If populated for a given service, the
value is an array of other services that are currently enabled and
incompatible with the given service. Disabling all of the services in
"blocked_by" will allow you to enable the blocked service.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run `ua status --format=json` on a vm with combinations of fips, fips-updates, and livepatch enabled and make sure the "blocked_by" values are appropriate.

Also maybe run the updated fips integration tests (they are marked `@slow`)
## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
