### PR TITLE
contract: send activity info during machine token update operations

### DIFF
--- a/uaclient/jobs/metering.py
+++ b/uaclient/jobs/metering.py
@@ -5,8 +5,6 @@ Functions to be used when running metering jobs
 from uaclient import config
 from uaclient.cli import assert_lock_file
 from uaclient.contract import UAContractClient
-from uaclient.entitlements import ENTITLEMENT_CLASSES
-from uaclient.status import UserFacingStatus
 
 
 @assert_lock_file("timer metering job")
@@ -18,12 +16,7 @@ def metering_enabled_resources(cfg: config.UAConfig) -> bool:
     if not cfg.is_attached:
         return False
 
-    enabled_services = [
-        ent(cfg).name
-        for ent in ENTITLEMENT_CLASSES
-        if ent(cfg).user_facing_status()[0] == UserFacingStatus.ACTIVE
-    ]
-
     contract = UAContractClient(cfg)
-    contract.report_machine_activity(enabled_services=enabled_services)
+    contract.report_machine_activity()
+
     return True


### PR DESCRIPTION
## Proposed Commit Message
contract: send activity info during machine token update operations

Updates the machine_token_update request to also include activity information if available, in a similar fashion to how the report_machine_activity request is behaving.

## Test Steps
Updated and ran unit tests.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
