### PR TITLE
enable: treat empty list affordance differently from null

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -564,8 +564,11 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 return ApplicabilityStatus.INAPPLICABLE, error_message
         affordances = entitlement_cfg["entitlement"].get("affordances", {})
         platform = util.get_platform_info()
-        affordance_arches = affordances.get("architectures", [])
-        if affordance_arches and platform["arch"] not in affordance_arches:
+        affordance_arches = affordances.get("architectures", None)
+        if (
+            affordance_arches is not None
+            and platform["arch"] not in affordance_arches
+        ):
             return (
                 ApplicabilityStatus.INAPPLICABLE,
                 messages.INAPPLICABLE_ARCH.format(
@@ -574,8 +577,11 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                     supported_arches=", ".join(affordance_arches),
                 ),
             )
-        affordance_series = affordances.get("series", [])
-        if affordance_series and platform["series"] not in affordance_series:
+        affordance_series = affordances.get("series", None)
+        if (
+            affordance_series is not None
+            and platform["series"] not in affordance_series
+        ):
             return (
                 ApplicabilityStatus.INAPPLICABLE,
                 messages.INAPPLICABLE_SERIES.format(
@@ -583,10 +589,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 ),
             )
         kernel = platform["kernel"]
-        affordance_kernels = affordances.get("kernelFlavors", [])
+        affordance_kernels = affordances.get("kernelFlavors", None)
         affordance_min_kernel = affordances.get("minKernelVersion")
         match = re.match(RE_KERNEL_UNAME, kernel)
-        if affordance_kernels:
+        if affordance_kernels is not None:
             if not match or match.group("flavor") not in affordance_kernels:
                 return (
                     ApplicabilityStatus.INAPPLICABLE,

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -52,7 +52,7 @@ def machine_access(
     additional_packages: List[str] = None
 ) -> Dict[str, Any]:
     if affordances is None:
-        affordances = {"series": []}  # Will match all series
+        affordances = {}
     if suites is None:
         suites = ["xenial"]
     if obligations is None:


### PR DESCRIPTION
## Notes

After this, an empty list for the series affordance will mean that no series are supported.
The same will be true for architectures and kernel flavors.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
enable: treat empty list affordance differently from null
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the new integration test.

Use machine token overlays to test that an empty affordance list behaves as you expect.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
