### PR TITLE
gcp-pro: handle metadata endpoint error

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from typing import Optional  # noqa: F401
 
 from uaclient import (
@@ -40,7 +39,6 @@ def attach_with_token(
         update_apt_and_motd_messages(cfg)
         raise exc
     except exceptions.UserFacingError as exc:
-        event.info(exc.msg, file_type=sys.stderr)
         # Persist updated status in the event of partial attach
         ua_status.status(cfg=cfg)
         update_apt_and_motd_messages(cfg)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -15,7 +15,7 @@ import tempfile
 import textwrap
 import time
 from functools import wraps
-from typing import Dict, List, Optional, Tuple  # noqa
+from typing import List, Optional, Tuple  # noqa
 
 import yaml
 
@@ -1308,9 +1308,7 @@ def action_auto_attach(args, *, cfg):
     try:
         actions.auto_attach(cfg, instance)
     except exceptions.UrlError:
-        event.info(messages.ATTACH_FAILURE)
-        return 1
-    except exceptions.UserFacingError:
+        event.info(messages.ATTACH_FAILURE.msg)
         return 1
     else:
         _post_cli_attach(cfg)

--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -5,7 +5,7 @@ import os
 from typing import Any, Dict, List, Optional  # noqa: F401
 from urllib.error import HTTPError
 
-from uaclient import exceptions, util
+from uaclient import exceptions, messages, util
 from uaclient.clouds import AutoAttachCloudInstance
 
 LOG = logging.getLogger("ua.clouds.gcp")
@@ -42,11 +42,33 @@ class UAAutoAttachGCPInstance(AutoAttachCloudInstance):
     # mypy does not handle @property around inner decorators
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
-    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
+    @util.retry(exceptions.GCPProAccountError, retry_sleeps=[1, 2, 5])
     def identity_doc(self) -> Dict[str, Any]:
-        url_response, _headers = util.readurl(
-            TOKEN_URL, headers={"Metadata-Flavor": "Google"}
-        )
+        try:
+            headers = {"Metadata-Flavor": "Google"}
+            url_response, _headers = util.readurl(TOKEN_URL, headers=headers)
+        except HTTPError as e:
+            body = getattr(e, "body", None)
+            error_desc = None
+            if body:
+                try:
+                    error_details = json.loads(
+                        body, cls=util.DatetimeAwareJSONDecoder
+                    )
+                except ValueError:
+                    error_details = None
+                if error_details:
+                    error_desc = error_details.get("error_description", None)
+            msg = error_desc if error_desc else e.reason
+            msg_code = None
+            if error_desc and "service account" in error_desc.lower():
+                msg = messages.GCP_SERVICE_ACCT_NOT_ENABLED_ERROR.msg.format(
+                    error_msg=msg
+                )
+                msg_code = messages.GCP_SERVICE_ACCT_NOT_ENABLED_ERROR.name
+            raise exceptions.GCPProAccountError(
+                msg=msg, msg_code=msg_code, code=getattr(e, "code", 0)
+            )
         return {"identityToken": url_response}
 
     @property

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -12,6 +12,7 @@ from uaclient.clouds.gcp import (
     WAIT_FOR_CHANGE,
     UAAutoAttachGCPInstance,
 )
+from uaclient.exceptions import GCPProAccountError
 
 M_PATH = "uaclient.clouds.gcp."
 
@@ -57,7 +58,7 @@ class TestUAAutoAttachGCPInstance:
 
         instance = UAAutoAttachGCPInstance()
         if exception:
-            with pytest.raises(HTTPError) as excinfo:
+            with pytest.raises(GCPProAccountError) as excinfo:
                 instance.identity_doc
             assert 704 == excinfo.value.code
         else:
@@ -69,9 +70,12 @@ class TestUAAutoAttachGCPInstance:
         assert expected_sleep_calls == sleep.call_args_list
 
         expected_logs = [
-            "HTTP Error 701: funky error msg Retrying 3 more times.",
-            "HTTP Error 702: funky error msg Retrying 2 more times.",
-            "HTTP Error 703: funky error msg Retrying 1 more times.",
+            "GCPProServiceAccount Error 701: "
+            + "funky error msg Retrying 3 more times.",
+            "GCPProServiceAccount Error 702: "
+            + "funky error msg Retrying 2 more times.",
+            "GCPProServiceAccount Error 703: "
+            + "funky error msg Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -258,6 +258,19 @@ class SecurityAPIMetadataError(UserFacingError):
         )
 
 
+class GCPProAccountError(UserFacingError):
+    """An exception raised when GCP Pro service account is not enabled"""
+
+    def __init__(self, msg: str, msg_code: Optional[str], code=None):
+        self.code = code
+        super().__init__(msg, msg_code)
+
+    def __str__(self):
+        return "GCPProServiceAccount Error {code}: {msg}".format(
+            code=self.code, msg=self.msg
+        )
+
+
 class CloudFactoryError(Exception):
     def __init__(self, cloud_type: Optional[str]) -> None:
         self.cloud_type = cloud_type

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -743,6 +743,13 @@ REALTIME_ERROR_INSTALL_ON_CONTAINER = NamedMessage(
     "Cannot install Real-Time Kernel on a container.",
 )
 
+GCP_SERVICE_ACCT_NOT_ENABLED_ERROR = NamedMessage(
+    "gcp-pro-service-account-not-enabled",
+    "Failed to attach machine\n"
+    "{error_msg}\n"
+    "For more information, "
+    "see https://cloud.google.com/iam/docs/service-accounts",
+)
 
 LOG_CONNECTIVITY_ERROR_TMPL = CONNECTIVITY_ERROR.msg + " {error}"
 LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (


### PR DESCRIPTION
gcp-pro: handle metadata endpoint error

We are handling for the errors raised when using gcp pro and the service account is not enabled.
Fixes #1936 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
