### PR TITLE
fips: enable fips-update on fips-pro

### DIFF
--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -97,6 +97,38 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         \s*\*\*\* .* 500
         \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
+        When I run `ua enable fips-updates --assume-yes` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Disabling incompatible service: FIPS
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install.
+            """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+            """
+            fips          +yes +n/a +NIST-certified core packages
+            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+            """
+        When I reboot the `<release>` machine
+        And I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            <fips-kernel-version>
+            """
+        When I run `apt-cache policy ubuntu-azure-fips` as non-root
+        Then stdout does not match regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
 
         Examples: ubuntu release
            | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
@@ -273,12 +305,44 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         \s*\*\*\* .* 500
         \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
+        When I run `ua enable fips-updates --assume-yes` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Disabling incompatible service: FIPS
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install.
+            """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+            """
+            fips          +yes +n/a +NIST-certified core packages
+            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+            """
+        When I reboot the `<release>` machine
+        And I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            <fips-kernel-version>
+            """
+        When I run `apt-cache policy ubuntu-aws-fips` as non-root
+        Then stdout does not match regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
 
         Examples: ubuntu release
            | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
            | xenial  | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
            | bionic  | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            |
-           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips          |
+           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
 
     @series.focal
     @uses.config.machine_type.aws.pro.fips

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -376,6 +376,9 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         "openssl",
         "strongswan",
         "strongswan-hmac",
+        "libgcrypt20",
+        "libgcrypt20-hmac",
+        "fips-initramfs-generic",
     ]
 
     @property

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1097,6 +1097,10 @@ class TestFipsSetupAPTConfig:
                 "openssh-server\nlibssl1.1-hmac\nasdf\n",
                 ["openssh-server", "libssl1.1-hmac"],
             ),
+            (
+                "libgcrypt20\nlibgcrypt20-hmac\nwow\n",
+                ["libgcrypt20", "libgcrypt20-hmac"],
+            ),
         ),
     )
     @mock.patch(M_REPOPATH + "RepoEntitlement.setup_apt_config")


### PR DESCRIPTION
fips: enable fips-update on fips-pro

A fips pro machine could not enable fips-updates. After testing, unholding these two libgcrypt packages helped solve this issue.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
