### PR TITLE
apt: allow caching apt-cache policy commands

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -103,8 +103,8 @@ class RepoEntitlement(base.UAEntitlement):
                 messages.NO_APT_URL_FOR_SERVICE.format(title=self.title),
             )
         protocol, repo_path = repo_url.split("://")
-        policy = apt.run_apt_command(
-            ["apt-cache", "policy"], messages.APT_POLICY_FAILED.msg
+        policy = apt.run_apt_cache_policy_command(
+            error_msg=messages.APT_POLICY_FAILED.msg
         )
         match = re.search(
             r"(?P<pin>(-)?\d+) {}/ubuntu".format(repo_url), policy

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1005,11 +1005,13 @@ class TestFIPSEntitlementApplicationStatus:
     def test_fips_does_not_show_enabled_when_fips_updates_is(
         self, entitlement
     ):
-        with mock.patch(M_PATH + "util.subp") as m_subp:
-            m_subp.return_value = (
+        with mock.patch(
+            "uaclient.apt.run_apt_cache_policy_command"
+        ) as m_apt_policy:
+            m_apt_policy.return_value = (
                 "1001 http://FIPS-UPDATES/ubuntu"
-                " xenial-updates/main amd64 Packages\n",
-                "",
+                " xenial-updates/main amd64 Packages\n"
+                ""
             )
 
             application_status, _ = entitlement.application_status()

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1038,9 +1038,9 @@ class TestApplicationStatus:
             (500, "https://esm.ubuntu.com/ubuntu", True),
         ),
     )
-    @mock.patch(M_PATH + "apt.run_apt_command")
+    @mock.patch(M_PATH + "apt.run_apt_cache_policy_command")
     def test_enabled_status_by_apt_policy(
-        self, m_run_apt_command, pin, policy_url, enabled, entitlement_factory
+        self, m_run_apt_policy, pin, policy_url, enabled, entitlement_factory
     ):
         """Report ENABLED when apt-policy lists specific aptURL and 500 pin."""
         entitlement = entitlement_factory(
@@ -1055,7 +1055,7 @@ class TestApplicationStatus:
             " release v=18.04,o=UbuntuESMApps,...,n=bionic,l=UbuntuESMApps",
             "  origin esm.ubuntu.com",
         ]
-        m_run_apt_command.return_value = "\n".join(policy_lines)
+        m_run_apt_policy.return_value = "\n".join(policy_lines)
 
         application_status, explanation = entitlement.application_status()
 

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1242,9 +1242,7 @@ def upgrade_packages_and_attach(
             ]
         )
     )
-    apt.run_apt_command(
-        cmd=["apt-get", "update"], error_msg=messages.APT_UPDATE_FAILED.msg
-    )
+    apt.run_apt_update_command()
     apt.run_apt_command(
         cmd=["apt-get", "install", "--only-upgrade", "-y"] + upgrade_packages,
         error_msg=messages.APT_INSTALL_FAILED.msg,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

We currently use the output to check if each repo entitlement is enabled in the system. This happens for example when we are
running an ua status operation, where we run an apt-cache policy for each entitled repo service the user has. We can cache that command if no update calls are performed. Therefore, we are speeding up the execution of ua status by caching the result of apt-cache policy calls.

Testing this changeset on a xenial container, `ua status` response average turns from `1.42s` to `0.57`.

## Test Steps
Please, run status with and without this change to confirm the speed up.
Additionally, run attach integration tests where more than one repo service is being enabled, to confirm the status in the end is not incorrect.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
