### PR TITLE
CI: build debs in schroots without -proposed enabled

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           gbp dch --ignore-branch --snapshot --distribution=${{ matrix.release }}
           dch --local=~${{ matrix.release }} ""
-          sg sbuild -c "mk-sbuild ${{ matrix.release }}"
+          sg sbuild -c "mk-sbuild --skip-proposed ${{ matrix.release }}"
           sg sbuild -c "sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'"
           mv ../*.deb '${{ runner.temp }}'  # Workaround for Debbug: #990734, drop in Jammy
       - name: Archive debs as artifacts


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
CI: build debs in schroots without -proposed enabled

Later testing (integration testing) is done in an environment which
doesn't have -proposed enabled. Building the package with -proposed
enabled can cause dependency issues.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
