### PR TITLE
Fips fips update correction

### DIFF
--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -278,7 +278,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
            | xenial  | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
            | bionic  | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            |
-           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips          |
+           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
 
     @series.focal
     @uses.config.machine_type.aws.pro.fips
@@ -353,3 +353,48 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | release  | fips-apt-source                                 |
            | xenial   | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
            | bionic   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
+
+    @series.lts
+    @uses.config.machine_type.aws.pro.fips
+    @uses.config.machine_type.azure.pro.fips
+    Scenario Outline: Enable fips-updates on pro fips machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        """
+        When I run `ua auto-attach` with sudo
+        And I run `ua status --wait` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            fips          +yes +enabled +NIST-certified core packages
+            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        When I run `ua enable fips-updates --assume-yes` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install.
+            """
+        When I reboot the `<release>` machine
+        And I run `ua status --all` with sudo
+        Then stdout matches regexp:
+            """
+            fips          +yes +n/a +NIST-certified core packages
+            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+            """
+
+        Examples: ubuntu release
+            | release |
+            | xenial  |
+            | bionic  |
+            | focal   |

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -376,6 +376,9 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         "openssl",
         "strongswan",
         "strongswan-hmac",
+        "libgcrypt20",
+        "libgcrypt20-hmac",
+        "fips-initramfs-generic",
     ]
 
     @property

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1098,6 +1098,10 @@ class TestFipsSetupAPTConfig:
                 "openssh-server\nlibssl1.1-hmac\nasdf\n",
                 ["openssh-server", "libssl1.1-hmac"],
             ),
+            (
+                "libgcrypt20\nlibgcrypt20-hmac\nwow\n",
+                ["libgcrypt20", "libgcrypt20-hmac"],
+            ),
         ),
     )
     @mock.patch(M_REPOPATH + "RepoEntitlement.setup_apt_config")


### PR DESCRIPTION
## Proposed Commit Message
fips: enable fips-update on fips-pro

A fips pro machine could not enable fips-updates. After testing, unholding these two libgcrypt packages helped solve this issue.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
