### PR TITLE
proxy: delete default route on container tests

### DIFF
--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -24,11 +24,22 @@ Feature: Proxy configuration
           https_proxy: http://<ci-proxy-ip>:3128
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        # We need this for the route command
+        And I run `apt-get install net-tools` with sudo
+        # We will guarantee that the machine will only use the proxy when
+        # running the ua commands
+        And I run `route del default` with sudo
         And I attach `contract_token` with sudo
         And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
         Then stdout matches regexp:
         """
         .*CONNECT contracts.canonical.com.*
+        """
+        When I run `ua status` with sudo
+        # Just to verify that the machine is attached
+        Then stdout matches regexp:
+        """
+        esm-infra     +yes      +enabled      +UA Infra: Extended Security Maintenance \(ESM\)
         """
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:


### PR DESCRIPTION
## Proposed Commit Message
proxy: delete default route on container tests

On the container tests, we are now deleting the default route to guarantee that the ua request are actually going through the proxy

## Test Steps
Run the modified proxy test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
