### PR TITLE
gcp-pro: handle metadata endpoint error

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -15,7 +15,7 @@ import tempfile
 import textwrap
 import time
 from functools import wraps
-from typing import Dict, List, Optional, Tuple  # noqa
+from typing import List, Optional, Tuple  # noqa
 
 import yaml
 
@@ -1291,10 +1291,10 @@ def action_auto_attach(args, *, cfg):
     try:
         actions.auto_attach(cfg, instance)
     except exceptions.UrlError:
-        event.info(messages.ATTACH_FAILURE)
+        event.info(messages.ATTACH_FAILURE.msg)
         return 1
-    except exceptions.UserFacingError:
-        return 1
+    except exceptions.UserFacingError as e:
+        raise e
     else:
         _post_cli_attach(cfg)
         return 0

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -12,6 +12,7 @@ from uaclient.clouds.gcp import (
     WAIT_FOR_CHANGE,
     UAAutoAttachGCPInstance,
 )
+from uaclient.exceptions import GCPProAccountError
 
 M_PATH = "uaclient.clouds.gcp."
 
@@ -57,7 +58,7 @@ class TestUAAutoAttachGCPInstance:
 
         instance = UAAutoAttachGCPInstance()
         if exception:
-            with pytest.raises(HTTPError) as excinfo:
+            with pytest.raises(GCPProAccountError) as excinfo:
                 instance.identity_doc
             assert 704 == excinfo.value.code
         else:
@@ -69,9 +70,12 @@ class TestUAAutoAttachGCPInstance:
         assert expected_sleep_calls == sleep.call_args_list
 
         expected_logs = [
-            "HTTP Error 701: funky error msg Retrying 3 more times.",
-            "HTTP Error 702: funky error msg Retrying 2 more times.",
-            "HTTP Error 703: funky error msg Retrying 1 more times.",
+            "GCPProServiceAccount Error 701: "
+            + "funky error msg Retrying 3 more times.",
+            "GCPProServiceAccount Error 702: "
+            + "funky error msg Retrying 2 more times.",
+            "GCPProServiceAccount Error 703: "
+            + "funky error msg Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -20,6 +20,7 @@ CLOUD_BUILD_INFO = "/etc/cloud/build.info"
 DOCUMENTATION_URL = (
     "https://discourse.ubuntu.com/t/ubuntu-advantage-client/21788"
 )
+GCP_SERVICE_ACCT_DOC_URL = "https://cloud.google.com/iam/docs/service-accounts"
 PRINT_WRAP_WIDTH = 80
 CONTRACT_EXPIRY_GRACE_PERIOD_DAYS = 14
 CONTRACT_EXPIRY_PENDING_DAYS = 20

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -258,6 +258,20 @@ class SecurityAPIMetadataError(UserFacingError):
         )
 
 
+class GCPProAccountError(UserFacingError):
+    """An exception raised when GCP Pro service account is not enabled"""
+
+    def __init__(self, msg: str, msg_code: Optional[str], code=None):
+        self.code = code
+        self.error_msg = msg
+        super().__init__(msg, msg_code)
+
+    def __str__(self):
+        return "GCPProServiceAccount Error {code}: {msg}".format(
+            code=self.code, msg=self.error_msg
+        )
+
+
 class CloudFactoryError(Exception):
     def __init__(self, cloud_type: Optional[str]) -> None:
         self.cloud_type = cloud_type

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1,6 +1,10 @@
 from typing import Dict, Optional  # noqa: F401
 
-from uaclient.defaults import BASE_UA_URL, DOCUMENTATION_URL
+from uaclient.defaults import (
+    BASE_UA_URL,
+    DOCUMENTATION_URL,
+    GCP_SERVICE_ACCT_DOC_URL,
+)
 
 
 class NamedMessage:
@@ -731,6 +735,14 @@ REALTIME_ERROR_INSTALL_ON_CONTAINER = NamedMessage(
     "Cannot install Real-Time Kernel on a container.",
 )
 
+GCP_SERVICE_ACCT_NOT_ENABLED_ERROR = NamedMessage(
+    "gcp-pro-service-account-not-enabled",
+    "Failed to attach machine\n" + "{error_msg}.",
+)
+
+GCP_SERVICE_ACCT_URL_MESSAGE = (
+    """For more information, see """ + GCP_SERVICE_ACCT_DOC_URL
+)
 
 LOG_CONNECTIVITY_ERROR_TMPL = CONNECTIVITY_ERROR.msg + " {error}"
 LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (


### PR DESCRIPTION
gcp-pro: handle metadata endpoint error

We are handling for the errors raised when using gcp pro and the service account is not enabled.
Fixes #1936 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
