### PR TITLE
lib: fix upgrade script for unsupported releases

### DIFF
--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -34,7 +34,8 @@ version_to_codename = {
     "16.04": "xenial",
     "18.04": "bionic",
     "20.04": "focal",
-    "20.10": "groovy",
+    "21.10": "impish",
+    "22.04": "jammy",
 }
 
 current_codename_to_past_codename = {
@@ -42,6 +43,8 @@ current_codename_to_past_codename = {
     "bionic": "xenial",
     "focal": "bionic",
     "groovy": "focal",
+    "impish": "focal",
+    "jammy": "focal",
 }
 
 
@@ -58,7 +61,15 @@ def process_contract_delta_after_apt_lock() -> None:
     logging.debug(msg)
 
     current_version = parse_os_release()["VERSION_ID"]
-    current_release = version_to_codename[current_version]
+    current_release = version_to_codename.get(current_version)
+
+    if current_release is None:
+        msg = "Unable to get release codename for version: {}".format(
+            current_version
+        )
+        print(msg)
+        logging.warning(msg)
+        sys.exit(1)
 
     if current_release == "trusty":
         msg = "Unable to execute upgrade-lts-contract.py on trusty"

--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -67,6 +67,37 @@ class TestUpgradeLTSContract:
     )
     @mock.patch("lib.upgrade_lts_contract.parse_os_release")
     @mock.patch("lib.upgrade_lts_contract.subp")
+    def test_upgrade_cancel_when_current_version_not_supported(
+        self, m_subp, m_parse_os, m_is_attached, capsys, caplog_text
+    ):
+        m_parse_os.return_value = {"VERSION_ID": "NOT-SUPPORTED"}
+        m_subp.return_value = ("", "")
+
+        expected_msgs = [
+            "Starting upgrade-lts-contract.",
+            "Unable to get release codename for version: NOT-SUPPORTED",
+        ]
+        expected_logs = ["Check whether to upgrade-lts-contract"]
+        with pytest.raises(SystemExit) as execinfo:
+            process_contract_delta_after_apt_lock()
+
+        assert 1 == execinfo.value.code
+        assert 1 == m_is_attached.call_count
+        assert 1 == m_parse_os.call_count
+        assert 1 == m_subp.call_count
+        out, _err = capsys.readouterr()
+        assert out == "\n".join(expected_msgs) + "\n"
+        debug_logs = caplog_text()
+        for log in expected_msgs + expected_logs:
+            assert log in debug_logs
+
+    @mock.patch(
+        "uaclient.config.UAConfig.is_attached",
+        new_callable=mock.PropertyMock,
+        return_value=True,
+    )
+    @mock.patch("lib.upgrade_lts_contract.parse_os_release")
+    @mock.patch("lib.upgrade_lts_contract.subp")
     @mock.patch("lib.upgrade_lts_contract.process_entitlements_delta")
     @mock.patch("lib.upgrade_lts_contract.time.sleep")
     def test_upgrade_contract_when_apt_lock_is_held(


### PR DESCRIPTION
## Proposed Commit Message
lib: fix upgrade script for unsupported releases

The upgrade_lts_script fails if it cannot find a codename for the current Ubuntu version it is running on. We are updating the script to properly finish if that situation happens

## Test Steps
Run the new unit test added

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
