### PR TITLE
Use pycloudlib.toml gce.credentials_path (SC-987)

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -105,14 +105,14 @@ jobs:
           UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED: '${{ secrets.UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED }}'
         run: |
           PYCLOUDLIB_CONFIG="$(mktemp --tmpdir="${{ runner.temp }}" pycloudlib.toml.XXXXXXXXXX)"
-          GOOGLE_APPLICATION_CREDENTIALS="$(mktemp --tmpdir="${{ runner.temp }}" gcloud.json.XXXXXXXXXX)"
+          GCE_CREDENTIALS_PATH="$(mktemp --tmpdir="${{ runner.temp }}" gcloud.json.XXXXXXXXXX)"
           export PYCLOUDLIB_CONFIG
-          export GOOGLE_APPLICATION_CREDENTIALS
+          export GCE_CREDENTIALS_PATH
 
           # Dump secrets using a subshell to avoid leaks due to xtrace.
           # Use printf as dash's echo always interpretes control sequences (e.g. \n).
           sh -c 'printf "%s\n" "$PYCLOUDLIB_CONFIG_CONTENTS" > "$PYCLOUDLIB_CONFIG"'
-          sh -c 'printf "%s\n" "$GOOGLE_APPLICATION_CREDENTIALS_CONTENTS" > "$GOOGLE_APPLICATION_CREDENTIALS"'
+          sh -c 'printf "%s\n" "$GOOGLE_APPLICATION_CREDENTIALS_CONTENTS" > "$GCE_CREDENTIALS_PATH"'
 
           # SSH keys (should match what specified in pycloudlib.toml)
           mkdir ~/.ssh

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -486,8 +486,10 @@ class GCP(Cloud):
         if self.service_account_email:
             return
 
-        gcp_credentials_path = credentials.get("gce", {}).get(
-            "credentials_path"
+        gcp_credentials_path = os.path.expandvars(
+            os.path.expanduser(
+                credentials.get("gce", {}).get("credentials_path")
+            )
         )
         if gcp_credentials_path:
             with open(gcp_credentials_path, "r") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ deps =
     isort: -rdev-requirements.txt
     behave: -rintegration-requirements.txt
 passenv =
-    GOOGLE_APPLICATION_CREDENTIALS
     PYCLOUDLIB_CONFIG
+    GCE_CREDENTIALS_PATH
     AZURE_CONFIG_DIR
     UACLIENT_BEHAVE_*
     TRAVIS


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
Use pycloudlib.toml gce.credentials_path

Have pycloudlib handle the GCE credentials rather than using
the special GOOGLE_APPLICATION_CREDENTIALS, which is handled
directly by the gcloud library.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Let CI run.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
