### PR TITLE
fix: add --dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Users can manually run the `ua` command to learn more or view the manpage.
 * [How to attach with a configuration file?](./docs/howtoguides/how_to_attach_with_config_file.md)
 * [How to collect UA logs?](./docs/howtoguides/how_to_collect_ua_logs.md)
 * [How to Simulate attach operation](./docs/howtoguides/how_to_simulate_attach.md)
+* [How to run ua fix in dry-run mode](./docs/howtoguides/how_to_run_ua_fix_in_dry_run_mode.md)
 
 ### Reference
 

--- a/docs/howtoguides/how_to_run_ua_fix_in_dry_run_mode.md
+++ b/docs/howtoguides/how_to_run_ua_fix_in_dry_run_mode.md
@@ -1,0 +1,50 @@
+# How to run fix command in dry run mode
+
+If you are unsure on what changes will happen on your system after you run `ua fix` to address a
+CVE/USN, you can use the `--dry-run` flag to see that packages will be installed in the system if
+the command was actually run. For example, this is the output of running `ua fix USN-5079-2 --dry-run`:
+
+```
+WARNING: The option --dry-run is being used.
+No packages will be installed when running this command.
+USN-5079-2: curl vulnerabilities
+Found CVEs:
+https://ubuntu.com/security/CVE-2021-22946
+https://ubuntu.com/security/CVE-2021-22947
+1 affected source package is installed: curl
+(1/1) curl:
+A fix is available in UA Infra.
+The machine is not attached to an Ubuntu Advantage (UA) subscription.
+To proceed with the fix, a prompt would ask for a valid UA token.
+{ ua attach TOKEN }
+UA service: esm-infra is not enabled.
+To proceed with the fix, a prompt would ask permission to automatically enable
+this service.
+{ ua enable esm-infra }
+{ apt update && apt install --only-upgrade -y curl libcurl3-gnutls }
+✔ USN-5079-2 is resolved.
+```
+
+You can see that using `--dry-run` will also indicate which actions would need to happen
+to completely address the USN/CVE. Here we can see that the package fix can only be accessed
+through the `esm-infra` service. Therefore, we need a UA subscription, as can be seen on this
+part of the output:
+
+```
+The machine is not attached to an Ubuntu Advantage (UA) subscription.
+To proceed with the fix, a prompt would ask for a valid UA token.
+{ ua attach TOKEN }
+```
+
+Additionally, we also inform you that even with a subscription, we need the specific
+`esm-infra` service to be enabled:
+
+```
+UA service: esm-infra is not enabled.
+To proceed with the fix, a prompt would ask permission to automatically enable
+this service.
+{ ua enable esm-infra }
+```
+
+After performing these steps during a fix command without `--dry-run`, your machine should
+no longer be affected by that USN we used as an example.

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -101,114 +101,170 @@ Feature: Ua fix command behaviour
         And I reboot the `<release>` machine
         And I verify that running `ua fix USN-4539-1` `as non-root` exits `1`
         Then stdout matches regexp:
-            """
-            USN-4539-1: AWL vulnerability
-            Found CVEs:
-            https://ubuntu.com/security/CVE-2020-11728
-            1 affected source package is installed: awl
-            \(1/1\) awl:
-            Sorry, no fix is available.
-            1 package is still affected: awl
-            .*✘.* USN-4539-1 is not resolved.
-            """
+        """
+        USN-4539-1: AWL vulnerability
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2020-11728
+        1 affected source package is installed: awl
+        \(1/1\) awl:
+        Sorry, no fix is available.
+        1 package is still affected: awl
+        .*✘.* USN-4539-1 is not resolved.
+        """
         When I run `ua fix CVE-2020-15180` as non-root
         Then stdout matches regexp:
-            """
-            CVE-2020-15180: MariaDB vulnerabilities
-            https://ubuntu.com/security/CVE-2020-15180
-            No affected source packages are installed.
-            .*✔.* CVE-2020-15180 does not affect your system.
-            """
+        """
+        CVE-2020-15180: MariaDB vulnerabilities
+        https://ubuntu.com/security/CVE-2020-15180
+        No affected source packages are installed.
+        .*✔.* CVE-2020-15180 does not affect your system.
+        """
         When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
-            """
-            CVE-2020-28196: Kerberos vulnerability
-            https://ubuntu.com/security/CVE-2020-28196
-            1 affected source package is installed: krb5
-            \(1/1\) krb5:
-            A fix is available in Ubuntu standard updates.
-            The update is already installed.
-            .*✔.* CVE-2020-28196 is resolved.
-            """
+        """
+        CVE-2020-28196: Kerberos vulnerability
+        https://ubuntu.com/security/CVE-2020-28196
+        1 affected source package is installed: krb5
+        \(1/1\) krb5:
+        A fix is available in Ubuntu standard updates.
+        The update is already installed.
+        .*✔.* CVE-2020-28196 is resolved.
+        """
         When I run `DEBIAN_FRONTEND=noninteractive apt-get install -y expat=2.1.0-7 swish-e matanza ghostscript` with sudo
-        And I verify that running `ua fix CVE-2017-9233` `with sudo` exits `1`
+        And I verify that running `ua fix CVE-2017-9233 --dry-run` `as non-root` exits `1`
         Then stdout matches regexp:
-            """
-            CVE-2017-9233: Expat vulnerability
-            https://ubuntu.com/security/CVE-2017-9233
-            3 affected source packages are installed: expat, matanza, swish-e
-            \(1/3, 2/3\) matanza, swish-e:
-            Sorry, no fix is available.
-            \(3/3\) expat:
-            A fix is available in Ubuntu standard updates.
-            .*\{ apt update && apt install --only-upgrade -y expat \}.*
-            2 packages are still affected: matanza, swish-e
-            .*✘.* CVE-2017-9233 is not resolved.
-            """
+        """
+        .*WARNING: The option --dry-run is being used.
+        No packages will be installed when running this command..*
+        CVE-2017-9233: Expat vulnerability
+        https://ubuntu.com/security/CVE-2017-9233
+        3 affected source packages are installed: expat, matanza, swish-e
+        \(1/3, 2/3\) matanza, swish-e:
+        Sorry, no fix is available.
+        \(3/3\) expat:
+        A fix is available in Ubuntu standard updates.
+        .*\{ apt update && apt install --only-upgrade -y expat \}.*
+        2 packages are still affected: matanza, swish-e
+        .*✘.* CVE-2017-9233 is not resolved.
+        """
+        When I verify that running `ua fix CVE-2017-9233` `with sudo` exits `1`
+        Then stdout matches regexp:
+        """
+        CVE-2017-9233: Expat vulnerability
+        https://ubuntu.com/security/CVE-2017-9233
+        3 affected source packages are installed: expat, matanza, swish-e
+        \(1/3, 2/3\) matanza, swish-e:
+        Sorry, no fix is available.
+        \(3/3\) expat:
+        A fix is available in Ubuntu standard updates.
+        .*\{ apt update && apt install --only-upgrade -y expat \}.*
+        2 packages are still affected: matanza, swish-e
+        .*✘.* CVE-2017-9233 is not resolved.
+        """
+        When I run `ua fix USN-5079-2 --dry-run` as non-root
+        Then stdout matches regexp:
+        """
+        .*WARNING: The option --dry-run is being used.
+        No packages will be installed when running this command..*
+        USN-5079-2: curl vulnerabilities
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2021-22946
+        https://ubuntu.com/security/CVE-2021-22947
+        1 affected source package is installed: curl
+        \(1/1\) curl:
+        A fix is available in UA Infra.
+        .*The machine is not attached to an Ubuntu Advantage \(UA\) subscription.
+        To proceed with the fix, a prompt would ask for a valid UA token.
+        \{ ua attach TOKEN \}.*
+        .*UA service: esm-infra is not enabled.
+        To proceed with the fix, a prompt would ask permission to automatically enable
+        this service.
+        \{ ua enable esm-infra \}.*
+        .*\{ apt update && apt install --only-upgrade -y curl libcurl3-gnutls \}.*
+        .*✔.* USN-5079-2 is resolved.
+        """
         When I fix `USN-5079-2` by attaching to a subscription with `contract_token_staging_expired`
         Then stdout matches regexp
-            """
-            USN-5079-2: curl vulnerabilities
-            Found CVEs:
-            https://ubuntu.com/security/CVE-2021-22946
-            https://ubuntu.com/security/CVE-2021-22947
-            1 affected source package is installed: curl
-            \(1/1\) curl:
-            A fix is available in UA Infra.
-            The update is not installed because this system is not attached to a
-            subscription.
+        """
+        USN-5079-2: curl vulnerabilities
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2021-22946
+        https://ubuntu.com/security/CVE-2021-22947
+        1 affected source package is installed: curl
+        \(1/1\) curl:
+        A fix is available in UA Infra.
+        The update is not installed because this system is not attached to a
+        subscription.
 
-            Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
-            > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
-            > .*\{ ua attach .*\}.*
-            Attach denied:
-            Contract ".*" expired on .*
-            Visit https://ubuntu.com/advantage to manage contract tokens.
-            1 package is still affected: curl
-            .*✘.* USN-5079-2 is not resolved.
-            """
+        Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
+        > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
+        > .*\{ ua attach .*\}.*
+        Attach denied:
+        Contract ".*" expired on .*
+        Visit https://ubuntu.com/advantage to manage contract tokens.
+        1 package is still affected: curl
+        .*✘.* USN-5079-2 is not resolved.
+        """
         When I fix `USN-5079-2` by attaching to a subscription with `contract_token`
         Then stdout matches regexp:
-            """
-            USN-5079-2: curl vulnerabilities
-            Found CVEs:
-            https://ubuntu.com/security/CVE-2021-22946
-            https://ubuntu.com/security/CVE-2021-22947
-            1 affected source package is installed: curl
-            \(1/1\) curl:
-            A fix is available in UA Infra.
-            The update is not installed because this system is not attached to a
-            subscription.
+        """
+        USN-5079-2: curl vulnerabilities
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2021-22946
+        https://ubuntu.com/security/CVE-2021-22947
+        1 affected source package is installed: curl
+        \(1/1\) curl:
+        A fix is available in UA Infra.
+        The update is not installed because this system is not attached to a
+        subscription.
 
-            Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
-            > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
-            > .*\{ ua attach .*\}.*
-            Updating package lists
-            UA Apps: ESM enabled
-            Updating package lists
-            UA Infra: ESM enabled
-            """
+        Choose: \[S\]ubscribe at ubuntu.com \[A\]ttach existing token \[C\]ancel
+        > Enter your token \(from https://ubuntu.com/advantage\) to attach this system:
+        > .*\{ ua attach .*\}.*
+        Updating package lists
+        UA Apps: ESM enabled
+        Updating package lists
+        UA Infra: ESM enabled
+        """
         And stdout matches regexp:
-            """
-            .*\{ apt update && apt install --only-upgrade -y curl libcurl3-gnutls \}.*
-            .*✔.* USN-5079-2 is resolved.
-            """
+        """
+        .*\{ apt update && apt install --only-upgrade -y curl libcurl3-gnutls \}.*
+        .*✔.* USN-5079-2 is resolved.
+        """
         When I verify that running `ua fix USN-5051-2` `with sudo` exits `2`
         Then stdout matches regexp:
-            """
-            USN-5051-2: OpenSSL vulnerability
-            Found CVEs:
-            https://ubuntu.com/security/CVE-2021-3712
-            1 affected source package is installed: openssl
-            \(1/1\) openssl:
-            A fix is available in UA Infra.
-            .*\{ apt update && apt install --only-upgrade -y libssl1.0.0 openssl \}.*
-            A reboot is required to complete fix operation.
-            .*✘.* USN-5051-2 is not resolved.
-            """
+        """
+        USN-5051-2: OpenSSL vulnerability
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2021-3712
+        1 affected source package is installed: openssl
+        \(1/1\) openssl:
+        A fix is available in UA Infra.
+        .*\{ apt update && apt install --only-upgrade -y libssl1.0.0 openssl \}.*
+        A reboot is required to complete fix operation.
+        .*✘.* USN-5051-2 is not resolved.
+        """
         When I run `ua disable esm-infra` with sudo
         And I run `apt-get install gzip -y` with sudo
-        And I run `ua fix USN-5378-4` `with sudo` and stdin `E`
+        And I run `ua fix USN-5378-4 --dry-run` as non-root
+        Then stdout matches regexp:
+        """
+        .*WARNING: The option --dry-run is being used.
+        No packages will be installed when running this command..*
+        USN-5378-4: Gzip vulnerability
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2022-1271
+        2 affected source packages are installed: gzip, xz-utils
+        \(1/2, 2/2\) gzip, xz-utils:
+        A fix is available in UA Infra.
+        .*UA service: esm-infra is not enabled.
+        To proceed with the fix, a prompt would ask permission to automatically enable
+        this service.
+        \{ ua enable esm-infra \}.*
+        .*\{ apt update && apt install --only-upgrade -y gzip liblzma5 xz-utils \}.*
+        .*✔.* USN-5378-4 is resolved.
+        """
+        When I run `ua fix USN-5378-4` `with sudo` and stdin `E`
         Then stdout matches regexp:
         """
         USN-5378-4: Gzip vulnerability
@@ -239,50 +295,64 @@ Feature: Ua fix command behaviour
         Given a `bionic` machine with ubuntu-advantage-tools installed
         When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
-            """
-            Error: CVE-1800-123456 not found.
-            """
+        """
+        Error: CVE-1800-123456 not found.
+        """
         When I verify that running `ua fix USN-12345-12` `as non-root` exits `1`
         Then I will see the following on stderr:
-            """
-            Error: USN-12345-12 not found.
-            """
+        """
+        Error: USN-12345-12 not found.
+        """
         When I verify that running `ua fix CVE-12345678-12` `as non-root` exits `1`
         Then I will see the following on stderr:
-            """
-            Error: issue "CVE-12345678-12" is not recognized.
-            Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
-            """
+        """
+        Error: issue "CVE-12345678-12" is not recognized.
+        Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
+        """
         When I verify that running `ua fix USN-12345678-12` `as non-root` exits `1`
         Then I will see the following on stderr:
-            """
-            Error: issue "USN-12345678-12" is not recognized.
-            Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
-            """
+        """
+        Error: issue "USN-12345678-12" is not recognized.
+        Usage: "ua fix CVE-yyyy-nnnn" or "ua fix USN-nnnn"
+        """
         When I run `apt install -y libawl-php` with sudo
-        And I verify that running `ua fix USN-4539-1` `as non-root` exits `1`
+        And I verify that running `ua fix USN-4539-1 --dry-run` `as non-root` exits `1`
         Then stdout matches regexp:
-            """
-            USN-4539-1: AWL vulnerability
-            Found CVEs:
-            https://ubuntu.com/security/CVE-2020-11728
-            1 affected source package is installed: awl
-            \(1/1\) awl:
-            Ubuntu security engineers are investigating this issue.
-            1 package is still affected: awl
-            .*✘.* USN-4539-1 is not resolved.
-            """
+        """
+        .*WARNING: The option --dry-run is being used.
+        No packages will be installed when running this command..*
+        USN-4539-1: AWL vulnerability
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2020-11728
+        1 affected source package is installed: awl
+        \(1/1\) awl:
+        Ubuntu security engineers are investigating this issue.
+        1 package is still affected: awl
+        .*✘.* USN-4539-1 is not resolved.
+        """
+        When I verify that running `ua fix USN-4539-1` `as non-root` exits `1`
+        Then stdout matches regexp:
+        """
+        USN-4539-1: AWL vulnerability
+        Found CVEs:
+        https://ubuntu.com/security/CVE-2020-11728
+        1 affected source package is installed: awl
+        \(1/1\) awl:
+        Ubuntu security engineers are investigating this issue.
+        1 package is still affected: awl
+        .*✘.* USN-4539-1 is not resolved.
+        """
         When I run `ua fix CVE-2020-28196` as non-root
         Then stdout matches regexp:
-            """
-            CVE-2020-28196: Kerberos vulnerability
-            https://ubuntu.com/security/CVE-2020-28196
-            1 affected source package is installed: krb5
-            \(1/1\) krb5:
-            A fix is available in Ubuntu standard updates.
-            The update is already installed.
-            .*✔.* CVE-2020-28196 is resolved.
-            """
+        """
+        CVE-2020-28196: Kerberos vulnerability
+        https://ubuntu.com/security/CVE-2020-28196
+        1 affected source package is installed: krb5
+        \(1/1\) krb5:
+        A fix is available in Ubuntu standard updates.
+        The update is already installed.
+        .*✔.* CVE-2020-28196 is resolved.
+        """
         When I run `apt-get install xterm=330-1ubuntu2 -y` with sudo
         And I verify that running `ua fix CVE-2021-27135` `as non-root` exits `1`
         Then stdout matches regexp:
@@ -296,6 +366,19 @@ Feature: Ua fix command behaviour
         To install them, run this command as root \(try using sudo\)
         1 package is still affected: xterm
         .*✘.* CVE-2021-27135 is not resolved.
+        """
+        When I run `ua fix CVE-2021-27135 --dry-run` with sudo
+        Then stdout matches regexp:
+        """
+        .*WARNING: The option --dry-run is being used.
+        No packages will be installed when running this command..*
+        CVE-2021-27135: xterm vulnerability
+        https://ubuntu.com/security/CVE-2021-27135
+        1 affected source package is installed: xterm
+        \(1/1\) xterm:
+        A fix is available in Ubuntu standard updates.
+        .*\{ apt update && apt install --only-upgrade -y xterm \}.*
+        .*✔.* CVE-2021-27135 is resolved.
         """
         When I run `ua fix CVE-2021-27135` with sudo
         Then stdout matches regexp:

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -422,6 +422,16 @@ def fix_parser(parser):
             " Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
         ),
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "If used, fix will not actually run but will display"
+            " everything that will happen on the machine during the"
+            " command."
+        ),
+    )
+
     return parser
 
 
@@ -506,7 +516,11 @@ def action_fix(args, *, cfg, **kwargs):
         ).format(args.security_issue)
         raise exceptions.UserFacingError(msg)
 
-    fix_status = security.fix_security_issue_id(cfg, args.security_issue)
+    fix_status = security.fix_security_issue_id(
+        cfg=cfg,
+        issue_id=args.security_issue,
+        dry_run=args.dry_run,
+    )
     return fix_status.value
 
 

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -107,6 +107,7 @@ def FakeConfig(tmpdir):
             cls,
             account_name: str = "test_account",
             machine_token: Dict[str, Any] = None,
+            status_cache: Dict[str, Any] = None,
         ):
             if not machine_token:
                 machine_token = {
@@ -133,8 +134,13 @@ def FakeConfig(tmpdir):
                         },
                     },
                 }
+
+            if not status_cache:
+                status_cache = {"attached": True}
+
             config = cls()
             config.write_cache("machine-token", machine_token)
+            config.write_cache("status-cache", status_cache)
             return config
 
         def override_features(self, features_override):

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -74,6 +74,32 @@ SECURITY_AFFECTED_PKGS = (
 USN_FIXED = "{issue} is addressed."
 CVE_FIXED = "{issue} is resolved."
 SECURITY_URL = "{issue}: {title}\nhttps://ubuntu.com/security/{url_path}"
+SECURITY_DRY_RUN_UA_SERVICE_NOT_ENABLED = """\
+{bold}UA service: {{service}} is not enabled.
+To proceed with the fix, a prompt would ask permission to automatically enable
+this service.
+{{{{ ua enable {{service}} }}}}{end_bold}""".format(
+    bold=TxtColor.BOLD, end_bold=TxtColor.ENDC
+)
+SECURITY_DRY_RUN_UA_NOT_ATTACHED = """\
+{bold}The machine is not attached to an Ubuntu Advantage (UA) subscription.
+To proceed with the fix, a prompt would ask for a valid UA token.
+{{ ua attach TOKEN }}{end_bold}""".format(
+    bold=TxtColor.BOLD, end_bold=TxtColor.ENDC
+)
+SECURITY_DRY_RUN_UA_EXPIRED_SUBSCRIPTION = """\
+{bold}The machine has an expired subscription.
+To proceed with the fix, a prompt would ask for a new Ubuntu Advantage (UA)
+token to renew the subscription.
+{{ ua detach --assume-yes }}
+{{ ua attach NEW_TOKEN }}{end_bold}""".format(
+    bold=TxtColor.BOLD, end_bold=TxtColor.ENDC
+)
+SECURITY_DRY_RUN_WARNING = """\
+{bold}WARNING: The option --dry-run is being used.
+No packages will be installed when running this command.{end_bold}""".format(
+    bold=TxtColor.BOLD, end_bold=TxtColor.ENDC
+)
 SECURITY_UA_SERVICE_NOT_ENABLED = """\
 Error: UA service: {service} is not enabled.
 Without it, we cannot fix the system."""

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -22,6 +22,9 @@ positional arguments:
 
 Flags:
   -h, --help      show this help message and exit
+  --dry-run       If used, fix will not actually run but will display
+                  everything that will happen on the machine during the
+                  command.
 """
 )
 
@@ -60,12 +63,12 @@ class TestActionFix:
     ):
         """Check that root and non-root will emit attached status"""
         cfg = FakeConfig()
-        args = mock.MagicMock(security_issue=issue)
+        args = mock.MagicMock(security_issue=issue, dry_run=False)
         m_fix_security_issue_id.return_value = FixStatus.SYSTEM_NON_VULNERABLE
         if is_valid:
             assert 0 == action_fix(args, cfg=cfg)
             assert [
-                mock.call(cfg, issue)
+                mock.call(cfg=cfg, issue_id=issue, dry_run=False)
             ] == m_fix_security_issue_id.call_args_list
         else:
             with pytest.raises(exceptions.UserFacingError) as excinfo:

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -563,6 +563,7 @@ class TestStatus:
         other_cfg = FakeConfig.for_attached_machine()
         cfg.write_cache("accounts", {"accounts": other_cfg.accounts})
         cfg.write_cache("machine-token", other_cfg.machine_token)
+        cfg.delete_cache_key("status-cache")
         assert status._attached_status(cfg=cfg) != before
 
         # Run as regular user and confirm that we see the result from


### PR DESCRIPTION
## Proposed Commit Message
fix: add --dry-run option

Add support for --dry-run option for ua fix command. This option allow users to see what will happen in their system once if the fix command is actually used.

## Test Steps
Run the modified integration test added

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
