### PR TITLE
CI: cleanup-ec2: only clean instances started by the current principal

### DIFF
--- a/.github/workflows/cloud-cleanup.yaml
+++ b/.github/workflows/cloud-cleanup.yaml
@@ -31,7 +31,13 @@ jobs:
       - name: Delete stale CI instances
         run: |
           yesterday=$(date --utc --iso-8601=seconds --date=yesterday)
-          stale_instances=$(aws ec2 describe-instances --query "Reservations[].Instances[?LaunchTime<=\`$yesterday\`][].InstanceId" --filters 'Name=tag:Name,Values=uaclient-ci-*' --output text)
+          current_aws_principal=$(aws sts get-caller-identity | jq -r '.UserId')
+          stale_instances=$(
+            aws ec2 describe-instances \
+            --query "Reservations[].Instances[?LaunchTime<=\`$yesterday\`][].InstanceId" \
+            --filters "Name=tag:PrincipalId,Values=$current_aws_principal" 'Name=tag:Name,Values=uaclient-ci-*' \
+            --output text
+          )
           [ -z "$stale_instances" ] || aws ec2 terminate-instances --instance-ids $stale_instances
   cleanup-gce:
     name: Cleanup GCE


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
CI: cleanup-ec2: only clean instances started by the current principal

We can have CI instances running under the same AWS account but started
by a different principal (~ IAM user). We want the CI cloud-cleanup
workflow to only deal with instances created by the same principal that
is used in the CI runs.

Fixes: #2051
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
