### PR TITLE
daemon: cloud-id file shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build:
 
 clean:
 	rm -f *.build *.buildinfo *.changes .coverage *.deb *.dsc *.tar.gz *.tar.xz
+	rm -f azure-*-uaclient-ci-* ec2-uaclient-ci-* gcp-*-uaclient-ci-* lxd-container-*-uaclient-ci-* lxd-virtual-machine-*-uaclient-ci-*
 	rm -rf *.egg-info/ .tox/ .cache/ .mypy_cache/
 	find . -type f -name '*.pyc' -delete
 	find . -type d -name '*__pycache__' -delete

--- a/debian/rules
+++ b/debian/rules
@@ -57,6 +57,10 @@ override_dh_systemd_enable:
 	dh_systemd_enable -pubuntu-advantage-tools ua-timer.timer
 	dh_systemd_enable -pubuntu-advantage-tools ua-timer.service
 	dh_systemd_enable -pubuntu-advantage-tools ubuntu-advantage.service
+ifeq (${VERSION_ID},"16.04")
+	# Only enable cloud-id-shim on Xenial
+	dh_systemd_enable -pubuntu-advantage-tools ubuntu-advantage-cloud-id-shim.service
+endif
 
 override_dh_systemd_start:
 	dh_systemd_start -pubuntu-advantage-tools ua-timer.timer
@@ -69,6 +73,11 @@ override_dh_auto_install:
 	# We want to guarantee that we are not shipping any conftest files
 	find $(CURDIR)/debian/ubuntu-advantage-tools -type f -name conftest.py -delete
 
+ifneq (${VERSION_ID},"16.04")
+	# Only install cloud-id-shim on Xenial
+	rm $(CURDIR)/debian/ubuntu-advantage-tools/lib/systemd/system/ubuntu-advantage-cloud-id-shim.service
+endif
+
 ifeq (${VERSION_ID},"14.04")
 	# Move ua-auto-attach.conf out to ubuntu-advantage-pro
 	mkdir -p debian/ubuntu-advantage-pro/etc/init
@@ -80,6 +89,7 @@ else
 	mv debian/ubuntu-advantage-tools/lib/systemd/system/ua-auto-attach.* debian/ubuntu-advantage-pro/lib/systemd/system
 	cd debian/ubuntu-advantage-tools
 endif
+
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -453,6 +453,7 @@ case "$1" in
       rm_old_license_check_marker
       disable_new_timer_if_old_timer_already_disabled $PREVIOUS_PKG_VER
       remove_old_systemd_timers
+      /usr/lib/ubuntu-advantage/cloud-id-shim.sh || true
       ;;
 esac
 

--- a/features/aws-ids.yaml
+++ b/features/aws-ids.yaml
@@ -1,6 +1,6 @@
-bionic: ami-0419d66039473da9d
+bionic: ami-02b4e50c1ebb5034c
 bionic-fips: ami-03b75f613f80bcff1
-focal: ami-0489b8bdbbf3a3b32
+focal: ami-01deb29ae4e3b9c97
+focal-fips: ami-02782bf2569bf457c
 xenial: ami-011bcfe2bea365b6a
 xenial-fips: ami-077e4c339a098fc9f
-focal-fips: ami-02782bf2569bf457c

--- a/features/gcp-ids.yaml
+++ b/features/gcp-ids.yaml
@@ -1,3 +1,3 @@
-bionic: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1804-bionic-v20220117
-focal: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-2004-focal-v20220110
+bionic: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1804-bionic-v20220411
+focal: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-2004-focal-v20220411
 xenial: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1604-xenial-v20211213

--- a/lib/cloud-id-shim.sh
+++ b/lib/cloud-id-shim.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+RUN_CLOUD_INIT=/run/cloud-init
+if [ ! -d "$RUN_CLOUD_INIT" ]; then
+  exit 0
+fi
+
+CLOUD_ID_LINK_PATH=$RUN_CLOUD_INIT/cloud-id
+if [ -L "$CLOUD_ID_LINK_PATH" ]; then
+  exit 0
+fi
+
+CLOUD_ID=$(cloud-id 2>/dev/null) || CLOUD_ID=""
+if [ -z "$CLOUD_ID" ]; then
+  exit 0
+fi
+
+CLOUD_ID_FILE_PATH=$RUN_CLOUD_INIT/cloud-id-$CLOUD_ID
+
+echo "$CLOUD_ID" > "$CLOUD_ID_FILE_PATH"
+ln -s "$CLOUD_ID_FILE_PATH" "$CLOUD_ID_LINK_PATH"
+echo "Created symlink $CLOUD_ID_LINK_PATH -> $CLOUD_ID_FILE_PATH." >&2
+
+exit 0

--- a/sru/release-27.8/gcp_auto_attach_long_poll.sh
+++ b/sru/release-27.8/gcp_auto_attach_long_poll.sh
@@ -38,7 +38,7 @@ function explanatory_message {
 
 explanatory_message "Starting gcloud instance"
 gcloud compute instances create $INSTANCE_NAME \
-    --image="ubuntu-2004-focal-v20220204" \
+    --image="ubuntu-2004-focal-v20220404" \
     --image-project="ubuntu-os-cloud" \
     --machine-type=$INSTANCE_TYPE \
     --zone=$ZONE
@@ -58,13 +58,6 @@ print_and_run_cmd "sudo sh -c \\\"printf \\\\\\\"  poll_for_pro_license: true\\\
 
 explanatory_message "change won't happen while daemon is running, so set short timeout to simulate the long poll returning"
 print_and_run_cmd "sudo sed -i \\\"s/wait_for_change=true/wait_for_change=true\&timeout_sec=5/\\\" /usr/lib/python3/dist-packages/uaclient/clouds/gcp.py"
-
-explanatory_message "Installing new version of cloud-init with cloud-id file feature and rebooting"
-print_and_run_cmd "sudo add-apt-repository ppa:cloud-init-dev/daily -y"
-print_and_run_cmd "sudo apt install cloud-init -y"
-gcloud compute instances stop $INSTANCE_NAME
-gcloud compute instances start $INSTANCE_NAME
-sleep 30
 
 explanatory_message "Checking the status and logs beforehand"
 print_and_run_cmd "sudo ua status --wait"

--- a/sru/release-27.8/gcp_auto_attach_on_boot.sh
+++ b/sru/release-27.8/gcp_auto_attach_on_boot.sh
@@ -38,7 +38,7 @@ function explanatory_message {
 
 explanatory_message "Starting gcloud instance"
 gcloud compute instances create $INSTANCE_NAME \
-    --image="ubuntu-2004-focal-v20220204" \
+    --image="ubuntu-2004-focal-v20220404" \
     --image-project="ubuntu-os-cloud" \
     --machine-type=$INSTANCE_TYPE \
     --zone=$ZONE
@@ -50,13 +50,6 @@ gcloud compute scp $ua_deb $INSTANCE_NAME:/tmp/ubuntu-advantage-tools.deb
 gcloud compute ssh $INSTANCE_NAME -- "sudo apt update"
 gcloud compute ssh $INSTANCE_NAME -- "sudo apt install ubuntu-advantage-tools jq -y"
 print_and_run_cmd "sudo dpkg -i /tmp/ubuntu-advantage-tools.deb"
-
-explanatory_message "Installing new version of cloud-init with cloud-id file feature and rebooting"
-print_and_run_cmd "sudo add-apt-repository ppa:cloud-init-dev/daily -y"
-print_and_run_cmd "sudo apt install cloud-init -y"
-gcloud compute instances stop $INSTANCE_NAME
-gcloud compute instances start $INSTANCE_NAME
-sleep 30
 
 explanatory_message "Checking the status and logs beforehand"
 print_and_run_cmd "sudo ua status --wait"

--- a/systemd/ubuntu-advantage-cloud-id-shim.service
+++ b/systemd/ubuntu-advantage-cloud-id-shim.service
@@ -1,0 +1,21 @@
+# This service exists to create a cloud-id-x file if it doesn't already exist.
+# This is only activated on Xenial systems and will only run if cloud-init is
+# less than version 22.1
+# Creating the cloud-id-x file allows ubuntu-advantage.service to activate on
+# the correct platforms.
+
+[Unit]
+Description=cloud-id shim
+After=cloud-config.service
+Before=ubuntu-advantage.service
+# Only run if cloud-init is installed and ran
+ConditionPathExists=/run/cloud-init/instance-data.json
+# Only run if cloud-init didn't create the cloud-id file
+ConditionPathExists=!/run/cloud-init/cloud-id
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /usr/lib/ubuntu-advantage/cloud-id-shim.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ubuntu-advantage.service
+++ b/systemd/ubuntu-advantage.service
@@ -9,7 +9,7 @@
 [Unit]
 Description=Ubuntu Advantage GCP Auto Attach Daemon
 Documentation=man:ubuntu-advantage https://ubuntu.com/advantage
-After=network.target network-online.target systemd-networkd.service ua-auto-attach.service cloud-config.service
+After=network.target network-online.target systemd-networkd.service ua-auto-attach.service cloud-config.service ubuntu-advantage-cloud-id-shim.service
 
 # Only run if not already attached
 ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
daemon: cloud-id file shim

This introduces a new systemd service that will run on startup only if
the version of cloud-init does not create the cloud-id file. The service
creates the same cloud-id file that cloud-init does in newer versions.
This is specifically necessary for xenial, and is a noop if cloud-init
is new enough.

It also runs the same script on postinst to cover the scenario where the
new version of cloud-init is installed but the instance has not
rebooted, and so cloud-init hasn't yet created the cloud-id file.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
run the edited integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
