### PR TITLE
daemon: lower memory with less imports and start testing memory

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1040,6 +1040,29 @@ def docker_image_is_not_larger(context, name, series, package):
     )
 
 
+@then(
+    "on `{release}`, systemd status output says memory usage is less than `{mb_limit}` MB"
+)
+def systemd_memory_usage_less_than(context, release, mb_limit):
+    curr_release = context.active_outline["release"]
+    if release != curr_release:
+        logging.debug("Skipping for {}".format(curr_release))
+        return
+    match = re.search(r"Memory: (.*)M", context.process.stdout.strip())
+    if match is None:
+        raise AssertionError(
+            "Memory usage not present in current process stdout"
+        )
+    mb_used = float(match.group(1))
+    logging.debug("Found {}M".format(mb_used))
+
+    mb_limit_float = float(mb_limit)
+    if mb_used > mb_limit_float:
+        raise AssertionError(
+            "Using more memory than expected ({}M)".format(mb_used)
+        )
+
+
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
     if user_spec == "with sudo":

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -4,10 +4,28 @@ import sys
 from systemd.daemon import notify  # type: ignore
 
 from uaclient import daemon
-from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
+from uaclient.defaults import DEFAULT_LOG_FORMAT
 
 LOG = logging.getLogger("ua")
+
+
+def setup_logging(console_level, log_level, log_file, logger):
+    logger.setLevel(log_level)
+
+    logger.handlers = []
+
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(logging.Formatter("%(message)s"))
+    console_handler.setLevel(console_level)
+    console_handler.set_name("ua-console")
+    logger.addHandler(console_handler)
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(logging.Formatter(DEFAULT_LOG_FORMAT))
+    file_handler.set_name("ua-file")
+    logger.addHandler(file_handler)
 
 
 def main() -> int:
@@ -22,7 +40,10 @@ def main() -> int:
     LOG.propagate = False
     # The root logger should only log errors to the daemon log file
     setup_logging(
-        logging.CRITICAL, logging.ERROR, log_file=cfg.daemon_log_file
+        logging.CRITICAL,
+        logging.ERROR,
+        log_file=cfg.daemon_log_file,
+        logger=logging.getLogger(),
     )
 
     LOG.debug("daemon starting")

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -42,6 +42,7 @@ from uaclient.defaults import (
     CLOUD_BUILD_INFO,
     CONFIG_FIELD_ENVVAR_ALLOWLIST,
     DEFAULT_CONFIG_FILE,
+    DEFAULT_LOG_FORMAT,
     PRINT_WRAP_WIDTH,
 )
 from uaclient.entitlements.entitlement_status import (
@@ -71,10 +72,6 @@ Valid until: {contract_expiry}
 Technical support level: {tech_support_level}
 """
 UA_AUTH_TOKEN_URL = "https://auth.contracts.canonical.com"
-
-DEFAULT_LOG_FORMAT = (
-    "%(asctime)s - %(filename)s:(%(lineno)d) [%(levelname)s]: %(message)s"
-)
 
 STATUS_FORMATS = ["tabular", "json", "yaml"]
 

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -24,6 +24,9 @@ PRINT_WRAP_WIDTH = 80
 CONTRACT_EXPIRY_GRACE_PERIOD_DAYS = 14
 CONTRACT_EXPIRY_PENDING_DAYS = 20
 ATTACH_FAIL_DATE_FORMAT = "%B %d, %Y"
+DEFAULT_LOG_FORMAT = (
+    "%(asctime)s - %(filename)s:(%(lineno)d) [%(levelname)s]: %(message)s"
+)
 
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,


### PR DESCRIPTION
## Notes

The tests are mostly so that we can keep an eye on memory usage. They're aren't "hard limits" necessarily.

This lowers memory usage by 2Mb by avoiding importing the cli module and using a smaller daemon-tailored `setup_logging` function.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
daemon: lower memory with less imports and start testing memory
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the gcp daemon test with new steps on all series

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
