### PR TITLE
Remove unnecessary creation of UAConfig instances

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -60,7 +60,9 @@ redact_ubuntu_release_from_ua_apt_filenames() {
     DIR=$1
     UA_SERVICES=$(/usr/bin/python3 -c "
 from uaclient.entitlements import valid_services
-print(*valid_services(allow_beta=True, all_names=True), sep=' ')
+from uaclient.config import UAConfig
+cfg = UAConfig()
+print(*valid_services(cfg=cfg, allow_beta=True, all_names=True), sep=' ')
 ")
 
     for file in "$DIR"/*; do
@@ -122,8 +124,8 @@ check_service_is_beta() {
 from uaclient.config import UAConfig
 from uaclient.entitlements import entitlement_factory
 try:
-    ent_cls = entitlement_factory('${service_name}')
     cfg = UAConfig()
+    ent_cls = entitlement_factory(cfg=cfg, name='${service_name}')
     allow_beta = cfg.features.get('allow_beta', False)
     print(all([ent_cls.is_beta, not allow_beta]))
 except Exception:

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -47,7 +47,8 @@ current_codename_to_past_codename = {
 
 def process_contract_delta_after_apt_lock() -> None:
     logging.debug("Check whether to upgrade-lts-contract")
-    if not UAConfig().is_attached:
+    cfg = UAConfig()
+    if not cfg.is_attached:
         logging.debug("Skiping upgrade-lts-contract. Machine is unattached")
         return
     out, _err = subp(["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1])
@@ -84,6 +85,7 @@ def process_contract_delta_after_apt_lock() -> None:
     logging.debug(msg)
 
     process_entitlements_delta(
+        cfg=cfg,
         past_entitlements=past_entitlements,
         new_entitlements=new_entitlements,
         allow_enable=True,

--- a/tools/ua.bash
+++ b/tools/ua.bash
@@ -2,7 +2,9 @@
 
 SERVICES=$(python3 -c "
 from uaclient.entitlements import valid_services
-print(*valid_services(), sep=' ')
+from uaclient.config import UAConfig
+cfg = UAConfig()
+print(*valid_services(cfg=cfg), sep=' ')
 ")
 
 _ua_complete()

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -91,7 +91,7 @@ def enable_entitlement_by_name(
     :raise EntitlementNotFoundError: If no entitlement with the given name is
         found, then raises this error.
     """
-    ent_cls = entitlements.entitlement_factory(name)
+    ent_cls = entitlements.entitlement_factory(cfg=cfg, name=name)
     entitlement = ent_cls(
         cfg, assume_yes=assume_yes, allow_beta=allow_beta, called_name=name
     )

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -126,6 +126,8 @@ class UAArgumentParser(argparse.ArgumentParser):
 
     @staticmethod
     def _get_service_descriptions() -> Tuple[List[str], List[str]]:
+        cfg = config.UAConfig()
+
         service_info_tmpl = " - {name}: {description}{url}"
         non_beta_services_desc = []
         beta_services_desc = []
@@ -133,7 +135,9 @@ class UAArgumentParser(argparse.ArgumentParser):
         resources = contract.get_available_resources(config.UAConfig())
         for resource in resources:
             try:
-                ent_cls = entitlements.entitlement_factory(resource["name"])
+                ent_cls = entitlements.entitlement_factory(
+                    cfg=cfg, name=resource["name"]
+                )
             except exceptions.EntitlementNotFoundError:
                 continue
             # Because we don't know the presentation name if unattached
@@ -219,7 +223,9 @@ def assert_attached(msg_function=None):
                 if msg_function:
                     command = getattr(args, "command", "")
                     service_names = getattr(args, "service", "")
-                    msg = msg_function(command, service_names)
+                    msg = msg_function(
+                        command=command, service_names=service_names, cfg=cfg
+                    )
                     exception = exceptions.UnattachedError(msg)
                 else:
                     exception = exceptions.UnattachedError()
@@ -503,7 +509,7 @@ def detach_parser(parser):
     return parser
 
 
-def help_parser(parser):
+def help_parser(parser, cfg: config.UAConfig):
     """Build or extend an arg parser for help subcommand."""
     usage = USAGE_TMPL.format(name=NAME, command="help [service]")
     parser.usage = usage
@@ -517,7 +523,7 @@ def help_parser(parser):
         action="store",
         nargs="?",
         help="a service to view help output for. One of: {}".format(
-            ", ".join(entitlements.valid_services())
+            ", ".join(entitlements.valid_services(cfg=cfg))
         ),
     )
 
@@ -542,7 +548,7 @@ def help_parser(parser):
     return parser
 
 
-def enable_parser(parser):
+def enable_parser(parser, cfg: config.UAConfig):
     """Build or extend an arg parser for enable subcommand."""
     usage = USAGE_TMPL.format(
         name=NAME, command="enable <service> [<service>]"
@@ -558,7 +564,9 @@ def enable_parser(parser):
         nargs="+",
         help=(
             "the name(s) of the Ubuntu Advantage services to enable."
-            " One of: {}".format(", ".join(entitlements.valid_services()))
+            " One of: {}".format(
+                ", ".join(entitlements.valid_services(cfg=cfg))
+            )
         ),
     )
     parser.add_argument(
@@ -579,7 +587,7 @@ def enable_parser(parser):
     return parser
 
 
-def disable_parser(parser):
+def disable_parser(parser, cfg: config.UAConfig):
     """Build or extend an arg parser for disable subcommand."""
     usage = USAGE_TMPL.format(
         name=NAME, command="disable <service> [<service>]"
@@ -595,7 +603,9 @@ def disable_parser(parser):
         nargs="+",
         help=(
             "the name(s) of the Ubuntu Advantage services to disable"
-            " One of: {}".format(", ".join(entitlements.valid_services()))
+            " One of: {}".format(
+                ", ".join(entitlements.valid_services(cfg=cfg))
+            )
         ),
     )
     parser.add_argument(
@@ -726,7 +736,7 @@ def _perform_disable(entitlement, cfg, *, assume_yes, update_status=True):
     return ret
 
 
-def get_valid_entitlement_names(names: List[str]):
+def get_valid_entitlement_names(names: List[str], cfg: config.UAConfig):
     """Return a list of valid entitlement names.
 
     :param names: List of entitlements to validate
@@ -736,7 +746,7 @@ def get_valid_entitlement_names(names: List[str]):
 
     for ent_name in names:
         if ent_name in entitlements.valid_services(
-            allow_beta=True, all_names=True
+            cfg=cfg, allow_beta=True, all_names=True
         ):
             entitlements_found.append(ent_name)
 
@@ -750,7 +760,7 @@ def action_config(args, *, cfg, **kwargs):
 
     :return: 0 on success, 1 otherwise
     """
-    parser = get_parser()
+    parser = get_parser(cfg=cfg)
     subparser = parser._get_positional_actions()[0].choices["config"]
     valid_choices = subparser._get_positional_actions()[0].choices.keys()
     if args.command not in valid_choices:
@@ -810,7 +820,7 @@ def action_config_set(args, *, cfg, **kwargs):
     from uaclient.entitlements.livepatch import configure_livepatch_proxy
     from uaclient.snap import configure_snap_proxy
 
-    parser = get_parser()
+    parser = get_parser(cfg=cfg)
     config_parser = parser._get_positional_actions()[0].choices["config"]
     subparser = config_parser._get_positional_actions()[0].choices["set"]
     try:
@@ -925,7 +935,7 @@ def action_config_unset(args, *, cfg, **kwargs):
     from uaclient.snap import unconfigure_snap_proxy
 
     if args.key not in config.UA_CONFIGURABLE_KEYS:
-        parser = get_parser()
+        parser = get_parser(cfg=cfg)
         config_parser = parser._get_positional_actions()[0].choices["config"]
         subparser = config_parser._get_positional_actions()[0].choices["unset"]
         subparser.print_help()
@@ -957,13 +967,13 @@ def action_config_unset(args, *, cfg, **kwargs):
     return 0
 
 
-def _create_enable_disable_unattached_msg(command, service_names):
+def _create_enable_disable_unattached_msg(command, service_names, cfg):
     """Generates a custom message for enable/disable commands when unattached.
 
     Takes into consideration if the services exist or not, and notify the user
     accordingly."""
     (entitlements_found, entitlements_not_found) = get_valid_entitlement_names(
-        service_names
+        names=service_names, cfg=cfg
     )
     if entitlements_found and entitlements_not_found:
         msg = messages.MIXED_SERVICES_FAILURE_UNATTACHED
@@ -997,12 +1007,12 @@ def action_disable(args, *, cfg, **kwargs):
     """
     names = getattr(args, "service", [])
     entitlements_found, entitlements_not_found = get_valid_entitlement_names(
-        names
+        names, cfg
     )
     ret = True
 
     for ent_name in entitlements_found:
-        ent_cls = entitlements.entitlement_factory(ent_name)
+        ent_cls = entitlements.entitlement_factory(cfg=cfg, name=ent_name)
         ent = ent_cls(cfg, assume_yes=args.assume_yes)
 
         ret &= _perform_disable(ent, cfg, assume_yes=args.assume_yes)
@@ -1010,7 +1020,7 @@ def action_disable(args, *, cfg, **kwargs):
     if entitlements_not_found:
         valid_names = (
             "Try "
-            + ", ".join(entitlements.valid_services(allow_beta=True))
+            + ", ".join(entitlements.valid_services(cfg=cfg, allow_beta=True))
             + "."
         )
         service_msg = "\n".join(
@@ -1032,13 +1042,15 @@ def action_disable(args, *, cfg, **kwargs):
 
 
 def _create_enable_entitlements_not_found_message(
-    entitlements_not_found, *, allow_beta: bool
+    entitlements_not_found, cfg: config.UAConfig, *, allow_beta: bool
 ) -> messages.NamedMessage:
     """
     Constructs the MESSAGE_INVALID_SERVICE_OP_FAILURE message
     based on the attempted services and valid services.
     """
-    valid_services_names = entitlements.valid_services(allow_beta=allow_beta)
+    valid_services_names = entitlements.valid_services(
+        cfg=cfg, allow_beta=allow_beta
+    )
     valid_names = ", ".join(valid_services_names)
     service_msg = "\n".join(
         textwrap.wrap(
@@ -1075,7 +1087,7 @@ def action_enable(args, *, cfg, **kwargs):
 
     names = getattr(args, "service", [])
     entitlements_found, entitlements_not_found = get_valid_entitlement_names(
-        names
+        names, cfg
     )
     ret = True
     for ent_name in entitlements_found:
@@ -1116,7 +1128,7 @@ def action_enable(args, *, cfg, **kwargs):
 
     if entitlements_not_found:
         msg = _create_enable_entitlements_not_found_message(
-            entitlements_not_found, allow_beta=args.beta
+            entitlements_not_found, cfg=cfg, allow_beta=args.beta
         )
         event.services_failed(entitlements_not_found)
         raise exceptions.UserFacingError(msg=msg.msg, msg_code=msg.name)
@@ -1325,7 +1337,7 @@ def action_attach(args, *, cfg):
         ret = 0
         if enable_services_override is not None and args.auto_enable:
             found, not_found = get_valid_entitlement_names(
-                enable_services_override
+                enable_services_override, cfg
             )
             for name in found:
                 ent_ret, reason = actions.enable_entitlement_by_name(
@@ -1437,7 +1449,7 @@ def action_collect_logs(args, *, cfg: config.UAConfig):
             results.add(output_dir, arcname="logs/")
 
 
-def get_parser():
+def get_parser(cfg: config.UAConfig):
     base_desc = __doc__
     parser = UAArgumentParser(
         prog=NAME,
@@ -1497,14 +1509,14 @@ def get_parser():
         "disable",
         help="disable a specific Ubuntu Advantage service on this machine",
     )
-    disable_parser(parser_disable)
+    disable_parser(parser_disable, cfg=cfg)
     parser_disable.set_defaults(action=action_disable)
 
     parser_enable = subparsers.add_parser(
         "enable",
         help="enable a specific Ubuntu Advantage service on this machine",
     )
-    enable_parser(parser_enable)
+    enable_parser(parser_enable, cfg=cfg)
     parser_enable.set_defaults(action=action_enable)
 
     parser_fix = subparsers.add_parser(
@@ -1525,7 +1537,7 @@ def get_parser():
         "help",
         help="show detailed information about Ubuntu Advantage services",
     )
-    help_parser(parser_help)
+    help_parser(parser_help, cfg=cfg)
     parser_help.set_defaults(action=action_help)
 
     parser_refresh = subparsers.add_parser(
@@ -1646,7 +1658,7 @@ def action_help(args, *, cfg):
     show_all = args.all
 
     if not service:
-        get_parser().print_help(show_all=show_all)
+        get_parser(cfg=cfg).print_help(show_all=show_all)
         return 0
 
     if not cfg:
@@ -1783,7 +1795,8 @@ def main_error_handler(func):
 def main(sys_argv=None):
     if not sys_argv:
         sys_argv = sys.argv
-    parser = get_parser()
+    cfg = config.UAConfig()
+    parser = get_parser(cfg=cfg)
     cli_arguments = sys_argv[1:]
     if not cli_arguments:
         parser.print_usage()
@@ -1791,7 +1804,6 @@ def main(sys_argv=None):
         sys.exit(1)
     args = parser.parse_args(args=cli_arguments)
     set_event_mode(args)
-    cfg = config.UAConfig()
 
     http_proxy = cfg.http_proxy
     https_proxy = cfg.https_proxy

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -680,7 +680,7 @@ class UAConfig:
         for resource in new_response.get("services", {}):
             resource_name = resource["name"]
             try:
-                ent_cls = entitlement_factory(resource_name)
+                ent_cls = entitlement_factory(cfg=self, name=resource_name)
             except exceptions.EntitlementNotFoundError:
                 """
                 Here we cannot know the status of a service,
@@ -755,7 +755,9 @@ class UAConfig:
             else:
                 available = status.UserFacingAvailability.UNAVAILABLE.value
             try:
-                ent_cls = entitlement_factory(resource.get("name", ""))
+                ent_cls = entitlement_factory(
+                    cfg=self, name=resource.get("name", "")
+                )
             except exceptions.EntitlementNotFoundError:
                 LOG.debug(
                     "Ignoring availability of unknown service %s"
@@ -870,10 +872,12 @@ class UAConfig:
 
         for resource in resources:
             try:
-                ent_cls = entitlement_factory(resource.get("name", ""))
+                ent_cls = entitlement_factory(
+                    cfg=self, name=resource.get("name", "")
+                )
             except exceptions.EntitlementNotFoundError:
                 continue
-            ent = ent_cls(self)
+            ent = ent_cls(cfg=self)
             response["services"].append(
                 self._attached_service_status(ent, inapplicable_resources)
             )
@@ -997,7 +1001,7 @@ class UAConfig:
         for resource in resources:
             entitlement_name = resource.get("name", "")
             try:
-                ent_cls = entitlement_factory(entitlement_name)
+                ent_cls = entitlement_factory(cfg=self, name=entitlement_name)
             except exceptions.EntitlementNotFoundError:
                 continue
             ent = ent_cls(self)
@@ -1086,7 +1090,9 @@ class UAConfig:
         for resource in resources:
             if resource["name"] == name or resource.get("presentedAs") == name:
                 try:
-                    help_ent_cls = entitlement_factory(resource["name"])
+                    help_ent_cls = entitlement_factory(
+                        cfg=self, name=resource["name"]
+                    )
                 except exceptions.EntitlementNotFoundError:
                     continue
                 help_resource = resource

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -24,11 +24,12 @@ ENTITLEMENT_CLASSES = [
 ]  # type: List[Type[UAEntitlement]]
 
 
-def entitlement_factory(name: str):
+def entitlement_factory(cfg: UAConfig, name: str):
     """Returns a UAEntitlement class based on the provided name.
 
     The return type is Optional[Type[UAEntitlement]].
     It cannot be explicit because of the Python version on Xenial (3.5.2).
+    :param cfg: UAConfig instance
     :param name: The name of the entitlement to return
     :param not_found_okay: If True and no entitlement with the given name is
         found, then returns None.
@@ -36,21 +37,21 @@ def entitlement_factory(name: str):
         entitlement with the given name is found, then raises this error.
     """
     for entitlement in ENTITLEMENT_CLASSES:
-        if name in entitlement().valid_names:
+        if name in entitlement(cfg=cfg).valid_names:
             return entitlement
     raise EntitlementNotFoundError()
 
 
 def valid_services(
-    allow_beta: bool = False, all_names: bool = False
+    cfg: UAConfig, allow_beta: bool = False, all_names: bool = False
 ) -> List[str]:
     """Return a list of valid (non-beta) services.
 
-    @param allow_beta: if we should allow beta services to be marked as valid
-    @param all_names: if we should return all the names for a service instead
+    :param cfg: UAConfig instance
+    :param allow_beta: if we should allow beta services to be marked as valid
+    :param all_names: if we should return all the names for a service instead
         of just the presentation_name
     """
-    cfg = UAConfig()
     allow_beta_cfg = is_config_value_true(cfg.cfg, "features.allow_beta")
     allow_beta |= allow_beta_cfg
 
@@ -65,10 +66,13 @@ def valid_services(
     if all_names:
         names = []
         for entitlement in entitlements:
-            names.extend(entitlement().valid_names)
+            names.extend(entitlement(cfg=cfg).valid_names)
 
         return sorted(names)
 
     return sorted(
-        [entitlement().presentation_name for entitlement in entitlements]
+        [
+            entitlement(cfg=cfg).presentation_name
+            for entitlement in entitlements
+        ]
     )

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -363,7 +363,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         for service in services:
             try:
-                ent_cls = entitlement_factory(service)
+                ent_cls = entitlement_factory(cfg=self.cfg, name=service)
             except EntitlementNotFoundError:
                 continue
             ent_status, _ = ent_cls(self.cfg).application_status()
@@ -396,7 +396,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         for required_service in self.required_services:
             try:
-                ent_cls = entitlement_factory(required_service)
+                ent_cls = entitlement_factory(
+                    cfg=self.cfg, name=required_service
+                )
                 ent_status, _ = ent_cls(self.cfg).application_status()
                 if ent_status != status.ApplicationStatus.ENABLED:
                     return False
@@ -494,7 +496,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         for required_service in self.required_services:
             try:
-                ent_cls = entitlement_factory(required_service)
+                ent_cls = entitlement_factory(
+                    cfg=self.cfg, name=required_service
+                )
             except exceptions.EntitlementNotFoundError:
                 msg = messages.REQUIRED_SERVICE_NOT_FOUND.format(
                     service=required_service
@@ -656,7 +660,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         for dependent_service in self.dependent_services:
             try:
-                ent_cls = entitlement_factory(dependent_service)
+                ent_cls = entitlement_factory(
+                    cfg=self.cfg, name=dependent_service
+                )
             except exceptions.EntitlementNotFoundError:
                 msg = messages.DEPENDENT_SERVICE_NOT_FOUND.format(
                     service=dependent_service

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -11,7 +11,12 @@ class TestValidServices:
     @pytest.mark.parametrize("is_beta", ((True), (False)))
     @mock.patch("uaclient.entitlements.is_config_value_true")
     def test_valid_services(
-        self, m_is_config_value, show_all_names, allow_beta, is_beta
+        self,
+        m_is_config_value,
+        show_all_names,
+        allow_beta,
+        is_beta,
+        FakeConfig,
     ):
         m_is_config_value.return_value = allow_beta
 
@@ -39,12 +44,12 @@ class TestValidServices:
                 expected_services.append("othername")
 
             assert expected_services == entitlements.valid_services(
-                all_names=show_all_names
+                cfg=FakeConfig(), all_names=show_all_names
             )
 
 
 class TestEntitlementFactory:
-    def test_entitlement_factory(self):
+    def test_entitlement_factory(self, FakeConfig):
         m_cls_1 = mock.MagicMock()
         m_cls_1.return_value.valid_names = ["ent1", "othername"]
 
@@ -52,9 +57,14 @@ class TestEntitlementFactory:
         m_cls_2.return_value.valid_names = ["ent2"]
 
         ents = {m_cls_1, m_cls_2}
+        cfg = FakeConfig()
 
         with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
-            assert m_cls_1 == entitlements.entitlement_factory("othername")
-            assert m_cls_2 == entitlements.entitlement_factory("ent2")
+            assert m_cls_1 == entitlements.entitlement_factory(
+                cfg=cfg, name="othername"
+            )
+            assert m_cls_2 == entitlements.entitlement_factory(
+                cfg=cfg, name="ent2"
+            )
         with pytest.raises(exceptions.EntitlementNotFoundError):
-            entitlements.entitlement_factory("nonexistent")
+            entitlements.entitlement_factory(cfg=cfg, name="nonexistent")

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -206,13 +206,13 @@ def write_apt_and_motd_templates(cfg: config.UAConfig, series: str) -> None:
     no_warranty_file = ExternalMessage.UBUNTU_NO_WARRANTY.value
     msg_dir = os.path.join(cfg.data_dir, "messages")
 
-    apps_cls = entitlements.entitlement_factory("esm-apps")
+    apps_cls = entitlements.entitlement_factory(cfg=cfg, name="esm-apps")
     apps_inst = apps_cls(cfg)
     config_allow_beta = util.is_config_value_true(
         config=cfg.cfg, path_to_value="features.allow_beta"
     )
     apps_valid = bool(config_allow_beta or not apps_cls.is_beta)
-    infra_cls = entitlements.entitlement_factory("esm-infra")
+    infra_cls = entitlements.entitlement_factory(cfg=cfg, name="esm-infra")
     infra_inst = infra_cls(cfg)
 
     expiry_status, remaining_days = get_contract_expiry_status(cfg)
@@ -292,7 +292,7 @@ def write_esm_announcement_message(cfg: config.UAConfig, series: str) -> None:
     :param cfg: UAConfig instance for this environment.
     :param series: string of Ubuntu release series: 'xenial'.
     """
-    apps_cls = entitlements.entitlement_factory("esm-apps")
+    apps_cls = entitlements.entitlement_factory(cfg=cfg, name="esm-apps")
     apps_inst = apps_cls(cfg)
     enabled_status = ApplicationStatus.ENABLED
     apps_not_enabled = apps_inst.application_status()[0] != enabled_status

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -801,7 +801,7 @@ def _get_service_for_pocket(pocket: str, cfg: UAConfig):
     elif pocket == UA_APPS_POCKET:
         service_to_check = "esm-apps"
 
-    ent_cls = entitlement_factory(service_to_check)
+    ent_cls = entitlement_factory(cfg=cfg, name=service_to_check)
     return ent_cls(cfg) if ent_cls else None
 
 

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -628,53 +628,59 @@ class TestParser:
         parser = attach_parser(mock.Mock())
         assert "Flags" == parser._optionals.title
 
-    def test_attach_parser_stores_token(self, _m_resources):
-        full_parser = get_parser()
+    def test_attach_parser_stores_token(self, _m_resources, FakeConfig):
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "attach", "token"]):
             args = full_parser.parse_args()
         assert "token" == args.token
 
-    def test_attach_parser_allows_empty_required_token(self, _m_resources):
+    def test_attach_parser_allows_empty_required_token(
+        self, _m_resources, FakeConfig
+    ):
         """Token required but parse_args allows none due to action_attach"""
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "attach"]):
             args = full_parser.parse_args()
         assert None is args.token
 
     def test_attach_parser_help_points_to_ua_contract_dashboard_url(
-        self, _m_resources, capsys
+        self, _m_resources, capsys, FakeConfig
     ):
         """Contracts' dashboard URL is referenced by ua attach --help."""
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "attach", "--help"]):
             with pytest.raises(SystemExit):
                 full_parser.parse_args()
         assert UA_AUTH_TOKEN_URL in capsys.readouterr()[0]
 
     def test_attach_parser_accepts_and_stores_no_auto_enable(
-        self, _m_resources
+        self, _m_resources, FakeConfig
     ):
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch(
             "sys.argv", ["ua", "attach", "--no-auto-enable", "token"]
         ):
             args = full_parser.parse_args()
         assert not args.auto_enable
 
-    def test_attach_parser_defaults_to_auto_enable(self, _m_resources):
-        full_parser = get_parser()
+    def test_attach_parser_defaults_to_auto_enable(
+        self, _m_resources, FakeConfig
+    ):
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "attach", "token"]):
             args = full_parser.parse_args()
         assert args.auto_enable
 
-    def test_attach_parser_default_to_cli_format(self, _m_resources):
-        full_parser = get_parser()
+    def test_attach_parser_default_to_cli_format(
+        self, _m_resources, FakeConfig
+    ):
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "attach", "token"]):
             args = full_parser.parse_args()
         assert "cli" == args.format
 
-    def test_attach_parser_accepts_format_flag(self, _m_resources):
-        full_parser = get_parser()
+    def test_attach_parser_accepts_format_flag(self, _m_resources, FakeConfig):
+        full_parser = get_parser(FakeConfig())
         with mock.patch(
             "sys.argv", ["ua", "attach", "token", "--format", "json"]
         ):

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -274,14 +274,16 @@ class TestActionAutoAttach:
 
 class TestParser:
     @mock.patch(M_PATH + "contract.get_available_resources")
-    def test_auto_attach_parser_updates_parser_config(self, _m_resources):
+    def test_auto_attach_parser_updates_parser_config(
+        self, _m_resources, FakeConfig
+    ):
         """Update the parser configuration for 'auto-attach'."""
         m_parser = auto_attach_parser(mock.Mock())
         assert "ua auto-attach [flags]" == m_parser.usage
         assert "auto-attach" == m_parser.prog
         assert "Flags" == m_parser._optionals.title
 
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "auto-attach"]):
             args = full_parser.parse_args()
         assert "auto-attach" == args.command

--- a/uaclient/tests/test_cli_collect_logs.py
+++ b/uaclient/tests/test_cli_collect_logs.py
@@ -124,13 +124,15 @@ class TestActionCollectLogs:
 
 class TestParser:
     @mock.patch(M_PATH + "contract.get_available_resources")
-    def test_collect_logs_parser_updates_parser_config(self, _m_resources):
+    def test_collect_logs_parser_updates_parser_config(
+        self, _m_resources, FakeConfig
+    ):
         """Update the parser configuration for 'collect-logs'."""
         m_parser = collect_logs_parser(mock.Mock())
         assert "ua collect-logs [flags]" == m_parser.usage
         assert "collect-logs" == m_parser.prog
 
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "collect-logs"]):
             args = full_parser.parse_args()
         assert "collect-logs" == args.command

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -426,24 +426,28 @@ class TestParser:
         assert "Flags" == parser._optionals.title
 
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_detach_parser_accepts_and_stores_assume_yes(self, _m_resources):
-        full_parser = get_parser()
+    def test_detach_parser_accepts_and_stores_assume_yes(
+        self, _m_resources, FakeConfig
+    ):
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "detach", "--assume-yes"]):
             args = full_parser.parse_args()
 
         assert args.assume_yes
 
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_detach_parser_defaults_to_not_assume_yes(self, _m_resources):
-        full_parser = get_parser()
+    def test_detach_parser_defaults_to_not_assume_yes(
+        self, _m_resources, FakeConfig
+    ):
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "detach"]):
             args = full_parser.parse_args()
 
         assert not args.assume_yes
 
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_detach_parser_with_json_format(self, _m_resources):
-        full_parser = get_parser()
+    def test_detach_parser_with_json_format(self, _m_resources, FakeConfig):
+        full_parser = get_parser(FakeConfig())
         with mock.patch("sys.argv", ["ua", "detach", "--format", "json"]):
             args = full_parser.parse_args()
 

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -6,12 +6,23 @@ import textwrap
 import mock
 import pytest
 
-from uaclient import entitlements, event_logger, exceptions, messages, status
+from uaclient import (
+    config,
+    entitlements,
+    event_logger,
+    exceptions,
+    messages,
+    status,
+)
 from uaclient.cli import action_disable, main, main_error_handler
 
 ALL_SERVICE_MSG = "\n".join(
     textwrap.wrap(
-        "Try " + ", ".join(entitlements.valid_services(allow_beta=True)) + ".",
+        "Try "
+        + ", ".join(
+            entitlements.valid_services(cfg=config.UAConfig(), allow_beta=True)
+        )
+        + ".",
         width=80,
         break_long_words=False,
         break_on_hyphens=False,
@@ -95,7 +106,7 @@ class TestDisable:
                 return_value=entitlement_name
             )
 
-        def factory_side_effect(name, ent_dict=ent_dict):
+        def factory_side_effect(cfg, name, ent_dict=ent_dict):
             return ent_dict.get(name)
 
         m_entitlement_factory.side_effect = factory_side_effect
@@ -200,7 +211,7 @@ class TestDisable:
         m_ent3_obj.disable.return_value = (True, None)
         type(m_ent3_obj).name = mock.PropertyMock(return_value="ent3")
 
-        def factory_side_effect(name):
+        def factory_side_effect(cfg, name):
             if name == "ent2":
                 return m_ent2_cls
             if name == "ent3":

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -239,7 +239,9 @@ class TestActionEnable:
                     (
                         "Try "
                         + ", ".join(
-                            entitlements.valid_services(allow_beta=True)
+                            entitlements.valid_services(
+                                cfg=cfg, allow_beta=True
+                            )
                         )
                         + "."
                     ),
@@ -438,7 +440,7 @@ class TestActionEnable:
         m_ent3_obj = m_ent3_cls.return_value
         m_ent3_obj.enable.return_value = (True, None)
 
-        def factory_side_effect(name, not_found_okay=True):
+        def factory_side_effect(cfg, name, not_found_okay=True):
             if name == "ent2":
                 return m_ent2_cls
             if name == "ent3":
@@ -566,7 +568,7 @@ class TestActionEnable:
         args_mock.assume_yes = assume_yes
         args_mock.beta = beta_flag
 
-        def factory_side_effect(name, not_found_okay=True):
+        def factory_side_effect(cfg, name, not_found_okay=True):
             if name == "ent2":
                 return m_ent2_cls
             if name == "ent3":
@@ -575,7 +577,7 @@ class TestActionEnable:
 
         m_entitlement_factory.side_effect = factory_side_effect
 
-        def valid_services_side_effect(allow_beta, all_names=False):
+        def valid_services_side_effect(cfg, allow_beta, all_names=False):
             if allow_beta:
                 return ["ent2", "ent3"]
             return ["ent2"]
@@ -587,7 +589,7 @@ class TestActionEnable:
         mock_ent_list = [m_ent3_cls]
         mock_obj_list = [m_ent3_obj]
 
-        service_names = entitlements.valid_services(allow_beta=beta_flag)
+        service_names = entitlements.valid_services(cfg, allow_beta=beta_flag)
         ent_str = "Try " + ", ".join(service_names) + "."
         if not beta_flag:
             not_found_name += ", ent2"
@@ -766,7 +768,7 @@ class TestActionEnable:
 
         assert expected_msg == fake_stdout.getvalue()
 
-        service_names = entitlements.valid_services(allow_beta=beta)
+        service_names = entitlements.valid_services(cfg=cfg, allow_beta=beta)
         ent_str = "Try " + ", ".join(service_names) + "."
         service_msg = "\n".join(
             textwrap.wrap(

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -105,12 +105,14 @@ class TestActionSecurityStatus:
 
 class TestParser:
     @mock.patch(M_PATH + "contract.get_available_resources")
-    def test_security_status_parser_updates_parser_config(self, _m_resources):
+    def test_security_status_parser_updates_parser_config(
+        self, _m_resources, FakeConfig
+    ):
         """Update the parser configuration for 'security-status'."""
         m_parser = security_status_parser(mock.Mock())
         assert "security-status" == m_parser.prog
 
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch(
             "sys.argv", ["ua", "security-status", "--format", "json"]
         ):

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -968,12 +968,14 @@ class TestActionStatus:
 
 class TestStatusParser:
     @mock.patch(M_PATH + "contract.get_available_resources")
-    def test_status_parser_updates_parser_config(self, _m_resources):
+    def test_status_parser_updates_parser_config(
+        self, _m_resources, FakeConfig
+    ):
         """Update the parser configuration for 'status'."""
         m_parser = status_parser(mock.Mock())
         assert "status" == m_parser.prog
 
-        full_parser = get_parser()
+        full_parser = get_parser(FakeConfig())
         with mock.patch(
             "sys.argv",
             [

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -59,19 +59,19 @@ DEFAULT_CFG_STATUS = {
 
 ALL_RESOURCES_AVAILABLE = [
     {"name": name, "available": True}
-    for name in valid_services(allow_beta=True)
+    for name in valid_services(cfg=UAConfig(), allow_beta=True)
 ]
 ALL_RESOURCES_ENTITLED = [
     {"type": name, "entitled": True}
-    for name in valid_services(allow_beta=True)
+    for name in valid_services(cfg=UAConfig(), allow_beta=True)
 ]
 NO_RESOURCES_ENTITLED = [
     {"type": name, "entitled": False}
-    for name in valid_services(allow_beta=True)
+    for name in valid_services(cfg=UAConfig(), allow_beta=True)
 ]
 RESP_ONLY_FIPS_RESOURCE_AVAILABLE = [
     {"name": name, "available": name == "fips"}
-    for name in valid_services(allow_beta=True)
+    for name in valid_services(cfg=UAConfig(), allow_beta=True)
 ]
 
 
@@ -719,8 +719,10 @@ class TestDeleteCache:
 @mock.patch("uaclient.config.UAConfig.remove_notice")
 @mock.patch("uaclient.util.should_reboot", return_value=False)
 class TestStatus:
-    esm_desc = entitlement_factory("esm-infra").description
-    ros_desc = entitlement_factory("ros").description
+    esm_desc = entitlement_factory(
+        cfg=UAConfig(), name="esm-infra"
+    ).description
+    ros_desc = entitlement_factory(cfg=UAConfig(), name="ros").description
 
     def check_beta(self, cls, show_beta, uacfg=None, status=""):
         if not show_beta:

--- a/uaclient/tests/test_update_messaging.py
+++ b/uaclient/tests/test_update_messaging.py
@@ -102,7 +102,7 @@ class TestWriteAPTAndMOTDTemplates:
         infra_obj.application_status.return_value = (infra_status, "")
         infra_obj.name = "esm-infra"
 
-        def factory_side_effect(name):
+        def factory_side_effect(cfg, name):
             if name == "esm-infra":
                 return infra_cls
             if name == "esm-apps":
@@ -192,7 +192,7 @@ class TestWriteAPTAndMOTDTemplates:
         apps_obj = apps_cls.return_value
         apps_obj.name = "esm-apps"
 
-        def factory_side_effect(name):
+        def factory_side_effect(cfg, name):
             if name == "esm-infra":
                 return infra_cls
             if name == "esm-apps":


### PR DESCRIPTION
## Proposed Commit Message
Remove unnecessary creation of UAConfig instances

Creating an UAConfig instance can be an expansive operation that can be avoided if we share the instance we create for every cli call throught the code. We are refactoring the code to allow that reuse of the instance when possible

I have tested this work to see if we would get any speedup when running some UA commands:
`ua status` from around 2.5s to 2.0s
`ua attach` form around 17s to 16.2s

Tests were performed with a bionic LXD container running both commands around 3 times using the latest package of UA and another with the config refactor applied.

## Test Steps
Run the integration steps for attach/enable/disable/deach and verify that the package doesn't break and that it still work as expected

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
