### PR TITLE
detach: remove contract detach call

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -52,47 +52,6 @@ Feature: Command behaviour when attached to an UA subscription
            | impish  |
            | jammy   |
 
-    @series.all
-    @uses.config.machine_type.lxd.container
-    Scenario Outline: Attached and detach correctly reach contract endpoint
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `ua detach --assume-yes` with sudo
-        Then I verify that running `grep "Found new machine-id. Do not call detach on contract backend" /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | impish  |
-           | jammy   |
-
-    @series.all
-    @uses.config.machine_type.lxd.container
-    Scenario Outline: Attached and detach don't reach contract endpoint if machine-id changes
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I update contract to use `machineId` as `new-machine-id`
-        And I run `ua detach --assume-yes` with sudo
-        Then stdout matches regexp:
-            """
-            This machine is now detached.
-            """
-        And I verify that running `grep "Found new machine-id. Do not call detach on contract backend" /var/log/ubuntu-advantage.log` `with sudo` exits `0`
-        When I run `ua status` with sudo
-        Then stdout matches regexp:
-          """
-          This machine is not attached to a UA subscription.
-          """
-
-        Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | impish  |
-           | jammy   |
 
     @series.all
     @uses.config.machine_type.lxd.container

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1131,10 +1131,6 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     for ent in to_disable:
         _perform_disable(ent, cfg, assume_yes=assume_yes, update_status=False)
 
-    contract_client = contract.UAContractClient(cfg)
-    machine_token = cfg.machine_token["machineToken"]
-    contract_id = cfg.machine_token["machineTokenInfo"]["contractInfo"]["id"]
-    contract_client.detach_machine_from_contract(machine_token, contract_id)
     cfg.delete_cache()
     jobs.enable_license_check_if_applicable(cfg)
     update_apt_and_motd_messages(cfg)

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -216,28 +216,6 @@ class UAContractClient(serviceclient.UAServiceClient):
             machine_token["activityInfo"] = response
             self.cfg.write_cache("machine-token", machine_token)
 
-    def detach_machine_from_contract(
-        self, machine_token: str, contract_id: str, machine_id: str = None
-    ) -> Dict:
-        """Report the attached machine should be detached from the contract."""
-        curr_machine_id = self._get_platform_data(machine_id=None).get(
-            "machineId", ""
-        )
-        past_machine_id = self.cfg.read_cache("machine-id")
-
-        if str(curr_machine_id) != str(past_machine_id):
-            logging.debug(
-                "Found new machine-id. Do not call detach on contract backend"
-            )
-            return {}
-
-        return self._request_machine_token_update(
-            machine_token=machine_token,
-            contract_id=contract_id,
-            machine_id=machine_id,
-            detach=True,
-        )
-
     def _request_machine_token_update(
         self,
         machine_token: str,

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import logging
 import socket
 
 import mock
@@ -759,43 +758,3 @@ class TestRequestUpdatedContract:
             ),
         ]
         assert process_calls == process_entitlement_delta.call_args_list
-
-
-class TestDetachMachineFromContract:
-    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
-    @pytest.mark.parametrize(
-        "curr_machine_id,past_machine_id",
-        (("123", "124"), (123, "124"), ("123", 124), ("123", "123")),
-    )
-    @mock.patch.object(UAContractClient, "_request_machine_token_update")
-    @mock.patch.object(UAContractClient, "_get_platform_data")
-    def test_do_not_make_make_detach_call_when_machine_id_is_different(
-        self,
-        m_platform_data,
-        m_request_machine_token_update,
-        curr_machine_id,
-        past_machine_id,
-        caplog_text,
-        FakeConfig,
-    ):
-        m_platform_data.return_value = {"machineId": curr_machine_id}
-        cfg = FakeConfig.for_attached_machine()
-        cfg.write_cache("machine-id", past_machine_id)
-        client = UAContractClient(cfg)
-
-        actual_value = client.detach_machine_from_contract(
-            machine_token="machine_token",
-            contract_id="contract_id",
-            machine_id="machine_id",
-        )
-
-        expected_msg = """\
-        Found new machine-id. Do not call detach on contract backend
-        """
-        if str(past_machine_id) != str(curr_machine_id):
-            assert actual_value == {}
-            assert m_request_machine_token_update.call_count == 0
-            assert expected_msg.strip() in caplog_text()
-        else:
-            assert m_request_machine_token_update.call_count == 1
-            assert expected_msg.strip() not in caplog_text()


### PR DESCRIPTION
## Proposed Commit Message
detach: remove contract detach call

The contract server is no longer detaching machines on their end. Therefore, we need to remove that call from detach, since it is doing nothing at the moment.

## Test Steps
Just verify that detach is still working as expected on the machine

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
