### PR TITLE
ua security-status round of improvements (SC-433)

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -920,7 +920,7 @@ Feature: Command behaviour when attached to an UA subscription
         Then stdout is a json matching the `ua_security_status` schema
         And stdout matches regexp:
         """
-        "_schema_version": "0"
+        "_schema_version": "0.1"
         """
         And stdout matches regexp:
         """
@@ -954,7 +954,7 @@ Feature: Command behaviour when attached to an UA subscription
         And I run `ua security-status --format json` as non-root
         Then stdout matches regexp:
         """
-        "_schema_version": "0"
+        "_schema_version": "0.1"
         """
         And stdout matches regexp:
         """
@@ -976,7 +976,7 @@ Feature: Command behaviour when attached to an UA subscription
         Then stdout is a yaml matching the `ua_security_status` schema
         And stdout matches regexp:
         """
-        _schema_version: '0'
+        _schema_version: '0.1'
         """
         When I verify that running `ua security-status --format unsupported` `as non-root` exits `2`
         Then I will see the following on stderr:

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -944,6 +944,10 @@ Feature: Command behaviour when attached to an UA subscription
         """
         And stdout matches regexp:
         """
+        "origin": "esm.ubuntu.com"
+        """
+        And stdout matches regexp:
+        """
         "status": "pending_attach"
         """
         When I attach `contract_token` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -916,7 +916,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
         And I run `dpkg-reconfigure ubuntu-advantage-tools` with sudo
         And I run `apt-get update` with sudo
-        When I run `ua security-status --format json --beta` as non-root
+        When I run `ua security-status --format json` as non-root
         Then stdout is a json matching the `ua_security_status` schema
         And stdout matches regexp:
         """
@@ -947,7 +947,7 @@ Feature: Command behaviour when attached to an UA subscription
         "status": "pending_attach"
         """
         When I attach `contract_token` with sudo
-        And I run `ua security-status --format json --beta` as non-root
+        And I run `ua security-status --format json` as non-root
         Then stdout matches regexp:
         """
         "_schema_version": "0"
@@ -968,29 +968,23 @@ Feature: Command behaviour when attached to an UA subscription
         """
         "status": "upgrade_available"
         """
-        When I run `ua security-status --format yaml --beta` as non-root
+        When I run `ua security-status --format yaml` as non-root
         Then stdout is a yaml matching the `ua_security_status` schema
         And stdout matches regexp:
         """
         _schema_version: '0'
         """
-        When I verify that running `ua security-status --format json` `as non-root` exits `2`
+        When I verify that running `ua security-status --format unsupported` `as non-root` exits `2`
         Then I will see the following on stderr:
         """
-        usage: security-status [-h] --format {json,yaml} --beta
-        the following arguments are required: --beta
-        """
-        When I verify that running `ua security-status --format unsupported --beta` `as non-root` exits `2`
-        Then I will see the following on stderr:
-        """
-        usage: security-status [-h] --format {json,yaml} --beta
+        usage: security-status [-h] --format {json,yaml}
         argument --format: invalid choice: 'unsupported' (choose from 'json', 'yaml')
         """
         When I verify that running `ua security-status` `as non-root` exits `2`
         Then I will see the following on stderr:
         """
-        usage: security-status [-h] --format {json,yaml} --beta
-        the following arguments are required: --format, --beta
+        usage: security-status [-h] --format {json,yaml}
+        the following arguments are required: --format
         """
         Examples: ubuntu release
            | release | package   | service   |

--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -62,6 +62,9 @@
           "service_name": {
             "type": "string"
           },
+          "origin": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "enum": [

--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -3,7 +3,7 @@
   "properties": {
     "_schema_version": {
       "type": "string",
-      "const": "0"
+      "const": "0.1"
     },
     "summary": {
       "type": "object",

--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -31,6 +31,12 @@
         "num_installed_packages": {
           "type": "integer"
         },
+        "num_esm_infra_packages": {
+          "type": "integer"
+        },
+        "num_esm_apps_packages": {
+          "type": "integer"
+        },
         "num_esm_infra_updates": {
           "type": "integer"
         },

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -426,15 +426,6 @@ def security_status_parser(parser):
         choices=("json", "yaml"),
         required=True,
     )
-    parser.add_argument(
-        "--beta",
-        help=(
-            "Acknowledge that this output is not final and may change in the"
-            " next version"
-        ),
-        action="store_true",
-        required=True,
-    )
     return parser
 
 

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -164,4 +164,4 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
         "standard-security"
     ]
 
-    return {"_schema_version": "0", "summary": summary, "packages": packages}
+    return {"_schema_version": "0.1", "summary": summary, "packages": packages}

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from enum import Enum
-from typing import Any, DefaultDict, Dict, List  # noqa: F401
+from typing import Any, DefaultDict, Dict, List, Tuple  # noqa: F401
 
 from apt import Cache  # type: ignore
 from apt import package as apt_package
@@ -45,15 +45,15 @@ def list_esm_for_package(package: apt_package.Package) -> List[str]:
     return esm_services
 
 
-def get_service_name(origins: List[apt_package.Origin]) -> str:
+def get_service_name(origins: List[apt_package.Origin]) -> Tuple[str, str]:
     "Translates the archive name in the version origin to a UA service name."
     for origin in origins:
         service = ORIGIN_INFORMATION_TO_SERVICE.get(
             (origin.origin, origin.archive)
         )
         if service:
-            return service
-    return ""
+            return service, origin.site
+    return ("", "")
 
 
 def get_update_status(service_name: str, ua_info: Dict[str, Any]) -> str:
@@ -143,7 +143,7 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
     security_upgradable_versions = filter_security_updates(installed_packages)
 
     for candidate in security_upgradable_versions:
-        service_name = get_service_name(candidate.origins)
+        service_name, origin_site = get_service_name(candidate.origins)
         status = get_update_status(service_name, ua_info)
         update_count[service_name] += 1
         packages.append(
@@ -152,6 +152,7 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
                 "version": candidate.version,
                 "service_name": service_name,
                 "status": status,
+                "origin": origin_site,
             }
         )
 

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -15,7 +15,7 @@ M_PATH = "uaclient.cli."
 
 HELP_OUTPUT = textwrap.dedent(
     """\
-usage: security-status \[-h\] --format {json,yaml} --beta
+usage: security-status \[-h\] --format {json,yaml}
 
 Show security updates for packages in the system, including all available ESM
 related content.
@@ -23,8 +23,6 @@ related content.
 (optional arguments|options):
   -h, --help            show this help message and exit
   --format {json,yaml}  Format for the output \(json or yaml\)
-  --beta                Acknowledge that this output is not final and may
-                        change in the next version
 """  # noqa
 )
 
@@ -104,29 +102,6 @@ class TestActionSecurityStatus:
         else:
             assert "the following arguments are required: --format" in err
 
-    # Remove this once we are no-longer beta
-    @pytest.mark.parametrize(
-        "beta_flag, expected_err",
-        ((False, "the following arguments are required: --beta"), (True, "")),
-    )
-    def test_require_beta_flag(
-        self, _m_resources, m_security_status, beta_flag, expected_err, capsys
-    ):
-        m_security_status.return_value = {}
-        cmdline_args = ["/usr/bin/ua", "security-status", "--format", "json"]
-        if beta_flag:
-            cmdline_args.extend(["--beta"])
-
-        try:
-            with mock.patch("sys.argv", cmdline_args):
-                main()
-        except SystemExit:
-            assert not beta_flag
-
-        _, err = capsys.readouterr()
-
-        assert expected_err in err
-
 
 class TestParser:
     @mock.patch(M_PATH + "contract.get_available_resources")
@@ -137,7 +112,7 @@ class TestParser:
 
         full_parser = get_parser()
         with mock.patch(
-            "sys.argv", ["ua", "security-status", "--format", "json", "--beta"]
+            "sys.argv", ["ua", "security-status", "--format", "json"]
         ):
             args = full_parser.parse_args()
         assert "security-status" == args.command

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -210,7 +210,7 @@ class TestSecurityStatus:
         cfg = FakeConfig()
 
         expected_output = {
-            "_schema_version": "0",
+            "_schema_version": "0.1",
             "packages": [
                 {
                     "package": "update_available",

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -13,11 +13,11 @@ from uaclient.security_status import (
 M_PATH = "uaclient.security_status."
 
 
-# Each candidate/installed is a tuple of (version, archive, origin)
+# Each candidate/installed is a tuple of (version, archive, origin, site)
 def mock_package(
     name,
-    installed: Tuple[str, str, str] = None,
-    candidates: List[Tuple[str, str, str]] = [],
+    installed: Tuple[str, str, str, str] = None,
+    candidates: List[Tuple[str, str, str, str]] = [],
 ):
     mock_package = mock.MagicMock()
     mock_package.name = name
@@ -34,6 +34,7 @@ def mock_package(
         mock_origin = mock.MagicMock()
         mock_origin.archive = installed[1]
         mock_origin.origin = installed[2]
+        mock_origin.site = installed[3]
         mock_installed.origins = [mock_origin]
 
         mock_package.installed = mock_installed
@@ -51,6 +52,7 @@ def mock_package(
         mock_origin = mock.MagicMock()
         mock_origin.archive = candidate[1]
         mock_origin.origin = candidate[2]
+        mock_origin.site = candidate[3]
         mock_candidate.origins = [mock_origin]
 
         mock_package.versions.append(mock_candidate)
@@ -137,30 +139,61 @@ class TestSecurityStatus:
             mock_package(name="not_installed"),
             mock_package(
                 name="there_is_no_update",
-                installed=("1.0", "somewhere", "somehow"),
+                installed=("1.0", "somewhere", "somehow", ""),
             ),
             mock_package(
                 name="latest_is_installed",
-                installed=("2.0", "standard-packages", "Ubuntu"),
-                candidates=[("1.0", "example-infra-security", "UbuntuESM")],
+                installed=("2.0", "standard-packages", "Ubuntu", ""),
+                candidates=[
+                    (
+                        "1.0",
+                        "example-infra-security",
+                        "UbuntuESM",
+                        "some.url.for.esm",
+                    )
+                ],
             ),
             mock_package(
                 name="update_available",
                 # this is an ESM-INFRA example for the counters
-                installed=("1.0", "example-infra-security", "UbuntuESM"),
-                candidates=[("2.0", "example-infra-security", "UbuntuESM")],
+                installed=("1.0", "example-infra-security", "UbuntuESM", ""),
+                candidates=[
+                    (
+                        "2.0",
+                        "example-infra-security",
+                        "UbuntuESM",
+                        "some.url.for.esm",
+                    )
+                ],
             ),
             mock_package(
                 name="not_a_security_update",
-                installed=("1.0", "somewhere", "somehow"),
-                candidates=[("2.0", "example-notsecurity", "NotUbuntuESM")],
+                installed=("1.0", "somewhere", "somehow", ""),
+                candidates=[
+                    (
+                        "2.0",
+                        "example-notsecurity",
+                        "NotUbuntuESM",
+                        "some.url.for.esm",
+                    )
+                ],
             ),
             mock_package(
                 name="more_than_one_update_available",
-                installed=("1.0", "somewhere", "somehow"),
+                installed=("1.0", "somewhere", "somehow", ""),
                 candidates=[
-                    ("2.0", "example-security", "Ubuntu"),
-                    ("3.0", "example-infra-security", "UbuntuESM"),
+                    (
+                        "2.0",
+                        "example-security",
+                        "Ubuntu",
+                        "some.url.for.standard",
+                    ),
+                    (
+                        "3.0",
+                        "example-infra-security",
+                        "UbuntuESM",
+                        "some.url.for.esm",
+                    ),
                 ],
             ),
         ]
@@ -184,18 +217,21 @@ class TestSecurityStatus:
                     "version": "2.0",
                     "service_name": "esm-infra",
                     "status": "pending_attach",
+                    "origin": "some.url.for.esm",
                 },
                 {
                     "package": "more_than_one_update_available",
                     "version": "2.0",
                     "service_name": "standard-security",
                     "status": "upgrade_available",
+                    "origin": "some.url.for.standard",
                 },
                 {
                     "package": "more_than_one_update_available",
                     "version": "3.0",
                     "service_name": "esm-infra",
                     "status": "pending_attach",
+                    "origin": "some.url.for.esm",
                 },
             ],
             "summary": {


### PR DESCRIPTION
This PR addresses feedback received from the beta version of `ua security-status`.
The main changes requested are:
- to include the origin site for the updates shown in the JSON
- to include the amount of packages installed from ESM

Aside from that, this PR also removes the `--beta` flag from the command and sets the schema version to `0.1`.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
