### PR TITLE
fips: allow enabling fips on azure xenial clouds

### DIFF
--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -18,20 +18,40 @@ Feature: FIPS enablement in cloud based machines
             | xenial  | Xenial        | fips-updates  |
 
     @series.xenial
+    @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
-    Scenario Outline: Enable FIPS services in an ubuntu Xenial Azure vm
-        Given a `xenial` machine with ubuntu-advantage-tools installed
+    Scenario Outline: FIPS unholds packages
+        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `ua enable <fips_service> --assume-yes` `with sudo` exits `1`
-        And stdout matches regexp:
+        And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
+        And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
+        And I run `ua enable fips --assume-yes` with sudo
+        Then I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+        When I run `ua disable fips --assume-yes` with sudo
+        And I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
+        Then I will see the following on stdout:
         """
-        Ubuntu Xenial does not provide an Azure optimized FIPS kernel
+        openssh-client was already not hold.
+        openssh-server was already not hold.
+        strongswan was already not hold.
         """
+        When I reboot the `<release>` machine
+        Then I verify that `openssh-server` installed version matches regexp `fips`
+        And I verify that `openssh-client` installed version matches regexp `fips`
+        And I verify that `strongswan` installed version matches regexp `fips`
+        And I verify that `openssh-server-hmac` installed version matches regexp `fips`
+        And I verify that `openssh-client-hmac` installed version matches regexp `fips`
+        And I verify that `strongswan-hmac` installed version matches regexp `fips`
 
-        Examples: fips
-           | fips_service  |
-           | fips          |
-           | fips-updates  |
+        Examples: ubuntu release
+           | release | fips-apt-source                                |
+           | xenial  | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+
 
     @series.bionic
     @uses.config.machine_type.aws.generic
@@ -102,6 +122,7 @@ Feature: FIPS enablement in cloud based machines
            | focal   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
+    @series.xenial
     @series.bionic
     @series.focal
     @uses.config.machine_type.azure.generic
@@ -123,7 +144,7 @@ Feature: FIPS enablement in cloud based machines
             """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        When I run `apt-cache policy ubuntu-azure-fips` as non-root
+        When I run `apt-cache policy <fips-package>` as non-root
         Then stdout does not match regexp:
         """
         .*Installed: \(none\)
@@ -132,7 +153,7 @@ Feature: FIPS enablement in cloud based machines
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
             """
-            azure-fips
+            <fips-kernel>
             """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
@@ -144,7 +165,7 @@ Feature: FIPS enablement in cloud based machines
         """
         Updating package lists
         """
-        When I run `apt-cache policy ubuntu-azure-fips` as non-root
+        When I run `apt-cache policy <fips-package>` as non-root
         Then stdout matches regexp:
         """
         .*Installed: \(none\)
@@ -157,11 +178,13 @@ Feature: FIPS enablement in cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | fips-name    | fips-service | fips-package      | fips-kernel  | fips-apt-source                                |
+           | xenial  | FIPS         | fips         | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | xenial  | FIPS Updates | fips-updates | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | bionic  | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     @series.xenial

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -180,7 +180,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     ) -> bool:
         """Return False when FIPS is allowed on this cloud and series.
 
-        On Xenial Azure and GCP there will be no cloud-optimized kernel so
+        On Xenial GCP there will be no cloud-optimized kernel so
         block default ubuntu-fips enable. This can be overridden in
         config with features.allow_xenial_fips_on_cloud.
 
@@ -191,9 +191,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
         :return: False when this cloud, series or config override allows FIPS.
         """
-        if cloud_id not in ("azure", "gce"):
-            return True
-
         if cloud_id == "gce":
             if util.is_config_value_true(
                 config=self.cfg.cfg,
@@ -206,16 +203,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 return True
 
             return bool("ubuntu-gcp-fips" in super().packages)
-
-        # Azure FIPS cloud support
-        if series == "xenial":
-            if util.is_config_value_true(
-                config=self.cfg.cfg,
-                path_to_value="features.allow_xenial_fips_on_cloud",
-            ):
-                return True
-            else:
-                return False
 
         return True
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -684,7 +684,7 @@ class TestFIPSEntitlementEnable:
         entitlement,
     ):
         m_handle_message_op.return_value = True
-        m_cloud_type.return_value = ("azure", None)
+        m_cloud_type.return_value = ("gce", None)
         m_platform_info.return_value = {"series": "xenial"}
         base_path = "uaclient.entitlements.livepatch.LivepatchEntitlement"
 
@@ -695,7 +695,7 @@ class TestFIPSEntitlementEnable:
             result, reason = entitlement.enable()
             assert not result
             expected_msg = """\
-            Ubuntu Xenial does not provide an Azure optimized FIPS kernel"""
+            Ubuntu Xenial does not provide a GCP optimized FIPS kernel"""
             assert expected_msg.strip() in reason.message.msg.strip()
 
     @mock.patch("uaclient.util.get_platform_info")
@@ -735,7 +735,9 @@ class TestFIPSEntitlementEnable:
             Ubuntu Test does not provide a GCP optimized FIPS kernel"""
             assert expected_msg.strip() in reason.message.msg.strip()
 
-    @pytest.mark.parametrize("allow_xenial_fips_on_cloud", ((True), (False)))
+    @pytest.mark.parametrize(
+        "allow_default_fips_metapackage_on_gcp", ((True), (False))
+    )
     @pytest.mark.parametrize("cloud_id", (("aws"), ("gce"), ("azure"), (None)))
     @pytest.mark.parametrize("series", (("xenial"), ("bionic")))
     @mock.patch("uaclient.util.is_config_value_true")
@@ -744,12 +746,12 @@ class TestFIPSEntitlementEnable:
         m_is_config_value_true,
         series,
         cloud_id,
-        allow_xenial_fips_on_cloud,
+        allow_default_fips_metapackage_on_gcp,
         entitlement,
     ):
         def mock_config_value(config, path_to_value):
-            if "allow_xenial_fips_on_cloud" in path_to_value:
-                return allow_xenial_fips_on_cloud
+            if "allow_default_fips_metapackage_on_gcp" in path_to_value:
+                return allow_default_fips_metapackage_on_gcp
 
             return False
 
@@ -758,17 +760,19 @@ class TestFIPSEntitlementEnable:
             cloud_id=cloud_id, series=series
         )
 
-        if cloud_id == "aws" or cloud_id is None:
+        if cloud_id in ("azure", "aws") or cloud_id is None:
             assert actual_value
-        elif cloud_id == "gce" and series != "bionic":
+        elif all([cloud_id == "gce", allow_default_fips_metapackage_on_gcp]):
+            assert actual_value
+        elif all(
+            [
+                cloud_id == "gce",
+                not allow_default_fips_metapackage_on_gcp,
+                series == "xenial",
+            ]
+        ):
             assert not actual_value
         elif cloud_id == "gce":
-            assert actual_value
-        elif all([allow_xenial_fips_on_cloud, series == "xenial"]):
-            assert actual_value
-        elif series == "xenial":
-            assert not actual_value
-        else:
             assert actual_value
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed Commit Message
fips: allow enabling fips on azure xenial clouds

Currently, on Azure Xenial PRO FIPS machine we install the non-optimized fips kernel. Therefore, we are now expanding that
to other Azure Xenial machines.

## Test Steps
Run the new integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
