### PR TITLE
cli: validate services when unattached (SC-805)

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -137,46 +137,6 @@ Feature: Command behaviour when unattached
 
     @series.all
     @uses.config.machine_type.lxd.container
-    Scenario Outline: Unattached command known and unknown services in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I verify that running `ua <command> <service>` `as non-root` exits `1`
-        Then I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo).
-            """
-        When I verify that running `ua <command> <service>` `with sudo` exits `1`
-        Then stderr matches regexp:
-            """
-            To use '<service>' you need an Ubuntu Advantage subscription
-            Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
-            """
-
-        Examples: ua commands
-           | release | command  | service   |
-           | bionic  | enable   | livepatch |
-           | bionic  | disable  | livepatch |
-           | bionic  | enable   | unknown   |
-           | bionic  | disable  | unknown   |
-           | focal   | enable   | livepatch |
-           | focal   | disable  | livepatch |
-           | focal   | enable   | unknown   |
-           | focal   | disable  | unknown   |
-           | xenial  | enable   | livepatch |
-           | xenial  | disable  | livepatch |
-           | xenial  | enable   | unknown   |
-           | xenial  | disable  | unknown   |
-           | impish  | enable   | livepatch |
-           | impish  | disable  | livepatch |
-           | impish  | enable   | unknown   |
-           | impish  | disable  | unknown   |
-           | jammy  | enable   | livepatch |
-           | jammy  | disable  | livepatch |
-           | jammy  | enable   | unknown   |
-           | jammy  | disable  | unknown   |
-
-    @series.all
-    @uses.config.machine_type.lxd.container
     Scenario Outline: Help command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `ua help esm-infra` as non-root
@@ -565,26 +525,73 @@ Feature: Command behaviour when unattached
 
     @series.all
     @uses.config.machine_type.lxd.container
-    Scenario Outline: Unattached enable fails in a ubuntu machine
+    Scenario Outline: Unattached enable/disable fails in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I verify that running `ua enable esm-infra` `with sudo` exits `1`
+        When I verify that running `ua <command> esm-infra` `as non-root` exits `1`
+        Then I will see the following on stderr:
+          """
+          This command must be run as root (try using sudo).
+          """
+        When I verify that running `ua <command> esm-infra` `with sudo` exits `1`
         Then I will see the following on stderr:
           """
           To use 'esm-infra' you need an Ubuntu Advantage subscription
           Personal and community subscriptions are available at no charge
           See https://ubuntu.com/advantage
           """
-        When I verify that running `ua enable esm-infra --format json --assume-yes` `with sudo` exits `1`
+        When I verify that running `ua <command> esm-infra --format json --assume-yes` `with sudo` exits `1`
         Then stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
           """
-          {"_schema_version": "0.1", "errors": [{"message": "To use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "message_code": "enable-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+          {"_schema_version": "0.1", "errors": [{"message": "To use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "message_code": "valid-service-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+          """
+        When I verify that running `ua <command> unknown` `as non-root` exits `1`
+        Then I will see the following on stderr:
+          """
+          This command must be run as root (try using sudo).
+          """
+        When I verify that running `ua <command> unknown` `with sudo` exits `1`
+        Then I will see the following on stderr:
+          """
+          Cannot <command> unknown service 'unknown'.
+          See https://ubuntu.com/advantage
+          """
+        When I verify that running `ua <command> unknown --format json --assume-yes` `with sudo` exits `1`
+        Then stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
+          """
+          {"_schema_version": "0.1", "errors": [{"message": "Cannot <command> unknown service 'unknown'.\nSee https://ubuntu.com/advantage", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+          """
+        When I verify that running `ua <command> esm-infra unknown` `as non-root` exits `1`
+        Then I will see the following on stderr:
+            """
+            This command must be run as root (try using sudo).
+            """
+        When I verify that running `ua <command> esm-infra unknown` `with sudo` exits `1`
+        Then I will see the following on stderr:
+          """
+          Cannot <command> unknown service 'unknown'.
+
+          To use 'esm-infra' you need an Ubuntu Advantage subscription
+          Personal and community subscriptions are available at no charge
+          See https://ubuntu.com/advantage
+          """
+        When I verify that running `ua <command> esm-infra unknown --format json --assume-yes` `with sudo` exits `1`
+        Then stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
+          """
+          {"_schema_version": "0.1", "errors": [{"message": "Cannot <command> unknown service 'unknown'.\n\nTo use 'esm-infra' you need an Ubuntu Advantage subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/advantage", "message_code": "mixed-services-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
           """
 
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | impish  |
-          | jammy   |
+          | release | command  |
+          | xenial  | enable   |
+          | xenial  | disable  |
+          | bionic  | enable   |
+          | bionic  | disable  |
+          | focal   | enable   |
+          | focal   | disable  |
+          | impish  | enable   |
+          | impish  | disable  |
+          | jammy   | enable   |
+          | jammy   | disable  |

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -98,9 +98,13 @@ class ErrorInstallingLivepatch(UserFacingError):
 
 
 class InvalidServiceToDisableError(UserFacingError):
-    def __init__(self, operation: str, name: str, service_msg: str) -> None:
+    def __init__(
+        self, operation: str, invalid_service: str, service_msg: str
+    ) -> None:
         msg = messages.INVALID_SERVICE_OP_FAILURE.format(
-            operation=operation, name=name, service_msg=service_msg
+            operation=operation,
+            invalid_service=invalid_service,
+            service_msg=service_msg,
         )
         super().__init__(msg=msg.msg, msg_code=msg.name)
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -272,13 +272,27 @@ See """
     + BASE_UA_URL,
 )
 
-ENABLE_FAILURE_UNATTACHED = FormattedNamedMessage(
-    "enable-failure-unattached",
+VALID_SERVICE_FAILURE_UNATTACHED = FormattedNamedMessage(
+    "valid-service-failure-unattached",
     """\
-To use '{name}' you need an Ubuntu Advantage subscription
+To use '{valid_service}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
 See """
     + BASE_UA_URL,
+)
+
+INVALID_SERVICE_OP_FAILURE = FormattedNamedMessage(
+    "invalid-service-or-failure",
+    """\
+Cannot {operation} unknown service '{invalid_service}'.
+{service_msg}""",
+)
+
+MIXED_SERVICES_FAILURE_UNATTACHED = FormattedNamedMessage(
+    "mixed-services-failure-unattached",
+    INVALID_SERVICE_OP_FAILURE.tmpl_msg
+    + "\n"
+    + VALID_SERVICE_FAILURE_UNATTACHED.tmpl_msg,
 )
 
 FAILED_DISABLING_DEPENDENT_SERVICE = FormattedNamedMessage(
@@ -578,13 +592,6 @@ Failed to enable default services, check: sudo ua status""",
 INVALID_CONTRACT_DELTAS_SERVICE_TYPE = FormattedNamedMessage(
     "invalid-contract-deltas-service-type",
     "Could not determine contract delta service type {orig} {new}",
-)
-
-INVALID_SERVICE_OP_FAILURE = FormattedNamedMessage(
-    "invalid-service-or-failure",
-    """\
-Cannot {operation} unknown service '{name}'.
-{service_msg}""",
 )
 
 LOCK_HELD = FormattedNamedMessage(

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -222,7 +222,9 @@ class TestDisable:
 
         assert (
             expected_error_tmpl.format(
-                operation="disable", name="ent1", service_msg="Try ent2, ent3."
+                operation="disable",
+                invalid_service="ent1",
+                service_msg="Try ent2, ent3.",
             ).msg
             == err.value.msg
         )
@@ -296,7 +298,9 @@ class TestDisable:
 
         if not uid:
             expected_error = expected_error_template.format(
-                operation="disable", name="bogus", service_msg=ALL_SERVICE_MSG
+                operation="disable",
+                invalid_service="bogus",
+                service_msg=ALL_SERVICE_MSG,
             )
         else:
             expected_error = expected_error_template
@@ -344,7 +348,7 @@ class TestDisable:
         args = mock.MagicMock()
         expected_error = expected_error_tmpl.format(
             operation="disable",
-            name=", ".join(sorted(service)),
+            invalid_service=", ".join(sorted(service)),
             service_msg=ALL_SERVICE_MSG,
         )
         with pytest.raises(exceptions.UserFacingError) as err:
@@ -385,7 +389,7 @@ class TestDisable:
     @pytest.mark.parametrize(
         "uid,expected_error_template",
         [
-            (0, messages.ENABLE_FAILURE_UNATTACHED),
+            (0, messages.VALID_SERVICE_FAILURE_UNATTACHED),
             (1000, messages.NONROOT_USER),
         ],
     )
@@ -397,8 +401,11 @@ class TestDisable:
 
         cfg = FakeConfig()
         args = mock.MagicMock()
+        args.command = "disable"
         if not uid:
-            expected_error = expected_error_template.format(name="esm-infra")
+            expected_error = expected_error_template.format(
+                valid_service="esm-infra"
+            )
         else:
             expected_error = expected_error_template
 


### PR DESCRIPTION
When trying to enable/disable, check if the services are valid and
present messages accordingly.

Added a new message name/content for the case when the user provides valid and invalid services to the CLI at the same time.

Fixes: #1976 

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
