### PR TITLE
attach: allow json response format (SC-769)

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -15,6 +15,12 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              """
              This command must be run as root (try using sudo).
              """
+        When I verify that running `ua attach invalid-token --format json` `with sudo` exits `1`
+        Then I will see the following on stdout:
+            """
+            {"_schema_version": "0.1", "errors": [{"message": "Invalid token. See https://ubuntu.com/advantage", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+
         Examples: ubuntu release
            | release |
            | xenial  |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -548,6 +548,16 @@ def then_i_verify_that_running_cmd_with_spec_exits_with_codes(
 
 
 @when(
+    "I verify that running attach `{spec}` with json response exits `{exit_codes}`"  # noqa
+)
+def when_i_verify_attach_with_json_response(context, spec, exit_codes):
+    cmd = "ua attach {} --format json".format(context.config.contract_token)
+    then_i_verify_that_running_cmd_with_spec_exits_with_codes(
+        context=context, cmd_name=cmd, spec=spec, exit_codes=exit_codes
+    )
+
+
+@when(
     "I verify that running `{cmd_name}` `{spec}` and stdin `{stdin}` exits `{exit_codes}`"  # noqa
 )
 def then_i_verify_that_running_cmd_with_spec_and_stdin_exits_with_codes(

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -178,7 +178,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         And I run `ua auto-attach` with sudo
         And I run `ua status --wait` as non-root
-        And I run `ua status` as non-root
         Then stdout matches regexp:
             """
             SERVICE       ENTITLED  STATUS    DESCRIPTION

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -546,7 +546,7 @@ Feature: Command behaviour when unattached
           """
           {"_schema_version": "0.1", "errors": [{"message": "To use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
           """
-        
+
         Examples: ubuntu release
           | release |
           | xenial  |

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -560,10 +560,7 @@ class UAConfig:
 
     def _handle_beta_resources(self, show_beta, response) -> Dict[str, Any]:
         """Remove beta services from response dict if needed"""
-        from uaclient.entitlements import (
-            EntitlementNotFoundError,
-            entitlement_factory,
-        )
+        from uaclient.entitlements import entitlement_factory
 
         config_allow_beta = util.is_config_value_true(
             config=self.cfg, path_to_value="features.allow_beta"
@@ -579,7 +576,7 @@ class UAConfig:
             resource_name = resource["name"]
             try:
                 ent_cls = entitlement_factory(resource_name)
-            except EntitlementNotFoundError:
+            except exceptions.EntitlementNotFoundError:
                 """
                 Here we cannot know the status of a service,
                 since it is not listed as a valid entitlement.
@@ -641,10 +638,7 @@ class UAConfig:
     def _unattached_status(self) -> Dict[str, Any]:
         """Return unattached status as a dict."""
         from uaclient.contract import get_available_resources
-        from uaclient.entitlements import (
-            EntitlementNotFoundError,
-            entitlement_factory,
-        )
+        from uaclient.entitlements import entitlement_factory
 
         response = copy.deepcopy(DEFAULT_STATUS)
         response["version"] = version.get_version(features=self.features)
@@ -657,7 +651,7 @@ class UAConfig:
                 available = status.UserFacingAvailability.UNAVAILABLE.value
             try:
                 ent_cls = entitlement_factory(resource.get("name", ""))
-            except EntitlementNotFoundError:
+            except exceptions.EntitlementNotFoundError:
                 LOG.debug(
                     "Ignoring availability of unknown service %s"
                     " from contract server",
@@ -716,10 +710,7 @@ class UAConfig:
     def _attached_status(self) -> Dict[str, Any]:
         """Return configuration of attached status as a dictionary."""
         from uaclient.contract import get_available_resources
-        from uaclient.entitlements import (
-            EntitlementNotFoundError,
-            entitlement_factory,
-        )
+        from uaclient.entitlements import entitlement_factory
 
         response = copy.deepcopy(DEFAULT_STATUS)
         machineTokenInfo = self.machine_token["machineTokenInfo"]
@@ -767,7 +758,7 @@ class UAConfig:
         for resource in resources:
             try:
                 ent_cls = entitlement_factory(resource.get("name", ""))
-            except EntitlementNotFoundError:
+            except exceptions.EntitlementNotFoundError:
                 continue
             ent = ent_cls(self)
             response["services"].append(
@@ -807,10 +798,7 @@ class UAConfig:
             get_available_resources,
             get_contract_information,
         )
-        from uaclient.entitlements import (
-            EntitlementNotFoundError,
-            entitlement_factory,
-        )
+        from uaclient.entitlements import entitlement_factory
 
         response = copy.deepcopy(DEFAULT_STATUS)
 
@@ -863,7 +851,7 @@ class UAConfig:
             entitlement_name = resource.get("name", "")
             try:
                 ent_cls = entitlement_factory(entitlement_name)
-            except EntitlementNotFoundError:
+            except exceptions.EntitlementNotFoundError:
                 continue
             ent = ent_cls(self)
             entitlement_information = self._get_entitlement_information(
@@ -937,10 +925,7 @@ class UAConfig:
         :raises: UserFacingError when no help is available.
         """
         from uaclient.contract import get_available_resources
-        from uaclient.entitlements import (
-            EntitlementNotFoundError,
-            entitlement_factory,
-        )
+        from uaclient.entitlements import entitlement_factory
 
         resources = get_available_resources(self)
         help_resource = None
@@ -955,7 +940,7 @@ class UAConfig:
             if resource["name"] == name or resource.get("presentedAs") == name:
                 try:
                     help_ent_cls = entitlement_factory(resource["name"])
-                except EntitlementNotFoundError:
+                except exceptions.EntitlementNotFoundError:
                     continue
                 help_resource = resource
                 help_ent = help_ent_cls(self)

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -8,6 +8,7 @@ from uaclient.entitlements.cis import CISEntitlement
 from uaclient.entitlements.esm import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.livepatch import LivepatchEntitlement
 from uaclient.entitlements.ros import ROSEntitlement, ROSUpdatesEntitlement
+from uaclient.exceptions import EntitlementNotFoundError
 from uaclient.util import is_config_value_true
 
 ENTITLEMENT_CLASSES = [
@@ -21,10 +22,6 @@ ENTITLEMENT_CLASSES = [
     ROSEntitlement,
     ROSUpdatesEntitlement,
 ]  # type: List[Type[UAEntitlement]]
-
-
-class EntitlementNotFoundError(Exception):
-    pass
 
 
 def entitlement_factory(name: str):

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -321,7 +321,7 @@ class LivepatchEntitlement(UAEntitlement):
 
         application_status, _ = self.application_status()
         if application_status == status.ApplicationStatus.DISABLED:
-            return True  # only operate on changed directives when ACTIVE
+            return False  # only operate on changed directives when ACTIVE
         delta_directives = delta_entitlement.get("directives", {})
         supported_deltas = set(["caCerts", "remoteServer"])
         process_directives = bool(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -173,7 +173,7 @@ class RepoEntitlement(base.UAEntitlement):
             application_status, _ = self.application_status()
 
         if application_status == status.ApplicationStatus.DISABLED:
-            return True
+            return False
 
         if not self._check_apt_url_is_applied(delta_apt_url):
             logging.info(

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -2,7 +2,7 @@
 import mock
 import pytest
 
-from uaclient import entitlements
+from uaclient import entitlements, exceptions
 
 
 class TestValidServices:
@@ -56,5 +56,5 @@ class TestEntitlementFactory:
         with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
             assert m_cls_1 == entitlements.entitlement_factory("othername")
             assert m_cls_2 == entitlements.entitlement_factory("ent2")
-        with pytest.raises(entitlements.EntitlementNotFoundError):
+        with pytest.raises(exceptions.EntitlementNotFoundError):
             entitlements.entitlement_factory("nonexistent")

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -484,14 +484,14 @@ class TestLivepatchProcessContractDeltas:
     @mock.patch(M_PATH + "LivepatchEntitlement.setup_livepatch_config")
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.applicability_status")
-    def test_true_on_inactive_livepatch_service(
+    def test_false_on_inactive_livepatch_service(
         self,
         m_applicability_status,
         m_application_status,
         m_setup_livepatch_config,
         entitlement,
     ):
-        """When livepatch is INACTIVE return True and do no setup."""
+        """When livepatch is INACTIVE return False and do no setup."""
         m_applicability_status.return_value = (
             status.ApplicabilityStatus.APPLICABLE,
             "",
@@ -501,7 +501,7 @@ class TestLivepatchProcessContractDeltas:
             "",
         )
         deltas = {"entitlement": {"directives": {"caCerts": "new"}}}
-        assert entitlement.process_contract_deltas({}, deltas, False)
+        assert not entitlement.process_contract_deltas({}, deltas, False)
         assert [] == m_setup_livepatch_config.call_args_list
 
     @pytest.mark.parametrize(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -145,7 +145,7 @@ class TestProcessContractDeltas:
             status.ApplicabilityStatus.APPLICABLE,
             "",
         )
-        assert entitlement.process_contract_deltas(
+        assert not entitlement.process_contract_deltas(
             {"entitlement": {"entitled": True}},
             {
                 "entitlement": {"obligations": {"enableByDefault": False}},
@@ -192,7 +192,7 @@ class TestProcessContractDeltas:
         m_application_status,
         m_enable,
         entitlement,
-        caplog_text,
+        capsys,
     ):
         """Log a message when inactive, enableByDefault and allow_enable."""
         m_application_status.return_value = (
@@ -215,7 +215,7 @@ class TestProcessContractDeltas:
         expected_msg = status.MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL.format(
             name="repotest"
         )
-        assert expected_msg in caplog_text()
+        assert expected_msg in capsys.readouterr()[1]
 
     @pytest.mark.parametrize("packages", ([], ["extremetuxracer"]))
     @mock.patch.object(RepoTestEntitlement, "install_packages")

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -131,3 +131,7 @@ class CloudFactoryUnsupportedCloudError(CloudFactoryError):
 
 class CloudFactoryNonViableCloudError(CloudFactoryError):
     pass
+
+
+class EntitlementNotFoundError(Exception):
+    pass

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -16,7 +16,7 @@ from uaclient.clouds.identity import (
 )
 from uaclient.config import UAConfig
 from uaclient.defaults import BASE_UA_URL, PRINT_WRAP_WIDTH
-from uaclient.entitlements import EntitlementNotFoundError, entitlement_factory
+from uaclient.entitlements import entitlement_factory
 
 CVE_OR_USN_REGEX = (
     r"((CVE|cve)-\d{4}-\d{4,7}$|(USN|usn|LSN|lsn)-\d{1,5}-\d{1,2}$)"
@@ -766,7 +766,7 @@ def _get_service_for_pocket(pocket: str, cfg: UAConfig):
     try:
         ent_cls = entitlement_factory(service_to_check)
         return ent_cls(cfg)
-    except EntitlementNotFoundError:
+    except exceptions.EntitlementNotFoundError:
         return None
 
 
@@ -1031,7 +1031,7 @@ def _run_ua_attach(cfg: UAConfig, token: str) -> bool:
         0
         == cli.action_attach(
             argparse.Namespace(
-                token=token, auto_enable=True, attach_config=None
+                token=token, auto_enable=True, attach_config=None, format="cli"
             ),
             cfg,
         )


### PR DESCRIPTION
## Proposed Commit Message
attach: allow json response format

This will allow users to have a json response when running `ua attach`

## Test Steps
Run the new integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
