### PR TITLE
make only new logs world readable

### DIFF
--- a/debian/ubuntu-advantage-tools.logrotate
+++ b/debian/ubuntu-advantage-tools.logrotate
@@ -2,6 +2,7 @@
 # of /var/log/ubuntu-advantage*.log files.
 /var/log/ubuntu-advantage*.log {
     su root root
+    create 0644 root root
     rotate 6
     monthly
     compress

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -422,16 +422,10 @@ case "$1" in
       # log files need to be world-readable
       if [ ! -f /var/log/ubuntu-advantage.log ]; then
           touch /var/log/ubuntu-advantage.log
+          # We are only making new log files world readable
+          chmod 0644 /var/log/ubuntu-advantage.log
       fi
-      chmod 0644 /var/log/ubuntu-advantage.log
       chown root:root /var/log/ubuntu-advantage.log
-
-      for log_file_suffix in timer license-check daemon
-      do
-        if [ -f /var/log/ubuntu-advantage-$log_file_suffix.log ]; then
-            chmod 0644 /var/log/ubuntu-advantage-$log_file_suffix.log
-        fi
-      done
 
       private_dir="/var/lib/ubuntu-advantage/private"
       if [ -d "$private_dir" ]; then

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -38,7 +38,9 @@ Feature: Command behaviour when attached to an UA subscription
         And I run `sh -c "ls /var/log/ubuntu-advantage* | sort -d"` as non-root
         Then stdout matches regexp:
         """
+        /var/log/ubuntu-advantage.log
         /var/log/ubuntu-advantage.log.1
+        /var/log/ubuntu-advantage-timer.log
         /var/log/ubuntu-advantage-timer.log.1
         """
 

--- a/sru/release-27.7/test_world_readable_logs.sh
+++ b/sru/release-27.7/test_world_readable_logs.sh
@@ -1,0 +1,66 @@
+series=$1
+deb=$2
+
+set -eE
+
+GREEN="\e[32m"
+RED="\e[31m"
+BLUE="\e[36m"
+END_COLOR="\e[0m"
+
+function cleanup {
+  lxc delete test --force
+}
+
+function on_err {
+  echo -e "${RED}Test Failed${END_COLOR}"
+  cleanup
+  exit 1
+}
+
+trap on_err ERR
+
+function print_and_run_cmd {
+  echo -e "${BLUE}Running:${END_COLOR}" "$@"
+  echo -e "${BLUE}Output:${END_COLOR}"
+  lxc exec test -- sh -c "$@"
+  echo
+}
+
+function explanatory_message {
+  echo -e "${BLUE}$@${END_COLOR}"
+}
+
+explanatory_message "Starting $series container and updating ubuntu-advantage-tools"
+lxc launch ubuntu-daily:$series test >/dev/null 2>&1
+sleep 10
+
+explanatory_message "Check that log is not world readable"
+print_and_run_cmd "ua version"
+print_and_run_cmd "head /var/log/ubuntu-advantage.log"
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log -perm 0600 | grep -qz ."
+
+lxc exec test -- apt-get update >/dev/null
+explanatory_message "installing new version of ubuntu-advantage-tools from local copy"
+lxc file push $deb test/tmp/ua.deb > /dev/null
+print_and_run_cmd "dpkg -i /tmp/ua.deb"
+print_and_run_cmd "ua version"
+
+explanatory_message "Check that log files permissions are still the same"
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log -perm 0600 | grep -qz ."
+
+explanatory_message "Check that logrotate command will create world readable files"
+print_and_run_cmd "logrotate --force /etc/logrotate.d/ubuntu-advantage-tools"
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log -perm 0644 | grep -qz ."
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log.1 -perm 0600 | grep -qz ."
+
+explanatory_message "Check that running logrotate again will stil make world readable files"
+# Just to add new entry to the log
+print_and_run_cmd "ua version"
+print_and_run_cmd "logrotate --force /etc/logrotate.d/ubuntu-advantage-tools"
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log -perm 0644 | grep -qz ."
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log.1 -perm 0644 | grep -qz ."
+print_and_run_cmd "find /var/log/ -name ubuntu-advantage.log.2.gz -perm 0600 | grep -qz ."
+
+echo -e "${GREEN}Test Passed${END_COLOR}"
+cleanup

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1635,8 +1635,10 @@ def setup_logging(console_level, log_level, log_file=None, logger=None):
     if os.getuid() == 0:
         # Setup readable-by-root-only debug file logging if running as root
         log_file_path = pathlib.Path(log_file)
-        log_file_path.touch()
-        log_file_path.chmod(0o644)
+
+        if not log_file_path.exists():
+            log_file_path.touch()
+            log_file_path.chmod(0o644)
 
         file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(log_level)

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -833,15 +833,17 @@ class TestSetupLogging:
     ):
         log_file = tmpdir.join("root-only.log")
         log_path = log_file.strpath
+        expected_mode = 0o644
         if pre_existing:
+            expected_mode = 0o640
             log_file.write("existing content\n")
-            os.chmod(log_path, 0o640)
+            os.chmod(log_path, expected_mode)
             assert 0o644 != stat.S_IMODE(os.lstat(log_path).st_mode)
 
         setup_logging(logging.INFO, logging.INFO, log_file=log_path)
         logging.info("after setup")
 
-        assert 0o644 == stat.S_IMODE(os.lstat(log_path).st_mode)
+        assert expected_mode == stat.S_IMODE(os.lstat(log_path).st_mode)
         log_content = log_file.read()
         assert "after setup" in log_content
         if pre_existing:


### PR DESCRIPTION
## Proposed Commit Message
make only new logs world readable

We are now modifying our logs to be world readable only when we are creating new log file, either through logrotate
or when ua set up logs. This means that old logs will not be modified

## Test Steps
Run the manual test script in this PR.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
