### PR TITLE
gcp-pro-fips: add integration tests for gcp fips

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -12,6 +12,7 @@ Feature: UA is expected version
     @uses.config.machine_type.azure.pro.fips
     @uses.config.machine_type.gcp.generic
     @uses.config.machine_type.gcp.pro
+    @uses.config.machine_type.gcp.pro.fips
     Scenario Outline: Check ua version
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `dpkg-query --showformat='${Version}' --show ubuntu-advantage-tools` with sudo

--- a/features/gcp-ids.yaml
+++ b/features/gcp-ids.yaml
@@ -1,3 +1,5 @@
 bionic: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1804-bionic-v20220411
+bionic-fips: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-fips-1804-bionic-v20220411a
 focal: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-2004-focal-v20220411
+focal-fips: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-fips-2004-focal-v20220411b
 xenial: projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-1604-xenial-v20211213

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -421,7 +421,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
     @series.focal
     @uses.config.machine_type.azure.pro.fips
     @uses.config.machine_type.aws.pro.fips
-    Scenario Outline: Check fips-updates can be enable in a focal PRO FIPS machine
+    @uses.config.machine_type.gcp.pro.fips
+    Scenario Outline: Check fips-updates can be enabled in a focal PRO FIPS machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
@@ -469,3 +470,209 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Examples: ubuntu release
            | release  |
            | focal    |
+
+    @series.focal
+    @series.bionic
+    @uses.config.machine_type.gcp.pro.fips
+    Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips GCP machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        """
+        And I run `ua auto-attach` with sudo
+        And I run `ua status --wait` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +enabled +NIST-certified core packages
+            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            livepatch     +yes +n/a  +Canonical Livepatch service
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        When I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            <fips-kernel-version>
+            """
+        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        Then stdout does not match regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+        When I run `systemctl start ua-auto-attach.service` with sudo
+        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
+        Then stdout matches regexp:
+        """
+        .*status=0\/SUCCESS.*
+        """
+        And stdout matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
+        When I run `ua auto-attach` with sudo
+        Then stderr matches regexp:
+        """
+        Skipping attach: Instance '[0-9a-z\-]+' is already attached.
+        """
+        When I run `apt-cache policy` with sudo
+        Then apt-cache policy for the following url has permission `500`
+        """
+        https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        """
+        And apt-cache policy for the following url has permission `500`
+        """
+        https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        """
+        And apt-cache policy for the following url has permission `500`
+        """
+        https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
+        """
+        And apt-cache policy for the following url has permission `500`
+        """
+        https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        """
+        And apt-cache policy for the following url has permission `1001`
+        """
+        <fips-apt-source> amd64 Packages
+        """
+        And I verify that running `apt update` `with sudo` exits `0`
+        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo, retrying exit [100]
+        And I run `apt-cache policy <infra-pkg>` as non-root
+        Then stdout matches regexp:
+        """
+        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        """
+        And stdout matches regexp:
+        """
+        Installed: .*[~+]esm
+        """
+        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo, retrying exit [100]
+        And I run `apt-cache policy <apps-pkg>` as non-root
+        Then stdout matches regexp:
+        """
+        Version table:
+        \s*\*\*\* .* 500
+        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        """
+        When I run `ua enable fips-updates --assume-yes` with sudo
+        Then I will see the following on stdout:
+            """
+            One moment, checking your subscription first
+            Disabling incompatible service: FIPS
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install.
+            """
+        When I run `ua status` with sudo
+        Then stdout matches regexp:
+            """
+            fips          +yes +n/a +NIST-certified core packages
+            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+            """
+        When I reboot the `<release>` machine
+        And I run `uname -r` as non-root
+        Then stdout matches regexp:
+            """
+            <fips-kernel-version>
+            """
+        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        Then stdout does not match regexp:
+        """
+        .*Installed: \(none\)
+        """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
+
+        Examples: ubuntu release
+           | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
+           | bionic  | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | gcp-fips            |
+           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            |
+
+    @series.focal
+    @uses.config.machine_type.gcp.pro.fips
+    Scenario Outline: Check fips packages are correctly installed on GCP Pro Focal machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        features:
+          allow_xenial_fips_on_cloud: true
+        """
+        And I run `ua auto-attach` with sudo
+        And I run `ua status --wait` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +enabled +NIST-certified core packages
+            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            livepatch     +yes +n/a  +Canonical Livepatch service
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+
+        Examples: ubuntu release
+           | release | fips-apt-source                                |
+           | focal   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+
+    @series.bionic
+    @uses.config.machine_type.gcp.pro.fips
+    Scenario Outline: Check fips packages are correctly installed on GCP Pro Bionic machines
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        data_dir: /var/lib/ubuntu-advantage
+        log_level: debug
+        log_file: /var/log/ubuntu-advantage.log
+        features:
+          allow_xenial_fips_on_cloud: true
+        """
+        And I run `ua auto-attach` with sudo
+        And I run `ua status --wait` as non-root
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+            """
+            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+            fips          +yes +enabled +NIST-certified core packages
+            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            livepatch     +yes +n/a  +Canonical Livepatch service
+            """
+        And I verify that running `apt update` `with sudo` exits `0`
+        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
+        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
+        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
+
+        Examples: ubuntu release
+           | release  | fips-apt-source                                 |
+           | bionic   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |

--- a/tools/refresh-gcp-pro-ids.py
+++ b/tools/refresh-gcp-pro-ids.py
@@ -42,12 +42,16 @@ def main(credentials_path=None, project=None):
         if not image["name"].startswith("ubuntu-pro"):
             continue
 
-        m = re.match(r"^ubuntu-pro-\d+-(?P<release>\w+)-v\d+", image["name"])
+        m = re.match(
+            r"^ubuntu-pro-(fips-)?\d+-(?P<release>\w+)-v\d+", image["name"]
+        )
         if not m:
             print("Skipping unexpected image name: ", image["name"])
             continue
         elif m.group("release") in SUPPORTED_SERIES:
             release = m.group("release")
+            if "ubuntu-pro-fips" in image["name"]:
+                release = release + "-fips"
             series_bucket[release].append(image["name"])
 
     for series, images in series_bucket.items():

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ setenv =
     azurepro-fips: UACLIENT_BEHAVE_MACHINE_TYPE = azure.pro.fips
     gcpgeneric: UACLIENT_BEHAVE_MACHINE_TYPE = gcp.generic
     gcppro: UACLIENT_BEHAVE_MACHINE_TYPE = gcp.pro
+    gcppro-fips: UACLIENT_BEHAVE_MACHINE_TYPE = gcp.pro.fips
     vm: UACLIENT_BEHAVE_MACHINE_TYPE = lxd.vm
     docker: UACLIENT_BEHAVE_MACHINE_TYPE = lxd.vm
 commands =
@@ -107,6 +108,8 @@ commands =
     behave-gcppro-16.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-gcppro-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
     behave-gcppro-20.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-fips-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro.fips" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-fips-20.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro.fips" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
gcp-pro-fips: add integration tests for gcp fips

We are adding integration tests for gcp pro fips machines. It should be noted that we do not have gcp xenial fips machines, thus we have not included tests for them. If the situation changes, then we will add xenial tests.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
