### PR TITLE
postinst: remove unneeded check for deb-systemd-helper

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -355,10 +355,8 @@ remove_old_systemd_timers() {
     # Since we actually want to remove this service from now on
     # we have replicated that behavior here
     if [ -L $OLD_MESSAGING_TIMER_MASKED_LOCATION ]; then
-        if [ -x "/usr/bin/deb-systemd-helper" ]; then
-            deb-systemd-helper purge ua-messaging.timer > /dev/null || true
-            deb-systemd-helper unmask ua-messaging.timer > /dev/null || true
-        fi
+        deb-systemd-helper purge ua-messaging.timer > /dev/null || true
+        deb-systemd-helper unmask ua-messaging.timer > /dev/null || true
     fi
 }
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
postinst: remove unneeded check for deb-systemd-helper

deb-systemd-helper is a part of init-system-helpers, which is
Essential: yes, so the check here was superfluous.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Install an old version of ua that has ua-messaging.timer. Upgrade to this version and make sure ua-messaging.timer is cleaned up correctly.

Or say "this doesn't really benefit us and we don't want to bother with the extra testing here so lets just leave it as it was" - that would make sense too :) - then we can just close this PR

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
