### PR TITLE
Add package counts for different components

### DIFF
--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -31,6 +31,24 @@
         "num_installed_packages": {
           "type": "integer"
         },
+        "num_installed_packages_main": {
+          "type": "integer"
+        },
+        "num_installed_packages_multiverse": {
+          "type": "integer"
+        },
+        "num_installed_packages_restricted": {
+          "type": "integer"
+        },
+        "num_installed_packages_universe": {
+          "type": "integer"
+        },
+        "num_installed_packages_third_party": {
+          "type": "integer"
+        },
+        "num_installed_packages_unavailable": {
+          "type": "integer"
+        },
         "num_esm_infra_packages": {
           "type": "integer"
         },

--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -46,7 +46,7 @@
         "num_installed_packages_third_party": {
           "type": "integer"
         },
-        "num_installed_packages_unavailable": {
+        "num_installed_packages_unknown": {
           "type": "integer"
         },
         "num_esm_infra_packages": {
@@ -66,7 +66,7 @@
         }
       }
     },
-    "packages": {
+    "updates": {
       "type": "array",
       "items": {
         "type": "object",

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -415,10 +415,25 @@ def fix_parser(parser):
 def security_status_parser(parser):
     """Build or extend an arg parser for security-status subcommand."""
     parser.prog = "security-status"
-    parser.description = (
-        "Show security updates for packages in the system, including all"
-        " available ESM related content."
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    parser.description = textwrap.dedent(
+        """\
+        Show security updates for packages in the system, including all
+        available ESM related content.
+
+        Besides the list of security updates, it also shows a summary of the
+        installed packages based on the origin.
+        - main/restricted/universe/multiverse: packages from the Ubuntu archive
+        - ESM Infra/Apps: packages from ESM
+        - third-party: packages installed from non-Ubuntu sources
+        - unknown: packages which don't have an installation source (like local
+          deb packages or packages for which the source was removed)
+
+        The summary contains basic information about UA and ESM. For a complete
+        status on UA services, run 'ua status'
+        """
     )
+
     parser.add_argument(
         "--format",
         help=("Format for the output (json or yaml)"),

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -32,7 +32,7 @@ def get_origin_for_package(package: apt_package.Package) -> str:
     available_origins = package.installed.origins
     if len(package.installed.origins) == 1:
         if package.installed == package.candidate:
-            return "unavailable"
+            return "unknown"
         available_origins = package.candidate.origins
 
     for origin in available_origins:
@@ -128,7 +128,7 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
     ua_info = get_ua_info(cfg)
 
     summary = {"ua": ua_info}  # type: Dict[str, Any]
-    packages = []
+    updates = []
     cache = Cache()
 
     installed_packages = [package for package in cache if package.is_installed]
@@ -147,7 +147,7 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
         service_name, origin_site = get_service_name(candidate.origins)
         status = get_update_status(service_name, ua_info)
         update_count[service_name] += 1
-        packages.append(
+        updates.append(
             {
                 "package": candidate.package.name,
                 "version": candidate.version,
@@ -164,9 +164,7 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
     summary["num_installed_packages_third_party"] = package_count[
         "third-party"
     ]
-    summary["num_installed_packages_unavailable"] = package_count[
-        "unavailable"
-    ]
+    summary["num_installed_packages_unknown"] = package_count["unknown"]
     summary["num_esm_infra_packages"] = package_count["esm-infra"]
     summary["num_esm_apps_packages"] = package_count["esm-apps"]
     summary["num_esm_infra_updates"] = update_count["esm-infra"]
@@ -175,4 +173,4 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
         "standard-security"
     ]
 
-    return {"_schema_version": "0.1", "summary": summary, "packages": packages}
+    return {"_schema_version": "0.1", "summary": summary, "updates": updates}

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -12,14 +12,11 @@ series = get_platform_info()["series"]
 
 ESM_SERVICES = ("esm-infra", "esm-apps")
 
-SERVICE_TO_ORIGIN_INFORMATION = {
-    "standard-security": ("Ubuntu", "{}-security".format(series)),
-    "esm-apps": ("UbuntuESMApps", "{}-apps-security".format(series)),
-    "esm-infra": ("UbuntuESM", "{}-infra-security".format(series)),
-}
 
 ORIGIN_INFORMATION_TO_SERVICE = {
-    v: k for k, v in SERVICE_TO_ORIGIN_INFORMATION.items()
+    ("Ubuntu", "{}-security".format(series)): "standard-security",
+    ("UbuntuESMApps", "{}-apps-security".format(series)): "esm-apps",
+    ("UbuntuESM", "{}-infra-security".format(series)): "esm-infra",
 }
 
 
@@ -34,14 +31,11 @@ class UpdateStatus(Enum):
 def list_esm_for_package(package: apt_package.Package) -> List[str]:
     esm_services = []
     for origin in package.installed.origins:
-        if (origin.origin, origin.archive) == SERVICE_TO_ORIGIN_INFORMATION[
-            "esm-infra"
-        ]:
-            esm_services.append("esm-infra")
-        if (origin.origin, origin.archive) == SERVICE_TO_ORIGIN_INFORMATION[
-            "esm-apps"
-        ]:
-            esm_services.append("esm-apps")
+        service = ORIGIN_INFORMATION_TO_SERVICE.get(
+            (origin.origin, origin.archive), ""
+        )
+        if service in ESM_SERVICES:
+            esm_services.append(service)
     return esm_services
 
 

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -28,15 +28,23 @@ class UpdateStatus(Enum):
     UNAVAILABLE = "upgrade_unavailable"
 
 
-def list_esm_for_package(package: apt_package.Package) -> List[str]:
-    esm_services = []
-    for origin in package.installed.origins:
+def get_origin_for_package(package: apt_package.Package) -> str:
+    available_origins = package.installed.origins
+    if len(package.installed.origins) == 1:
+        if package.installed == package.candidate:
+            return "unavailable"
+        available_origins = package.candidate.origins
+
+    for origin in available_origins:
         service = ORIGIN_INFORMATION_TO_SERVICE.get(
             (origin.origin, origin.archive), ""
         )
         if service in ESM_SERVICES:
-            esm_services.append(service)
-    return esm_services
+            return service
+        if origin.origin == "Ubuntu":
+            return origin.component
+
+    return "third-party"
 
 
 def get_service_name(origins: List[apt_package.Origin]) -> Tuple[str, str]:
@@ -69,7 +77,7 @@ def get_update_status(service_name: str, ua_info: Dict[str, Any]) -> str:
 
 def filter_security_updates(
     packages: List[apt_package.Package],
-) -> List[apt_package.Package]:
+) -> List[apt_package.Version]:
     """Filters a list of packages looking for available security updates.
 
     Checks if the package has a greater version available, and if the origin of
@@ -130,9 +138,8 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
     update_count = defaultdict(int)  # type: DefaultDict[str, int]
 
     for package in installed_packages:
-        esm_services = list_esm_for_package(package)
-        for service in esm_services:
-            package_count[service] += 1
+        package_origin = get_origin_for_package(package)
+        package_count[package_origin] += 1
 
     security_upgradable_versions = filter_security_updates(installed_packages)
 
@@ -150,6 +157,16 @@ def security_status(cfg: UAConfig) -> Dict[str, Any]:
             }
         )
 
+    summary["num_installed_packages_main"] = package_count["main"]
+    summary["num_installed_packages_restricted"] = package_count["restricted"]
+    summary["num_installed_packages_universe"] = package_count["universe"]
+    summary["num_installed_packages_multiverse"] = package_count["multiverse"]
+    summary["num_installed_packages_third_party"] = package_count[
+        "third-party"
+    ]
+    summary["num_installed_packages_unavailable"] = package_count[
+        "unavailable"
+    ]
     summary["num_esm_infra_packages"] = package_count["esm-infra"]
     summary["num_esm_apps_packages"] = package_count["esm-apps"]
     summary["num_esm_infra_updates"] = update_count["esm-infra"]

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -17,8 +17,19 @@ HELP_OUTPUT = textwrap.dedent(
     """\
 usage: security-status \[-h\] --format {json,yaml}
 
-Show security updates for packages in the system, including all available ESM
-related content.
+Show security updates for packages in the system, including all
+available ESM related content.
+
+Besides the list of security updates, it also shows a summary of the
+installed packages based on the origin.
+- main/restricted/universe/multiverse: packages from the Ubuntu archive
+- ESM Infra/Apps: packages from ESM
+- third-party: packages installed from non-Ubuntu sources
+- unknown: packages which don't have an installation source \(like local
+  deb packages or packages for which the source was removed\)
+
+The summary contains basic information about UA and ESM. For a complete
+status on UA services, run 'ua status'
 
 (optional arguments|options):
   -h, --help            show this help message and exit

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -1,10 +1,13 @@
-from typing import List, Tuple
+from typing import List, Optional
 
 import mock
 import pytest
 
 from uaclient.security_status import (
     UpdateStatus,
+    filter_security_updates,
+    get_origin_for_package,
+    get_service_name,
     get_ua_info,
     get_update_status,
     security_status,
@@ -13,51 +16,77 @@ from uaclient.security_status import (
 M_PATH = "uaclient.security_status."
 
 
-# Each candidate/installed is a tuple of (version, archive, origin, site)
+def mock_origin(
+    component: str, archive: str, origin: str, site: str
+) -> mock.MagicMock:
+    mock_origin = mock.MagicMock()
+    mock_origin.component = component
+    mock_origin.archive = archive
+    mock_origin.origin = origin
+    mock_origin.site = site
+    return mock_origin
+
+
+def mock_version(
+    version: str, origin_list: List[mock.MagicMock] = []
+) -> mock.MagicMock:
+    mock_version = mock.MagicMock()
+    mock_version.__gt__ = lambda self, other: self.version > other.version
+    mock_version.version = version
+    mock_version.origins = origin_list
+    return mock_version
+
+
 def mock_package(
-    name,
-    installed: Tuple[str, str, str, str] = None,
-    candidates: List[Tuple[str, str, str, str]] = [],
+    name: str,
+    installed_version: Optional[mock.MagicMock] = None,
+    other_versions: List[mock.MagicMock] = [],
 ):
     mock_package = mock.MagicMock()
     mock_package.name = name
     mock_package.versions = []
-    mock_package.is_installed = bool(installed)
+    mock_package.is_installed = bool(installed_version)
 
-    if installed:
-        mock_installed = mock.MagicMock()
-        mock_installed.__gt__ = (
-            lambda self, other: self.version > other.version
-        )
-        mock_installed.version = installed[0]
+    if installed_version:
+        mock_package.installed = installed_version
+        installed_version.package = mock_package
+        mock_package.versions.append(installed_version)
 
-        mock_origin = mock.MagicMock()
-        mock_origin.archive = installed[1]
-        mock_origin.origin = installed[2]
-        mock_origin.site = installed[3]
-        mock_installed.origins = [mock_origin]
+    for version in other_versions:
+        version.package = mock_package
+        mock_package.versions.append(version)
 
-        mock_package.installed = mock_installed
-        mock_package.versions.append(mock_installed)
-
-    for candidate in candidates:
-        mock_candidate = mock.MagicMock()
-        mock_candidate.__gt__ = (
-            lambda self, other: self.version > other.version
-        )
-
-        mock_candidate.package = mock_package
-        mock_candidate.version = candidate[0]
-
-        mock_origin = mock.MagicMock()
-        mock_origin.archive = candidate[1]
-        mock_origin.origin = candidate[2]
-        mock_origin.site = candidate[3]
-        mock_candidate.origins = [mock_origin]
-
-        mock_package.versions.append(mock_candidate)
+    if mock_package.versions:
+        mock_package.candidate = max(mock_package.versions)
 
     return mock_package
+
+
+MOCK_ORIGINS = {
+    "now": mock_origin("now", "now", "", ""),
+    "third-party": mock_origin("main", "", "other", "some.other.site"),
+    "infra": mock_origin(
+        "main", "example-infra-security", "UbuntuESM", "esm.ubuntu.com"
+    ),
+    "apps": mock_origin(
+        "main", "example-apps-security", "UbuntuESMApps", "esm.ubuntu.com"
+    ),
+    "standard-security": mock_origin(
+        "main", "example-security", "Ubuntu", "security.ubuntu.com"
+    ),
+    "archive_main": mock_origin(
+        "main", "example-updates", "Ubuntu", "archive.ubuntu.com"
+    ),
+    "archive_universe": mock_origin(
+        "universe", "example-updates", "Ubuntu", "archive.ubuntu.com"
+    ),
+}
+
+ORIGIN_TO_SERVICE_MOCK = {
+    ("UbuntuESM", "example-infra-security"): "esm-infra",
+    ("Ubuntu", "example-security"): "standard-security",
+    ("UbuntuESMApps", "example-apps-security"): "esm-apps",
+}
 
 
 class TestSecurityStatus:
@@ -130,102 +159,192 @@ class TestSecurityStatus:
                 "entitled_services": [],
             }
 
-    @mock.patch(M_PATH + "UAConfig.status", return_value={"attached": False})
-    @mock.patch(M_PATH + "Cache")
-    def test_finds_updates_for_installed_packages(
-        self, m_cache, _m_status, FakeConfig
+    @pytest.mark.parametrize(
+        "installed_version,other_versions,expected_output",
+        (
+            (mock_version("1.0", [MOCK_ORIGINS["now"]]), [], "unavailable"),
+            (
+                mock_version("2.0", [MOCK_ORIGINS["now"]]),
+                [mock_version("1.0", [MOCK_ORIGINS["archive_main"]])],
+                "unavailable",
+            ),
+            (
+                mock_version("2.0", [MOCK_ORIGINS["now"]]),
+                [mock_version("3.0", [MOCK_ORIGINS["archive_main"]])],
+                "main",
+            ),
+            (
+                mock_version(
+                    "1.0", [MOCK_ORIGINS["infra"], MOCK_ORIGINS["now"]]
+                ),
+                [],
+                "esm-infra",
+            ),
+            (
+                mock_version(
+                    "1.0", [MOCK_ORIGINS["apps"], MOCK_ORIGINS["now"]]
+                ),
+                [],
+                "esm-apps",
+            ),
+            (
+                mock_version(
+                    "1.0", [MOCK_ORIGINS["archive_main"], MOCK_ORIGINS["now"]]
+                ),
+                [],
+                "main",
+            ),
+            (
+                mock_version(
+                    "1.0",
+                    [MOCK_ORIGINS["archive_universe"], MOCK_ORIGINS["now"]],
+                ),
+                [],
+                "universe",
+            ),
+            (
+                mock_version(
+                    "1.0", [MOCK_ORIGINS["third-party"], MOCK_ORIGINS["now"]]
+                ),
+                [],
+                "third-party",
+            ),
+        ),
+    )
+    def test_get_origin_for_package(
+        self, installed_version, other_versions, expected_output
     ):
-        m_cache.return_value = [
-            mock_package(name="not_installed"),
+        package_mock = mock_package(
+            "example", installed_version, other_versions
+        )
+        with mock.patch(
+            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE",
+            ORIGIN_TO_SERVICE_MOCK,
+        ):
+            assert expected_output == get_origin_for_package(package_mock)
+
+    @pytest.mark.parametrize(
+        "origins_input,expected_output",
+        (
+            ([], ("", "")),
+            ([MOCK_ORIGINS["now"]], ("", "")),
+            ([MOCK_ORIGINS["third-party"], MOCK_ORIGINS["now"]], ("", "")),
+            (
+                [MOCK_ORIGINS["infra"], MOCK_ORIGINS["now"]],
+                ("esm-infra", "esm.ubuntu.com"),
+            ),
+            (
+                [MOCK_ORIGINS["apps"], MOCK_ORIGINS["now"]],
+                ("esm-apps", "esm.ubuntu.com"),
+            ),
+            (
+                [MOCK_ORIGINS["standard-security"], MOCK_ORIGINS["now"]],
+                ("standard-security", "security.ubuntu.com"),
+            ),
+        ),
+    )
+    def test_service_name(self, origins_input, expected_output):
+        with mock.patch(
+            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE",
+            ORIGIN_TO_SERVICE_MOCK,
+        ):
+            assert expected_output == get_service_name(origins_input)
+
+    def test_filter_security_updates(self):
+        expected_return = [
+            mock_version("2.0", [MOCK_ORIGINS["infra"]]),
+            mock_version("2.0", [MOCK_ORIGINS["standard-security"]]),
+            mock_version("3.0", [MOCK_ORIGINS["apps"]]),
+        ]
+        package_list = [
+            mock_package(name="not-installed"),
             mock_package(
-                name="there_is_no_update",
-                installed=("1.0", "somewhere", "somehow", ""),
+                name="there-is-no-update",
+                installed_version=mock_version(
+                    "1.0", [MOCK_ORIGINS["now"], MOCK_ORIGINS["archive_main"]]
+                ),
             ),
             mock_package(
-                name="latest_is_installed",
-                installed=("2.0", "standard-packages", "Ubuntu", ""),
-                candidates=[
-                    (
-                        "1.0",
-                        "example-infra-security",
-                        "UbuntuESM",
-                        "some.url.for.esm",
-                    )
+                name="latest-is-installed",
+                installed_version=mock_version(
+                    "2.0", [MOCK_ORIGINS["now"], MOCK_ORIGINS["infra"]]
+                ),
+                other_versions=[mock_version("1.0", [MOCK_ORIGINS["infra"]])],
+            ),
+            mock_package(
+                name="update-available",
+                installed_version=mock_version(
+                    "1.0", [MOCK_ORIGINS["now"], MOCK_ORIGINS["archive_main"]]
+                ),
+                other_versions=[expected_return[0]],
+            ),
+            mock_package(
+                name="not-a-security-update",
+                installed_version=mock_version(
+                    "1.0", [MOCK_ORIGINS["now"], MOCK_ORIGINS["archive_main"]]
+                ),
+                other_versions=[
+                    mock_version("2.0", [MOCK_ORIGINS["archive_main"]])
                 ],
             ),
             mock_package(
-                name="update_available",
-                # this is an ESM-INFRA example for the counters
-                installed=("1.0", "example-infra-security", "UbuntuESM", ""),
-                candidates=[
-                    (
-                        "2.0",
-                        "example-infra-security",
-                        "UbuntuESM",
-                        "some.url.for.esm",
-                    )
-                ],
-            ),
-            mock_package(
-                name="not_a_security_update",
-                installed=("1.0", "somewhere", "somehow", ""),
-                candidates=[
-                    (
-                        "2.0",
-                        "example-notsecurity",
-                        "NotUbuntuESM",
-                        "some.url.for.esm",
-                    )
-                ],
-            ),
-            mock_package(
-                name="more_than_one_update_available",
-                installed=("1.0", "somewhere", "somehow", ""),
-                candidates=[
-                    (
-                        "2.0",
-                        "example-security",
-                        "Ubuntu",
-                        "some.url.for.standard",
-                    ),
-                    (
-                        "3.0",
-                        "example-infra-security",
-                        "UbuntuESM",
-                        "some.url.for.esm",
-                    ),
-                ],
+                name="more-than-one-update",
+                installed_version=mock_version(
+                    "1.0", [MOCK_ORIGINS["now"], MOCK_ORIGINS["archive_main"]]
+                ),
+                other_versions=[expected_return[1], expected_return[2]],
             ),
         ]
+        with mock.patch(
+            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE",
+            ORIGIN_TO_SERVICE_MOCK,
+        ):
+            filtered_versions = filter_security_updates(package_list)
+            assert expected_return == filtered_versions
+            assert [
+                "update-available",
+                "more-than-one-update",
+                "more-than-one-update",
+            ] == [v.package.name for v in filtered_versions]
 
-        origin_to_service_dict = {
-            ("UbuntuESM", "example-infra-security"): "esm-infra",
-            ("Ubuntu", "example-security"): "standard-security",
-            ("UbuntuESMApps", "example-apps-security"): "esm-apps",
-        }
-
+    @mock.patch(M_PATH + "UAConfig.status", return_value={"attached": False})
+    @mock.patch(
+        M_PATH + "get_service_name",
+        return_value=("esm-infra", "some.url.for.esm"),
+    )
+    @mock.patch(M_PATH + "get_origin_for_package", return_value="main")
+    @mock.patch(M_PATH + "filter_security_updates")
+    @mock.patch(M_PATH + "Cache")
+    def test_security_status_format(
+        self,
+        m_cache,
+        m_filter_sec_updates,
+        _m_get_origin,
+        _m_service_name,
+        _m_status,
+        FakeConfig,
+    ):
+        """Make sure the output format matches the expected JSON"""
         cfg = FakeConfig()
+        m_version = mock_version("1.0")
+        m_package = mock_package("example_package", m_version)
+
+        m_cache.return_value = [m_package] * 10
+        m_filter_sec_updates.return_value = [m_version] * 2
 
         expected_output = {
             "_schema_version": "0.1",
             "packages": [
                 {
-                    "package": "update_available",
-                    "version": "2.0",
+                    "package": "example_package",
+                    "version": "1.0",
                     "service_name": "esm-infra",
                     "status": "pending_attach",
                     "origin": "some.url.for.esm",
                 },
                 {
-                    "package": "more_than_one_update_available",
-                    "version": "2.0",
-                    "service_name": "standard-security",
-                    "status": "upgrade_available",
-                    "origin": "some.url.for.standard",
-                },
-                {
-                    "package": "more_than_one_update_available",
-                    "version": "3.0",
+                    "package": "example_package",
+                    "version": "1.0",
                     "service_name": "esm-infra",
                     "status": "pending_attach",
                     "origin": "some.url.for.esm",
@@ -237,17 +356,19 @@ class TestSecurityStatus:
                     "enabled_services": [],
                     "entitled_services": [],
                 },
-                "num_installed_packages": 5,
+                "num_installed_packages": 10,
+                "num_installed_packages_main": 10,
+                "num_installed_packages_restricted": 0,
+                "num_installed_packages_universe": 0,
+                "num_installed_packages_multiverse": 0,
+                "num_installed_packages_third_party": 0,
+                "num_installed_packages_unavailable": 0,
                 "num_esm_infra_updates": 2,
                 "num_esm_apps_updates": 0,
-                "num_esm_infra_packages": 1,
+                "num_esm_infra_packages": 0,
                 "num_esm_apps_packages": 0,
-                "num_standard_security_updates": 1,
+                "num_standard_security_updates": 0,
             },
         }
 
-        with mock.patch(
-            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE", origin_to_service_dict
-        ):
-            output = security_status(cfg)
-        assert output == expected_output
+        assert expected_output == security_status(cfg)

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -198,13 +198,10 @@ class TestSecurityStatus:
             ),
         ]
 
-        service_to_origin_dict = {
-            "esm-infra": ("UbuntuESM", "example-infra-security"),
-            "standard-security": ("Ubuntu", "example-security"),
-            "esm-apps": ("UbuntuESMApps", "example-apps-security"),
-        }
         origin_to_service_dict = {
-            v: k for k, v in service_to_origin_dict.items()
+            ("UbuntuESM", "example-infra-security"): "esm-infra",
+            ("Ubuntu", "example-security"): "standard-security",
+            ("UbuntuESMApps", "example-apps-security"): "esm-apps",
         }
 
         cfg = FakeConfig()
@@ -250,8 +247,6 @@ class TestSecurityStatus:
         }
 
         with mock.patch(
-            M_PATH + "SERVICE_TO_ORIGIN_INFORMATION", service_to_origin_dict
-        ), mock.patch(
             M_PATH + "ORIGIN_INFORMATION_TO_SERVICE", origin_to_service_dict
         ):
             output = security_status(cfg)

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -162,11 +162,11 @@ class TestSecurityStatus:
     @pytest.mark.parametrize(
         "installed_version,other_versions,expected_output",
         (
-            (mock_version("1.0", [MOCK_ORIGINS["now"]]), [], "unavailable"),
+            (mock_version("1.0", [MOCK_ORIGINS["now"]]), [], "unknown"),
             (
                 mock_version("2.0", [MOCK_ORIGINS["now"]]),
                 [mock_version("1.0", [MOCK_ORIGINS["archive_main"]])],
-                "unavailable",
+                "unknown",
             ),
             (
                 mock_version("2.0", [MOCK_ORIGINS["now"]]),
@@ -334,7 +334,7 @@ class TestSecurityStatus:
 
         expected_output = {
             "_schema_version": "0.1",
-            "packages": [
+            "updates": [
                 {
                     "package": "example_package",
                     "version": "1.0",
@@ -362,7 +362,7 @@ class TestSecurityStatus:
                 "num_installed_packages_universe": 0,
                 "num_installed_packages_multiverse": 0,
                 "num_installed_packages_third_party": 0,
-                "num_installed_packages_unavailable": 0,
+                "num_installed_packages_unknown": 0,
                 "num_esm_infra_updates": 2,
                 "num_esm_apps_updates": 0,
                 "num_esm_infra_packages": 0,


### PR DESCRIPTION
Add package counts based on archive components to security-status.
Show how many packages are installed from the different archive components: `main`, `universe`, etc

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
