### PR TITLE
fips: clean notice for older PRO FIPS images

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1041,7 +1041,7 @@ def docker_image_is_not_larger(context, name, series, package):
 
 
 @then(
-    "on `{release}`, systemd status output says memory usage is less than `{mb_limit}` MB"
+    "on `{release}`, systemd status output says memory usage is less than `{mb_limit}` MB"  # noqa
 )
 def systemd_memory_usage_less_than(context, release, mb_limit):
     curr_release = context.active_outline["release"]

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -83,6 +83,7 @@ def fix_pro_pkg_holds(cfg):
                     )
                     sys.exit(1)
                 cfg.remove_notice("", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg)
+                cfg.remove_notice("", messages.FIPS_REBOOT_REQUIRED_MSG)
 
 
 def refresh_contract(cfg):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -314,6 +314,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             self.cfg.remove_notice(
                 "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
             )
+            self.cfg.remove_notice("", messages.FIPS_REBOOT_REQUIRED_MSG)
             if util.load_file(self.FIPS_PROC_FILE).strip() == "1":
                 self.cfg.remove_notice(
                     "", messages.NOTICE_FIPS_MANUAL_DISABLE_URL
@@ -372,6 +373,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             self.cfg.remove_notice(
                 "", messages.NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD
             )
+            self.cfg.remove_notice("", messages.FIPS_REBOOT_REQUIRED_MSG)
             return True
 
         return False

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -432,7 +432,8 @@ class TestFIPSEntitlementEnable:
                 [
                     mock.call(
                         "", messages.NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD
-                    )
+                    ),
+                    mock.call("", messages.FIPS_REBOOT_REQUIRED_MSG),
                 ],
             ),
             (False, []),
@@ -451,7 +452,7 @@ class TestFIPSEntitlementEnable:
         m_repo_enable.return_value = repo_enable_return_value
         assert repo_enable_return_value is entitlement._perform_enable()
         assert (
-            expected_remove_notice_calls == m_remove_notice.call_args_list[:1]
+            expected_remove_notice_calls == m_remove_notice.call_args_list[:2]
         )
 
     @mock.patch("uaclient.apt.setup_apt_proxy")
@@ -961,6 +962,9 @@ class TestFIPSEntitlementApplicationStatus:
         entitlement.cfg.add_notice(
             "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
         )
+
+        if path_exists:
+            entitlement.cfg.add_notice("", messages.FIPS_REBOOT_REQUIRED_MSG)
 
         if proc_content == "0":
             entitlement.cfg.add_notice(


### PR DESCRIPTION
## Proposed Commit Message
fips: clean notice for older PRO FIPS images

We currently detect that an user is on an old PRO FIPS machine on our postinst script and emit a notice for that. However, even
after we fix the issue on the older image, we don't remove the notice. We are now properly cleaning up that notice.

LP: #1972026

## Test Steps
Run the modified unit tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
