### PR TITLE
unhold fips package when enabling fips-updates

### DIFF
--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -303,9 +303,11 @@ class TestFIPSEntitlementEnable:
             stack.enter_context(
                 mock.patch.object(type(entitlement), "packages", m_packages)
             )
+            stack.enter_context(
+                mock.patch("uaclient.util.is_container", return_value=False)
+            )
 
             m_can_enable.return_value = (True, None)
-
             assert (True, None) == entitlement.enable()
 
         repo_url = "http://{}".format(entitlement.name.upper())
@@ -365,27 +367,20 @@ class TestFIPSEntitlementEnable:
                 )
             )
 
-        if isinstance(entitlement, FIPSEntitlement):
-            subp_calls = [
-                mock.call(
-                    ["apt-mark", "showholds"],
-                    capture=True,
-                    retry_sleeps=apt.APT_RETRIES,
-                    env={},
-                )
-            ]
-        else:
-            subp_calls = []
-        subp_calls.extend(
-            [
-                mock.call(
-                    ["apt-get", "update"],
-                    capture=True,
-                    retry_sleeps=apt.APT_RETRIES,
-                    env={},
-                )
-            ]
-        )
+        subp_calls = [
+            mock.call(
+                ["apt-mark", "showholds"],
+                capture=True,
+                retry_sleeps=apt.APT_RETRIES,
+                env={},
+            ),
+            mock.call(
+                ["apt-get", "update"],
+                capture=True,
+                retry_sleeps=apt.APT_RETRIES,
+                env={},
+            ),
+        ]
         subp_calls += install_cmd
 
         assert [mock.call()] == m_can_enable.call_args_list
@@ -1117,19 +1112,12 @@ class TestFipsSetupAPTConfig:
         """Unmark only fips-specific package holds if present."""
         run_apt_command.return_value = held_packages
         entitlement.setup_apt_config(silent=False)
-        if isinstance(entitlement, FIPSUpdatesEntitlement):
-            expected_calls = []
-        else:
-            expected_calls = [
-                mock.call(
-                    ["apt-mark", "showholds"], "apt-mark showholds failed."
-                )
-            ]
-            if unhold_packages:
-                cmd = ["apt-mark", "unhold"] + unhold_packages
-                expected_calls.append(
-                    mock.call(cmd, " ".join(cmd) + " failed.")
-                )
+        expected_calls = [
+            mock.call(["apt-mark", "showholds"], "apt-mark showholds failed.")
+        ]
+        if unhold_packages:
+            cmd = ["apt-mark", "unhold"] + unhold_packages
+            expected_calls.append(mock.call(cmd, " ".join(cmd) + " failed."))
         assert expected_calls == run_apt_command.call_args_list
         assert [mock.call(silent=False)] == setup_apt_config.call_args_list
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

Currently, we only unhold fips related packages when we enable fips. Since on FIPS PRO machines, users might want to enable fips-updates, we are now also unholding packages on that operation.

## Test Steps
Launch a PRO FIPS machine, install an updated version of UA with this change and verify that running `ua enable fips-updates` works as expected

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
