### PR TITLE
Cloud overrides core

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -911,3 +911,88 @@ Feature: Enable command behaviour when attached to an UA subscription
            | release | ros-security-source                                    | ros-updates-source                                            |
            | xenial  | https://esm.ubuntu.com/ros/ubuntu xenial-security/main | https://esm.ubuntu.com/ros-updates/ubuntu xenial-updates/main |
            | bionic  | https://esm.ubuntu.com/ros/ubuntu bionic-security/main | https://esm.ubuntu.com/ros-updates/ubuntu bionic-updates/main |
+
+    # Overall test for overrides; in the future, when many services
+    # have overrides, we can consider removing this
+    # FIPS is a good choice because we expect to have it
+    @series.focal
+    @uses.config.machine_type.aws.generic
+    Scenario: Cloud overrides for a generic aws Focal instance
+       Given a `focal` machine with ubuntu-advantage-tools installed
+        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        """
+        {
+          "machineTokenInfo": {
+            "contractInfo": {
+              "resourceEntitlements": [
+                {
+                  "type": "fips",
+                  "entitled": true,
+                  "affordances": {
+                    "architectures": [
+                      "amd64",
+                      "ppc64el",
+                      "ppc64le",
+                      "s390x",
+                      "x86_64"
+                    ],
+                    "series": [
+                      "xenial",
+                      "bionic",
+                      "focal"
+                    ]
+                  },
+                  "directives": {
+                    "additionalPackages": [
+                      "ubuntu-fips"
+                    ],
+                    "aptKey": "E23341B2A1467EDBF07057D6C1997C40EDE22758",
+                    "aptURL": "https://esm.ubuntu.com/fips",
+                    "suites": [
+                      "xenial",
+                      "bionic",
+                      "focal"
+                    ]
+                  },
+                  "obligations": {
+                    "enableByDefault": false
+                  },
+                  "overrides": [
+                    {
+                      "selector": {
+                        "series": "focal"
+                      },
+                      "directives": {
+                        "additionalPackages": [
+                          "some-package-focal"
+                        ]
+                      }
+                    },
+                    {
+                      "selector": {
+                        "cloud": "aws"
+                      },
+                      "directives": {
+                        "additionalPackages": [
+                          "some-package-aws"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """
+        And I append the following on uaclient config:
+        """
+        features:
+          machine_token_overlay: "/tmp/machine-token-overlay.json"
+        """
+        And I attach `contract_token` with sudo
+        And I verify that running `ua enable fips --assume-yes` `with sudo` exits `1`
+        Then stderr matches regexp:
+        """
+        Stderr: E: Unable to locate package some-package-aws
+        """

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from functools import lru_cache
 from typing import Dict, Optional, Tuple, Type  # noqa: F401
 
 from uaclient import clouds, exceptions, util
@@ -36,6 +37,7 @@ def get_instance_id() -> Optional[str]:
     return None
 
 
+@lru_cache(maxsize=None)
 @apply_config_settings_override("cloud_type")
 def get_cloud_type() -> Tuple[Optional[str], Optional[NoCloudTypeReason]]:
     if util.which("cloud-id"):

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -40,7 +40,7 @@ class TestGetCloudType:
     @mock.patch(M_PATH + "util.subp", return_value=("somecloud\n", ""))
     def test_use_cloud_id_when_available(self, m_subp, m_which):
         """Use cloud-id utility to discover cloud type."""
-        assert ("somecloud", None) == get_cloud_type()
+        assert ("somecloud", None) == get_cloud_type.__wrapped__()
         assert [mock.call("cloud-id")] == m_which.call_args_list
 
     @mock.patch(M_PATH + "util.which", return_value="/usr/bin/cloud-id")
@@ -49,7 +49,10 @@ class TestGetCloudType:
         side_effect=exceptions.ProcessExecutionError("cloud-id"),
     )
     def test_error_when_cloud_id_fails(self, m_subp, m_which):
-        assert (None, NoCloudTypeReason.CLOUD_ID_ERROR) == get_cloud_type()
+        assert (
+            None,
+            NoCloudTypeReason.CLOUD_ID_ERROR,
+        ) == get_cloud_type.__wrapped__()
 
     @pytest.mark.parametrize(
         "settings_overrides",
@@ -80,7 +83,7 @@ class TestGetCloudType:
             expected_value = "test"
 
         m_load_file.return_value = settings_overrides
-        assert get_cloud_type() == (expected_value, None)
+        assert get_cloud_type.__wrapped__() == (expected_value, None)
 
 
 @mock.patch(M_PATH + "get_cloud_type")

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -357,7 +357,7 @@ class UAConfig:
                 entitlement_cfg["resourceToken"] = tokens_by_name[
                     entitlement_name
                 ]
-            util.apply_series_overrides(entitlement_cfg, self.series)
+            util.apply_contract_overrides(entitlement_cfg, self.series)
             self._entitlements[entitlement_name] = entitlement_cfg
         return self._entitlements
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -347,7 +347,7 @@ def process_entitlement_delta(
     from uaclient.entitlements import entitlement_factory
 
     if series_overrides:
-        util.apply_series_overrides(new_access)
+        util.apply_contract_overrides(new_access)
 
     deltas = util.get_dict_deltas(orig_access, new_access)
     ret = False

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -836,7 +836,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         transition_to_unentitled = bool(delta_entitlement == util.DROPPED_KEY)
         if not transition_to_unentitled:
             if delta_entitlement:
-                util.apply_series_overrides(deltas)
+                util.apply_contract_overrides(deltas)
                 delta_entitlement = deltas["entitlement"]
             if orig_access and "entitled" in delta_entitlement:
                 transition_to_unentitled = delta_entitlement["entitled"] in (

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -110,8 +110,10 @@ class TestCommonCriteriaEntitlementEnable:
     @mock.patch("uaclient.util.should_reboot")
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.get_platform_info")
+    @mock.patch("uaclient.util.apply_contract_overrides")
     def test_enable_configures_apt_sources_and_auth_files(
         self,
+        _m_contract_overrides,
         m_platform_info,
         m_subp,
         m_should_reboot,

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -617,6 +617,7 @@ class TestLivepatchEntitlementEnable:
     @pytest.mark.parametrize("apt_update_success", (True, False))
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp")
+    @mock.patch("uaclient.util.apply_contract_overrides")
     @mock.patch("uaclient.apt.run_apt_install_command")
     @mock.patch("uaclient.apt.run_apt_update_command")
     @mock.patch("uaclient.util.which", return_value=False)
@@ -631,6 +632,7 @@ class TestLivepatchEntitlementEnable:
         m_which,
         m_run_apt_update,
         m_run_apt_install,
+        _m_contract_overrides,
         m_subp,
         _m_get_platform_info,
         m_livepatch_proxy,
@@ -678,6 +680,7 @@ class TestLivepatchEntitlementEnable:
 
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp", return_value=("snapd", ""))
+    @mock.patch("uaclient.util.apply_contract_overrides")
     @mock.patch(
         "uaclient.util.which", side_effect=lambda cmd: cmd == "/usr/bin/snap"
     )
@@ -690,6 +693,7 @@ class TestLivepatchEntitlementEnable:
         m_can_enable,
         m_app_status,
         m_which,
+        _m_contract_overrides,
         m_subp,
         _m_get_platform_info,
         m_livepatch_proxy,
@@ -759,6 +763,7 @@ class TestLivepatchEntitlementEnable:
     @mock.patch("uaclient.apt.get_installed_packages", return_value=["snapd"])
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp")
+    @mock.patch("uaclient.util.apply_contract_overrides")
     @mock.patch("uaclient.util.which", side_effect=[True, True])
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(
@@ -769,6 +774,7 @@ class TestLivepatchEntitlementEnable:
         m_can_enable,
         m_app_status,
         m_which,
+        _m_contract_overrides,
         m_subp,
         _m_get_platform_info,
         _m_get_installed_packages,
@@ -808,6 +814,7 @@ class TestLivepatchEntitlementEnable:
     @mock.patch("uaclient.apt.get_installed_packages", return_value=["snapd"])
     @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp")
+    @mock.patch("uaclient.util.apply_contract_overrides")
     @mock.patch("uaclient.util.which", side_effect=[True, True])
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(
@@ -818,6 +825,7 @@ class TestLivepatchEntitlementEnable:
         m_can_enable,
         m_app_status,
         m_which,
+        _m_contract_overrides,
         m_subp,
         _m_get_platform_info,
         _m_get_installed_packages,

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -734,8 +734,10 @@ class TestRemoveAptConfig:
     @mock.patch(M_PATH + "apt.remove_apt_list_files")
     @mock.patch(M_PATH + "apt.run_apt_command")
     @mock.patch(M_PATH + "util.get_platform_info")
+    @mock.patch(M_PATH + "util.apply_contract_overrides")
     def test_repo_pin_priority_int_removes_apt_preferences(
         self,
+        _m_contract_overrides,
         m_get_platform,
         _m_run_apt_command,
         _m_remove_apt_list_files,
@@ -862,8 +864,10 @@ class TestSetupAptConfig:
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch(M_PATH + "apt.add_auth_apt_repo")
     @mock.patch(M_PATH + "apt.run_apt_install_command")
+    @mock.patch(M_PATH + "util.apply_contract_overrides")
     def test_install_prerequisite_packages(
         self,
+        _m_contract_overrides,
         m_run_apt_install_command,
         m_add_auth_repo,
         _m_setup_apt_proxy,
@@ -908,8 +912,10 @@ class TestSetupAptConfig:
     @mock.patch(M_PATH + "apt.add_auth_apt_repo")
     @mock.patch(M_PATH + "apt.run_apt_command")
     @mock.patch(M_PATH + "util.get_platform_info")
+    @mock.patch(M_PATH + "util.apply_contract_overrides")
     def test_setup_with_repo_pin_priority_never_removes_apt_preferences_file(
         self,
+        _m_contract_overrides,
         m_get_platform_info,
         m_run_apt_command,
         m_add_auth_repo,
@@ -940,8 +946,10 @@ class TestSetupAptConfig:
     @mock.patch(M_PATH + "apt.run_apt_update_command")
     @mock.patch(M_PATH + "apt.add_ppa_pinning")
     @mock.patch(M_PATH + "util.get_platform_info")
+    @mock.patch(M_PATH + "util.apply_contract_overrides")
     def test_setup_with_repo_pin_priority_int_adds_a_pins_repo_apt_preference(
         self,
+        _m_apply_overrides,
         m_get_platform_info,
         m_add_ppa_pinning,
         m_run_apt_update_command,

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -532,14 +532,14 @@ class TestActionAttach:
         assert expected == json.loads(fake_stdout.getvalue())
 
     @mock.patch("uaclient.contract.process_entitlement_delta")
-    @mock.patch("uaclient.util.apply_series_overrides")
+    @mock.patch("uaclient.util.apply_contract_overrides")
     @mock.patch("uaclient.contract.UAContractClient.request_url")
     @mock.patch("uaclient.jobs.update_messaging.update_apt_and_motd_messages")
     def test_attach_when_one_service_fails_to_enable(
         self,
         _m_update_messages,
         m_request_url,
-        _m_apply_series_overrides,
+        _m_apply_contract_overrides,
         m_process_entitlement_delta,
         _m_getuid,
         FakeConfig,


### PR DESCRIPTION
Support generic overrides from the contract server.
Currently, the supported overrides are `series` and `cloud`, but more can be added in the future.

Further testing, mainly integration testing, can be performed once contracts starts applying those specific overrides with anything different than the regular `series` one that we had before. Right now, no flow has changed.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
