### PR TITLE
Fix tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ifneq (,$(findstring trusty,$(TOXENV)))
 endif
 	pip install tox
 	pip install tox-pip-version
+	pip install tox-setuptools-version
 
 travis-deb-install:
 	git fetch --unshallow

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
-envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic}, mypy, black, isort
-
-[testenv:flake8-trusty]
-pip_version = 9.0.2
+envlist = py3, flake8, py3-{xenial,bionic}, flake8-{xenial,bionic}, mypy, black, isort
 
 [testenv:flake8-bionic]
 pip_version = 9.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,19 @@ pip_version = 9.0.2
 
 [testenv:flake8-bionic]
 pip_version = 9.0.2
+setuptools_version = 59.8.0
 
 [testenv:flake8-xenial]
 pip_version = 9.0.2
+setuptools_version = 59.8.0
 
 [testenv:py3-xenial]
 pip_version = 9.0.2
+setuptools_version = 59.8.0
 
 [testenv:py3-bionic]
 pip_version = 9.0.2
+setuptools_version = 59.8.0
 
 [testenv]
 deps =


### PR DESCRIPTION
## Proposed Commit Message
tox: set version of setuptools for some tests

For some older ubuntu releases, we need to set up an older version of pip. That's because the constraints we have for the older releases could not be successfully used with new versions of pip. This pip restriction is now affecting new versions of setuptools as well. Because of that, we are now setting up the versions of setuptools for those older ubuntu version tests

## Test Steps
Delete one of the modified environment and run tox for it again. See that it fails, then apply this fix and run tox again recreating the scenario

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
