### PR TITLE
cli: add refresh subcommand to update motd message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Current jobs being checked and executed are:
 
 - The `update_messaging` job makes sure that the MOTD and APT messages match the
 available/enabled services on the system, showing information about available
-packages or security updates. See [MOTD messages](#motd-messages).
+packages or security updates. See [MOTD messages](./docs/howtoguides/update_motd_messages.md).
 - The `update_status` job makes sure the `ua status` command will have the latest
 information even when executed by a non-root user, updating the
 `/var/lib/ubuntu-advantage/status.json` file.
@@ -392,31 +392,6 @@ following environment variable to launch your specfic Image Id instead of buildi
 a daily ubuntu-advantage-tools image.
 ```sh
 UACLIENT_BEHAVE_REUSE_IMAGE=your-custom-image-id tox -e behave-awspro-20.04
-```
-
-### MOTD Messages
-
-Since ubuntu-advantage-tools is responsible for enabling ESM services, we advertise them on different
-applications thorough the system, such as MOTD and apt commands like upgrade.
-
-To verify that the MOTD message is advertising the ESM packages, ensure that we have ESM source list
-files in the system. If that is the case, please run the following commands to update the state of
-MOTD and display the message:
-
-```sh
-# Make sure ubuntu-advantage-tools version >= 27.0
-ua version
-# Make apt aware of the ESM source files
-sudo apt update
-# Generates ubuntu-advantage-tools messages that should be delivered to MOTD
-# This script is triggered by the systemd timer 4 times a day. To test it, we need
-# to enforce that it was already executed.
-sudo systemctl start ua-timer.service
-# Force updating MOTD messages related to update-notifier
-sudo rm /var/lib/ubuntu-advantage/jobs-status.json
-sudo python3 /usr/lib/ubuntu-advantage/timer.py
-# Update MOTD and display the message
-run-parts /etc/update-motd.d/
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Users can manually run the `ua` command to learn more or view the manpage.
 * [How to Configure Proxies](./docs/howtoguides/configure_proxies.md)
 * [How to Enable Ubuntu Advantage Services in a Dockerfile](./docs/howtoguides/enable_ua_in_dockerfile.md)
 * [How to Create a custom Golden Image based on Ubuntu Pro](./docs/howtoguides/create_pro_golden_image.md)
+* [How to Manually update MOTD and APT messages](./docs/howtoguides/update_motd_messages.md)
 
 ### Reference
 

--- a/docs/howtoguides/update_motd_messages.md
+++ b/docs/howtoguides/update_motd_messages.md
@@ -1,0 +1,12 @@
+# How to update MOTD and APT messages
+
+Since ubuntu-advantage-tools is responsible for enabling ESM services, we advertise them on different
+applications thorough the system, such as MOTD and apt commands like upgrade.
+
+To verify that APT and MOTD message is advertising the ESM packages, ensure that we have ESM
+source list files in the system. If that is the case, please run the following command to
+update the state of MOTD and APT messages:
+
+```sh
+ua refresh messages
+```

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -29,8 +29,14 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo, retrying exit [100]
+        And I run `apt install update-motd` with sudo, retrying exit [100]
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y <downrev_pkg>` with sudo, retrying exit [100]
-        And I run `run-parts /etc/update-motd.d/` with sudo
+        And I run `ua refresh messages` with sudo
+        Then stdout matches regexp:
+        """
+        Successfully updated UA related APT and MOTD messages.
+        """
+        When I run `update-motd` with sudo
         Then if `<release>` in `xenial` and stdout matches regexp:
         """
         \d+ update(s)? can be applied immediately.
@@ -88,9 +94,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
               allow_beta: true
             """
         And I run `apt update` with sudo
-        And I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
-        And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
-        And I run `apt install update-motd` with sudo, retrying exit [100]
+        And I run `ua refresh messages` with sudo
         And I run `update-motd` with sudo
         Then if `<release>` in `focal` and stdout matches regexp:
         """
@@ -163,6 +167,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         https:\/\/ubuntu.com\/advantage
 
         """
+
         Examples: ubuntu release packages
            | release | downrev_pkg                 | cc_status | cis_or_usg | cis      | fips     | livepatch_desc                |
            | xenial  | libkrad0=1.13.2+dfsg-5      | disabled  | cis        | disabled | disabled | Canonical Livepatch service   |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -16,6 +16,7 @@ Feature: Command behaviour when attached to an UA subscription
             """
             Successfully processed your ua configuration.
             Successfully refreshed your subscription.
+            Successfully updated UA related APT and MOTD messages.
             """
         When I run `ua refresh config` with sudo
         Then I will see the following on stdout:
@@ -26,6 +27,11 @@ Feature: Command behaviour when attached to an UA subscription
         Then I will see the following on stdout:
             """
             Successfully refreshed your subscription.
+            """
+        When I run `ua refresh messages` with sudo
+        Then I will see the following on stdout:
+            """
+            Successfully updated UA related APT and MOTD messages.
             """
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         And I run `sh -c "ls /var/log/ubuntu-advantage* | sort -d"` as non-root

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -146,9 +146,18 @@ REFRESH_CONTRACT_SUCCESS = "Successfully refreshed your subscription."
 REFRESH_CONTRACT_FAILURE = "Unable to refresh your subscription"
 REFRESH_CONFIG_SUCCESS = "Successfully processed your ua configuration."
 REFRESH_CONFIG_FAILURE = "Unable to process uaclient.conf"
+REFRESH_MESSAGES_SUCCESS = (
+    "Successfully updated UA related APT and MOTD messages."
+)
+REFRESH_MESSAGES_FAILURE = "Unable to update UA related APT and MOTD messages."
+
 UPDATE_CHECK_CONTRACT_FAILURE = (
     """Failed to check for change in machine contract. Reason: {reason}"""
 )
+UPDATE_MOTD_NO_REQUIRED_CMD = (
+    "Required command to update MOTD messages not found: {cmd}."
+)
+
 INCOMPATIBLE_SERVICE = """\
 {service_being_enabled} cannot be enabled with {incompatible_service}.
 Disable {incompatible_service} and proceed to enable {service_being_enabled}? \


### PR DESCRIPTION
## Proposed Commit Message
cli: add refresh subcommand to update motd message

Right now, users have no direct way to update the MOTD messages UA deliver. For example, if a contract is renewed, users will need to wait for our timer job to run so they can see the expiry message on MOTD disappear. We are now adding a `ua refresh motd` command that updates the MOTD message

## Test Steps
Run the modified integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
