### PR TITLE
Add package counts for different components (minimal backwards compatible version)

### DIFF
--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -31,6 +31,24 @@
         "num_installed_packages": {
           "type": "integer"
         },
+        "num_main_packages": {
+          "type": "integer"
+        },
+        "num_multiverse_packages": {
+          "type": "integer"
+        },
+        "num_restricted_packages": {
+          "type": "integer"
+        },
+        "num_universe_packages": {
+          "type": "integer"
+        },
+        "num_third_party_packages": {
+          "type": "integer"
+        },
+        "num_unknown_packages": {
+          "type": "integer"
+        },
         "num_esm_infra_packages": {
           "type": "integer"
         },

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -428,10 +428,25 @@ def fix_parser(parser):
 def security_status_parser(parser):
     """Build or extend an arg parser for security-status subcommand."""
     parser.prog = "security-status"
-    parser.description = (
-        "Show security updates for packages in the system, including all"
-        " available ESM related content."
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    parser.description = textwrap.dedent(
+        """\
+        Show security updates for packages in the system, including all
+        available ESM related content.
+
+        Besides the list of security updates, it also shows a summary of the
+        installed packages based on the origin.
+        - main/restricted/universe/multiverse: packages from the Ubuntu archive
+        - ESM Infra/Apps: packages from ESM
+        - third-party: packages installed from non-Ubuntu sources
+        - unknown: packages which don't have an installation source (like local
+          deb packages or packages for which the source was removed)
+
+        The summary contains basic information about UA and ESM. For a complete
+        status on UA services, run 'ua status'
+        """
     )
+
     parser.add_argument(
         "--format",
         help=("Format for the output (json or yaml)"),

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -13,14 +13,11 @@ series = get_platform_info()["series"]
 
 ESM_SERVICES = ("esm-infra", "esm-apps")
 
-SERVICE_TO_ORIGIN_INFORMATION = {
-    "standard-security": ("Ubuntu", "{}-security".format(series)),
-    "esm-apps": ("UbuntuESMApps", "{}-apps-security".format(series)),
-    "esm-infra": ("UbuntuESM", "{}-infra-security".format(series)),
-}
 
 ORIGIN_INFORMATION_TO_SERVICE = {
-    v: k for k, v in SERVICE_TO_ORIGIN_INFORMATION.items()
+    ("Ubuntu", "{}-security".format(series)): "standard-security",
+    ("UbuntuESMApps", "{}-apps-security".format(series)): "esm-apps",
+    ("UbuntuESM", "{}-infra-security".format(series)): "esm-infra",
 }
 
 
@@ -35,14 +32,11 @@ class UpdateStatus(Enum):
 def list_esm_for_package(package: apt_package.Package) -> List[str]:
     esm_services = []
     for origin in package.installed.origins:
-        if (origin.origin, origin.archive) == SERVICE_TO_ORIGIN_INFORMATION[
-            "esm-infra"
-        ]:
-            esm_services.append("esm-infra")
-        if (origin.origin, origin.archive) == SERVICE_TO_ORIGIN_INFORMATION[
-            "esm-apps"
-        ]:
-            esm_services.append("esm-apps")
+        service = ORIGIN_INFORMATION_TO_SERVICE.get(
+            (origin.origin, origin.archive), ""
+        )
+        if service in ESM_SERVICES:
+            esm_services.append(service)
     return esm_services
 
 

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -17,8 +17,19 @@ HELP_OUTPUT = textwrap.dedent(
     """\
 usage: security-status \[-h\] --format {json,yaml}
 
-Show security updates for packages in the system, including all available ESM
-related content.
+Show security updates for packages in the system, including all
+available ESM related content.
+
+Besides the list of security updates, it also shows a summary of the
+installed packages based on the origin.
+- main/restricted/universe/multiverse: packages from the Ubuntu archive
+- ESM Infra/Apps: packages from ESM
+- third-party: packages installed from non-Ubuntu sources
+- unknown: packages which don't have an installation source \(like local
+  deb packages or packages for which the source was removed\)
+
+The summary contains basic information about UA and ESM. For a complete
+status on UA services, run 'ua status'
 
 (optional arguments|options):
   -h, --help            show this help message and exit

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -200,13 +200,10 @@ class TestSecurityStatus:
             ),
         ]
 
-        service_to_origin_dict = {
-            "esm-infra": ("UbuntuESM", "example-infra-security"),
-            "standard-security": ("Ubuntu", "example-security"),
-            "esm-apps": ("UbuntuESMApps", "example-apps-security"),
-        }
         origin_to_service_dict = {
-            v: k for k, v in service_to_origin_dict.items()
+            ("UbuntuESM", "example-infra-security"): "esm-infra",
+            ("Ubuntu", "example-security"): "standard-security",
+            ("UbuntuESMApps", "example-apps-security"): "esm-apps",
         }
 
         cfg = FakeConfig()
@@ -252,8 +249,6 @@ class TestSecurityStatus:
         }
 
         with mock.patch(
-            M_PATH + "SERVICE_TO_ORIGIN_INFORMATION", service_to_origin_dict
-        ), mock.patch(
             M_PATH + "ORIGIN_INFORMATION_TO_SERVICE", origin_to_service_dict
         ):
             output = security_status(cfg)


### PR DESCRIPTION
## Notes

Should essentially be the same as #2033 but backwards compatible. Once we start implementing our versioned API, we can move this functionality there and introduce a new versioned schema using that infrastructure.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
cli: add package counts based on archive components to security-status

We count how many packages are from main, restricted, universe,
multiverse, and present it in the summary
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run `ua security-status --format yaml` in different systems. Compare the numbers to what `ubuntu-security-status` says and what you know.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
