### PR TITLE
[doc] Fix link to ua-client-daily PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ the project, you should install them via `dev-requirements.txt`.)
 ## Daily Builds
 
 On Launchpad, there is a [daily build recipe](https://code.launchpad.net/~canonical-server/+recipe/ua-client-daily),
-which will build the client and place it in the [ua-client-daily PPA](https://code.launchpad.net/~canonical-server/+archive/ubuntu/ua-client-daily).
+which will build the client and place it in the [ua-client-daily PPA](https://code.launchpad.net/~ua-client/+archive/ubuntu/daily).
 
 ## Remastering custom golden images based on Ubuntu PRO
 


### PR DESCRIPTION
Current link leads to deprecated site (_"This PPA is retired as of 03/23/2021."_). Change the link to the one already used in line 276.

## Proposed Commit Message
[doc] Fix link to ua-client-daily PPA

