### PR TITLE
fix: dont raise issue if usn has no related cves (SC-162)

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -354,6 +354,28 @@ Feature: Command behaviour when unattached
             2 packages are still affected: matanza, swish-e
             .*✘.* CVE-2017-9233 is not resolved.
             """
+        When I fix `USN-5079-2` by attaching to a subscription with `contract_token_staging_expired`
+        Then stdout matches regexp
+            """
+            USN-5079-2: curl vulnerabilities
+            Found CVEs:
+            https://ubuntu.com/security/CVE-2021-22946
+            https://ubuntu.com/security/CVE-2021-22947
+            1 affected source package is installed: curl
+            \(1/1\) curl:
+            A fix is available in UA Infra.
+            The update is not installed because this system is not attached to a
+            subscription.
+
+            Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
+            > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
+            > .*\{ ua attach .*\}.*
+            Attach denied:
+            Contract ".*" expired on .*
+            Visit https://ubuntu.com/advantage to manage contract tokens.
+            1 package is still affected: curl
+            .*✘.* USN-5079-2 is not resolved.
+            """
         When I fix `USN-5079-2` by attaching to a subscription with `contract_token`
         Then stdout matches regexp:
             """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -484,6 +484,20 @@ Feature: Command behaviour when unattached
         The update is already installed.
         .*✔.* CVE-2021-27135 is resolved.
         """
+        When I run `apt-get install libbz2-1.0=1.0.6-8.1 -y --allow-downgrades` with sudo
+        And I run `apt-get install bzip2=1.0.6-8.1 -y` with sudo
+        And I run `ua fix USN-4038-3` with sudo
+        Then stdout matches regexp:
+        """
+        USN-4038-3: bzip2 regression
+        Found Launchpad bugs:
+        https://launchpad.net/bugs/1834494
+        1 affected source package is installed: bzip2
+        \(1/1\) bzip2:
+        A fix is available in Ubuntu standard updates.
+        .*\{ apt update && apt install --only-upgrade -y bzip2 libbz2-1.0 \}.*
+        .*✔.* USN-4038-3 is resolved.
+        """
 
 
     @series.all


### PR DESCRIPTION
## Proposed Commit Message
fix: dont raise issue if usn has no related cves

Some USNs do not have related CVEs. If that happens, we should rely entirely on the USN release packages to fix the underlying system. We are now adapting the code to identify that scenario and act accordingly

## Test Steps
Run the modified bionic integration test and confirm that the provided USN does not have any CVEs associated with it

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
