### PR TITLE
lib: fix upgrade script for unsupported releases

### DIFF
--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -17,7 +17,6 @@ Feature: Upgrade between releases when uaclient is attached
         [Sources]
         AllowThirdParty=yes
         """
-        And I run `sed -i 's/Prompt=lts/Prompt=normal/' /etc/update-manager/release-upgrades` with sudo
         And I run `do-release-upgrade <devel_release> --frontend DistUpgradeViewNonInteractive` `with sudo` and stdin `y\n`
         And I reboot the `<release>` machine
         And I run `lsb_release -cs` as non-root
@@ -42,7 +41,7 @@ Feature: Upgrade between releases when uaclient is attached
 
         Examples: ubuntu release
         | release | next_release | devel_release   |
-        | focal   | impish       |                 |
+        | focal   | jammy        | --devel-release |
         | impish  | jammy        | --devel-release |
 
     @slow

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -34,14 +34,20 @@ version_to_codename = {
     "16.04": "xenial",
     "18.04": "bionic",
     "20.04": "focal",
-    "20.10": "groovy",
+    "21.10": "impish",
+    "22.04": "jammy",
 }
 
 current_codename_to_past_codename = {
     "xenial": "trusty",
     "bionic": "xenial",
     "focal": "bionic",
-    "groovy": "focal",
+    "impish": "focal",
+    # We are considering the past release for Jammy to be Focal
+    # because we don't have any services available on Impish.
+    # Therefore, it is safer for us to try to process contract deltas
+    # using Focal
+    "jammy": "focal",
 }
 
 
@@ -49,7 +55,7 @@ def process_contract_delta_after_apt_lock() -> None:
     logging.debug("Check whether to upgrade-lts-contract")
     cfg = UAConfig()
     if not cfg.is_attached:
-        logging.debug("Skiping upgrade-lts-contract. Machine is unattached")
+        logging.debug("Skipping upgrade-lts-contract. Machine is unattached")
         return
     out, _err = subp(["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1])
     msg = "Starting upgrade-lts-contract."
@@ -59,7 +65,15 @@ def process_contract_delta_after_apt_lock() -> None:
     logging.debug(msg)
 
     current_version = parse_os_release()["VERSION_ID"]
-    current_release = version_to_codename[current_version]
+    current_release = version_to_codename.get(current_version)
+
+    if current_release is None:
+        msg = "Unable to get release codename for version: {}".format(
+            current_version
+        )
+        print(msg)
+        logging.warning(msg)
+        sys.exit(1)
 
     if current_release == "trusty":
         msg = "Unable to execute upgrade-lts-contract.py on trusty"
@@ -67,7 +81,13 @@ def process_contract_delta_after_apt_lock() -> None:
         logging.warning(msg)
         sys.exit(1)
 
-    past_release = current_codename_to_past_codename[current_release]
+    past_release = current_codename_to_past_codename.get(current_release)
+    if past_release is None:
+        msg = "Could not find past release for: {}".format(current_release)
+        print(msg)
+        logging.warning(msg)
+        sys.exit(1)
+
     past_entitlements = UAConfig(series=past_release).entitlements
     new_entitlements = UAConfig(series=current_release).entitlements
 

--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -16,7 +16,7 @@ class TestUpgradeLTSContract:
     def test_unattached_noops(self, m_is_attached, capsys, caplog_text):
         expected_logs = [
             "Check whether to upgrade-lts-contract",
-            "Skiping upgrade-lts-contract. Machine is unattached",
+            "Skipping upgrade-lts-contract. Machine is unattached",
         ]
 
         process_contract_delta_after_apt_lock()
@@ -49,6 +49,72 @@ class TestUpgradeLTSContract:
         expected_logs = ["Check whether to upgrade-lts-contract"]
         with pytest.raises(SystemExit) as execinfo:
             process_contract_delta_after_apt_lock()
+
+        assert 1 == execinfo.value.code
+        assert 1 == m_is_attached.call_count
+        assert 1 == m_parse_os.call_count
+        assert 1 == m_subp.call_count
+        out, _err = capsys.readouterr()
+        assert out == "\n".join(expected_msgs) + "\n"
+        debug_logs = caplog_text()
+        for log in expected_msgs + expected_logs:
+            assert log in debug_logs
+
+    @mock.patch(
+        "uaclient.config.UAConfig.is_attached",
+        new_callable=mock.PropertyMock,
+        return_value=True,
+    )
+    @mock.patch("lib.upgrade_lts_contract.parse_os_release")
+    @mock.patch("lib.upgrade_lts_contract.subp")
+    def test_upgrade_cancel_when_current_version_not_supported(
+        self, m_subp, m_parse_os, m_is_attached, capsys, caplog_text
+    ):
+        m_parse_os.return_value = {"VERSION_ID": "NOT-SUPPORTED"}
+        m_subp.return_value = ("", "")
+
+        expected_msgs = [
+            "Starting upgrade-lts-contract.",
+            "Unable to get release codename for version: NOT-SUPPORTED",
+        ]
+        expected_logs = ["Check whether to upgrade-lts-contract"]
+        with pytest.raises(SystemExit) as execinfo:
+            process_contract_delta_after_apt_lock()
+
+        assert 1 == execinfo.value.code
+        assert 1 == m_is_attached.call_count
+        assert 1 == m_parse_os.call_count
+        assert 1 == m_subp.call_count
+        out, _err = capsys.readouterr()
+        assert out == "\n".join(expected_msgs) + "\n"
+        debug_logs = caplog_text()
+        for log in expected_msgs + expected_logs:
+            assert log in debug_logs
+
+    @mock.patch(
+        "uaclient.config.UAConfig.is_attached",
+        new_callable=mock.PropertyMock,
+        return_value=True,
+    )
+    @mock.patch("lib.upgrade_lts_contract.parse_os_release")
+    @mock.patch("lib.upgrade_lts_contract.subp")
+    def test_upgrade_cancel_when_past_version_not_supported(
+        self, m_subp, m_parse_os, m_is_attached, capsys, caplog_text
+    ):
+        m_parse_os.return_value = {"VERSION_ID": "20.10"}
+        m_subp.return_value = ("", "")
+
+        expected_msgs = [
+            "Starting upgrade-lts-contract.",
+            "Could not find past release for: groovy",
+        ]
+        expected_logs = ["Check whether to upgrade-lts-contract"]
+        with pytest.raises(SystemExit) as execinfo:
+            with mock.patch(
+                "lib.upgrade_lts_contract.version_to_codename",
+                {"20.10": "groovy"},
+            ):
+                process_contract_delta_after_apt_lock()
 
         assert 1 == execinfo.value.code
         assert 1 == m_is_attached.call_count


### PR DESCRIPTION
## Proposed Commit Message
lib: fix upgrade script for unsupported releases

The upgrade_lts_script fails if it cannot find a codename for the current Ubuntu version it is running on. We are updating the script to properly finish if that situation happens

## Test Steps
Run the new unit test added

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
