### PR TITLE
cli: add additional_info to json response errors

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -16,7 +16,8 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              This command must be run as root (try using sudo).
              """
         When I verify that running `ua attach invalid-token --format json` `with sudo` exits `1`
-        Then I will see the following on stdout:
+        Then stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
             """
             {"_schema_version": "0.1", "errors": [{"message": "Invalid token. See https://ubuntu.com/advantage", "message_code": "attach-invalid-token", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
@@ -29,9 +30,9 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | impish  |
            | jammy   |
 
-    @uses.config.contract_token_staging_expired
     @series.all
     @uses.config.machine_type.lxd.container
+    @uses.config.contract_token_staging_expired
     Scenario Outline: Attach command failure on expired token
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attempt to attach `contract_token_staging_expired` with sudo
@@ -41,6 +42,13 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
              Contract ".*" .*
              Visit https://ubuntu.com/advantage to manage contract tokens.
              """
+        When I verify that running attach `with sudo` using expired token with json response fails
+        Then stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
+            """
+            {"_schema_version": "0.1", "errors": [{"additional_info": {"contract_expiry_date": "12-31-2019", "contract_id": "cAJ4NHcl2qAld2CbJt5cufzZNHgVZ0YTPIH96Ihsy4bU"}, "message": "Attach denied:\nContract \"cAJ4NHcl2qAld2CbJt5cufzZNHgVZ0YTPIH96Ihsy4bU\" expired on December 31, 2019\nVisit https://ubuntu.com/advantage to manage contract tokens.", "message_code": "attach-forbidden-expired", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+            """
+
         Examples: ubuntu release
            | release |
            | xenial  |

--- a/features/schemas/ua_operation.json
+++ b/features/schemas/ua_operation.json
@@ -23,6 +23,9 @@
            },
            "service": {
              "type": ["null", "string"]
+           },
+           "additional_info": {
+             "type": "object"
            }
         },
         "patternProperties": {

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -36,6 +36,8 @@ CONTAINER_PREFIX = "ubuntu-behave-test"
 IMAGE_BUILD_PREFIX = "ubuntu-behave-image-build"
 IMAGE_PREFIX = "ubuntu-behave-image"
 
+ERROR_CODE = "1"
+
 
 def add_test_name_suffix(context, series, prefix):
     pr_number = os.environ.get("UACLIENT_BEHAVE_JENKINS_CHANGE_ID")
@@ -646,6 +648,19 @@ def when_i_verify_attach_with_json_response(context, spec, exit_codes):
     cmd = "ua attach {} --format json".format(context.config.contract_token)
     then_i_verify_that_running_cmd_with_spec_exits_with_codes(
         context=context, cmd_name=cmd, spec=spec, exit_codes=exit_codes
+    )
+
+
+@when(
+    "I verify that running attach `{spec}` using expired token with json response fails"  # noqa
+)
+def when_i_verify_attach_expired_token_with_json_response(context, spec):
+    change_contract_endpoint_to_staging(context, user_spec="with sudo")
+    cmd = "ua attach {} --format json".format(
+        context.config.contract_token_staging_expired
+    )
+    then_i_verify_that_running_cmd_with_spec_exits_with_codes(
+        context=context, cmd_name=cmd, spec=spec, exit_codes=ERROR_CODE
     )
 
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1242,16 +1242,7 @@ def action_attach(args, *, cfg):
     try:
         actions.attach_with_token(cfg, token=token, allow_enable=allow_enable)
     except exceptions.UrlError:
-        msg = messages.ATTACH_FAILURE
-        event.info(msg.msg)
-        event.error(error_msg=msg.msg, error_code=msg.name)
-        event.process_events()
-        return 1
-    except exceptions.UserFacingError as exc:
-        event.info(exc.msg)
-        event.error(error_msg=exc.msg, error_code=exc.msg_code)
-        event.process_events()
-        return 1
+        raise exceptions.AttachError()
     else:
         ret = 0
         if enable_services_override is not None and args.auto_enable:
@@ -1660,7 +1651,12 @@ def main_error_handler(func):
         except exceptions.UserFacingError as exc:
             with util.disable_log_to_console():
                 logging.error(exc.msg)
-            event.error(error_msg=exc.msg, error_code=exc.msg_code)
+
+            event.error(
+                error_msg=exc.msg,
+                error_code=exc.msg_code,
+                additional_info=exc.additional_info,
+            )
             event.info(info_msg="{}".format(exc.msg), file_type=sys.stderr)
             if not isinstance(exc, exceptions.LockHeldError):
                 # Only clear the lock if it is ours.

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -391,14 +391,24 @@ def _create_attach_forbidden_message(
 
         if reason == "no-longer-effective":
             date = info["time"].strftime(ATTACH_FAIL_DATE_FORMAT)
+            additional_info = {
+                "contract_expiry_date": info["time"].strftime("%m-%d-%Y"),
+                "contract_id": contract_id,
+            }
             reason_msg = messages.ATTACH_FORBIDDEN_EXPIRED.format(
                 contract_id=contract_id, date=date
             )
+            reason_msg.additional_info = additional_info
         elif reason == "not-effective-yet":
             date = info["time"].strftime(ATTACH_FAIL_DATE_FORMAT)
+            additional_info = {
+                "contract_effective_date": info["time"].strftime("%m-%d-%Y"),
+                "contract_id": contract_id,
+            }
             reason_msg = messages.ATTACH_FORBIDDEN_NOT_YET.format(
                 contract_id=contract_id, date=date
             )
+            reason_msg.additional_info = additional_info
         elif reason == "never-effective":
             reason_msg = messages.ATTACH_FORBIDDEN_NEVER.format(
                 contract_id=contract_id
@@ -407,6 +417,7 @@ def _create_attach_forbidden_message(
         if reason_msg:
             msg = messages.ATTACH_FORBIDDEN.format(reason=reason_msg.msg)
             msg.name = reason_msg.name
+            msg.additional_info = reason_msg.additional_info
 
     return msg
 
@@ -447,7 +458,9 @@ def request_updated_contract(
                     elif e.code == 403:
                         msg = _create_attach_forbidden_message(e)
                         raise exceptions.UserFacingError(
-                            msg=msg.msg, msg_code=msg.name
+                            msg=msg.msg,
+                            msg_code=msg.name,
+                            additional_info=msg.additional_info,
                         )
                 raise e
             with util.disable_log_to_console():

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -17,9 +17,15 @@ class UserFacingError(Exception):
 
     exit_code = 1
 
-    def __init__(self, msg: str, msg_code: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        msg: str,
+        msg_code: Optional[str] = None,
+        additional_info: Optional[Dict[str, str]] = None,
+    ) -> None:
         self.msg = msg
         self.msg_code = msg_code
+        self.additional_info = additional_info
 
 
 class APTInstallError(UserFacingError):
@@ -159,6 +165,16 @@ class AlreadyAttachedError(UserFacingError):
         msg = messages.ALREADY_ATTACHED.format(
             account_name=cfg.accounts[0].get("name", "")
         )
+        super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class AttachError(UserFacingError):
+    """An exception to be raised when we detect a generic attach error."""
+
+    exit_code = 1
+
+    def __init__(self):
+        msg = messages.ATTACH_FAILURE
         super().__init__(msg=msg.msg, msg_code=msg.name)
 
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1,3 +1,5 @@
+from typing import Dict, Optional  # noqa: F401
+
 from uaclient.defaults import BASE_UA_URL, DOCUMENTATION_URL
 
 
@@ -5,6 +7,10 @@ class NamedMessage:
     def __init__(self, name: str, msg: str):
         self.name = name
         self.msg = msg
+        # we should use this field whenever we want to provide
+        # extra information to the message. This is specially
+        # useful if the message represents an error.
+        self.additional_info = None  # type: Optional[Dict[str, str]]
 
 
 class FormattedNamedMessage(NamedMessage):

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -273,8 +273,10 @@ class TestActionAttach:
             raise error_class(error_str)
 
         request_updated_contract.side_effect = fake_request_updated_contract
-        ret = action_attach(args, cfg=cfg)
-        assert 1 == ret
+        with pytest.raises(SystemExit) as excinfo:
+            main_error_handler(action_attach)(args, cfg)
+
+        assert 1 == excinfo.value.code
         assert cfg.is_attached
         # Assert updated status cache is written to disk
         assert orig_unattached_status != cfg.read_cache(
@@ -583,11 +585,14 @@ class TestActionAttach:
         )
 
         fake_stdout = io.StringIO()
-        with contextlib.redirect_stdout(fake_stdout):
-            with mock.patch.object(
-                event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-            ):
-                main_error_handler(action_attach)(args, cfg)
+        with pytest.raises(SystemExit):
+            with contextlib.redirect_stdout(fake_stdout):
+                with mock.patch.object(
+                    event,
+                    "_event_logger_mode",
+                    event_logger.EventLoggerMode.JSON,
+                ):
+                    main_error_handler(action_attach)(args, cfg)
 
         expected_msg = messages.ATTACH_FAILURE_DEFAULT_SERVICES
         expected = {

--- a/uaclient/tests/test_event_logger.py
+++ b/uaclient/tests/test_event_logger.py
@@ -25,6 +25,7 @@ class TestEventLogger:
                 event.error(error_msg="error1", error_code="error1-code")
                 event.error(error_msg="error2", service="esm")
                 event.error(error_msg="error3", error_type="exception")
+                event.error(error_msg="error4", additional_info={"test": 123})
                 event.warning(warning_msg="warning1")
                 event.warning(warning_msg="warning2", service="esm")
                 event.process_events()
@@ -51,6 +52,13 @@ class TestEventLogger:
                         "message_code": None,
                         "service": None,
                         "type": "exception",
+                    },
+                    {
+                        "message": "error4",
+                        "message_code": None,
+                        "service": None,
+                        "type": "system",
+                        "additional_info": {"test": 123},
                     },
                 ],
                 "warnings": [


### PR DESCRIPTION
## Proposed Commit Message
cli: add additional_info to json response errors

If users want to modify the error messages delivered by us, we need to provide additional info to some of those error messages. We are now adding that information only for expired contract errors but we can add more additional info in the future if needed.

## Test Steps
Run the modified integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
