### PR TITLE
tests: fix apt proxy test

### DIFF
--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -29,7 +29,7 @@ Feature: Proxy configuration
         # We will guarantee that the machine will only use the proxy when
         # running the ua commands
         And I run `route del default` with sudo
-        And I attach `contract_token` with sudo
+        And I attach `contract_token` with sudo and options `--no-auto-enable`
         And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
         Then stdout matches regexp:
         """
@@ -39,7 +39,7 @@ Feature: Proxy configuration
         # Just to verify that the machine is attached
         Then stdout matches regexp:
         """
-        esm-infra     +yes      +enabled      +UA Infra: Extended Security Maintenance \(ESM\)
+        esm-infra     +yes      +disabled      +UA Infra: Extended Security Maintenance \(ESM\)
         """
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -193,7 +193,7 @@ def when_i_run_command_on_machine(context, command, user_spec, instance_name):
 
 @when("I verify `{file_name}` is empty on `{instance_name}` machine")
 def when_i_verify_file_is_empty_on_machine(context, file_name, instance_name):
-    command = 'sh -c "cat {} | wc -l"'
+    command = 'sh -c "cat {} | wc -l"'.format(file_name)
     when_i_run_command(
         context, command, user_spec="with sudo", instance_name=instance_name
     )
@@ -282,6 +282,9 @@ def when_i_run_command(
         logging.error("Error executing command: {}".format(command))
         logging.error("stdout: {}".format(result.stdout))
         logging.error("stderr: {}".format(result.stderr))
+    else:
+        logging.debug("stdout: {}".format(result.stdout))
+        logging.debug("stderr: {}".format(result.stderr))
 
     if verify_return:
         assert_that(process.returncode, equal_to(0))
@@ -372,9 +375,18 @@ def change_contract_endpoint_to_production(context, user_spec):
     )
 
 
+@when("I attach `{token_type}` {user_spec} and options `{options}`")
+def when_i_attach_staging_token_with_options(
+    context, token_type, user_spec, options
+):
+    when_i_attach_staging_token(
+        context, token_type, user_spec, options=options
+    )
+
+
 @when("I attach `{token_type}` {user_spec}")
 def when_i_attach_staging_token(
-    context, token_type, user_spec, verify_return=True
+    context, token_type, user_spec, verify_return=True, options=""
 ):
     token = getattr(context.config, token_type)
     if (
@@ -382,7 +394,7 @@ def when_i_attach_staging_token(
         or token_type == "contract_token_staging_expired"
     ):
         change_contract_endpoint_to_staging(context, user_spec)
-    cmd = "ua attach {}".format(token)
+    cmd = "ua attach {} {}".format(token, options).strip()
     when_i_run_command(context, cmd, user_spec, verify_return=False)
 
     if verify_return:


### PR DESCRIPTION
## Why
Currently the first proxy test where we delete the default route is failing for bionic and focal. That is because it is trying to enable esm before the apt proxy is set up.

This commit fixes that by using `--no-auto-enable` during the attach step.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
tests: fix apt proxy test
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run `env UACLIENT_BEHAVE_BUILD_PR=1 tox -e behave-lxd-20.04 -- features/proxy_config.feature` for each series

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
