### PR TITLE
chore: fix tox version of python for older tests to 3.8

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -27,7 +27,7 @@ jobs:
         run: tox -e mypy
   unit-tests:
     name: Unit
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
         run: |
@@ -39,5 +39,5 @@ jobs:
         run: |
           python3 -m venv unit-test-venv
           . unit-test-venv/bin/activate
-          pip install tox tox-pip-version
-          tox -e py3 -e py3-bionic -e py3-xenial
+          pip install tox tox-pip-version tox-setuptools-version
+          tox -e py3-test -e py38-test-bionic -e py38-test-xenial

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,9 +161,12 @@ The output file path/name can be changed using the `-o` option.
 
 ## Testing
 
-All unit and lint tests are run using `tox`. We also use `tox-pip-version` to specify an older pip version as a workaround: we have some required dependencies that can't meet the strict compatibility checks of current pip versions.
+All unit and lint tests are run using `tox`. We also use `tox-pip-version` and `tox-setuptools-version` to specify an older pip version as a workaround: we have some required dependencies that can't meet the strict compatibility checks of current pip/setuptools versions.
 
-First, install `tox` and `tox-pip-version` - you'll only have to do this once.
+The tests will run using your python3 installation. For the Xenial/Bionic, **it needs to be Python 3.8**: make sure you have it installed in your system.
+If Python 3.8 is not available from the repositories (too new or too old for your Ubuntu version), the [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) may be of help. You will need the `python3.8` and the `python3.8-distutils` packages.
+
+First, install `tox`, `tox-pip-version` and `tox-setuptools-version` - you'll only have to do this once.
 
 ```shell
 make testdeps

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
-envlist = py3, flake8, py3-{xenial,bionic}, flake8-{xenial,bionic}, mypy, black, isort
+envlist = py3-test, py3-flake8, py38-test-{xenial,bionic}, py38-flake8-{xenial,bionic}, mypy, black, isort
 
-[testenv:flake8-bionic]
+[testenv:py38-flake8-bionic]
 pip_version = 9.0.2
 setuptools_version = 59.8.0
 
-[testenv:flake8-xenial]
+[testenv:py38-flake8-xenial]
 pip_version = 9.0.2
 setuptools_version = 59.8.0
 
-[testenv:py3-xenial]
+[testenv:py38-test-xenial]
 pip_version = 9.0.2
 setuptools_version = 59.8.0
 
-[testenv:py3-bionic]
+[testenv:py38-test-bionic]
 pip_version = 9.0.2
 setuptools_version = 59.8.0
 
@@ -49,7 +49,7 @@ setenv =
     vm: UACLIENT_BEHAVE_MACHINE_TYPE = lxd.vm
     docker: UACLIENT_BEHAVE_MACHINE_TYPE = lxd.vm
 commands =
-    py3: py.test --junitxml=pytest_results.xml {posargs:--cov uaclient uaclient}
+    test: py.test --junitxml=pytest_results.xml {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient lib setup.py
     flake8-bionic: flake8 features
     mypy: mypy --python-version 3.5 uaclient/


### PR DESCRIPTION
Jammy runs Python 3.10, and it fails to satisfy the pip and setuptools
pinned versions.
Those tests (for Xenial/Bionic constraints) run fine with Python 3.8.
Python 3.8 (and its distutils) must be in your system for those tests to run properly.

## Test Steps
On a Jammy system, with Python 3.10 as the default, and Python 3.8 installed:
`$ make clean`
`$ tox`
Everything should be executed as usual, and pass.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
