### PR TITLE
fips: remove message when enabling fips-updates

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -22,7 +22,7 @@ DAILY_PPA_KEYID = "6E34E7116C0BC933"
 
 USERDATA_BLOCK_AUTO_ATTACH_IMG = """\
 #cloud-config
-bootcmd:
+[bootcmd, once]:
  - cp /usr/bin/ua /usr/bin/ua.orig
  - 'echo "#!/bin/sh\ndate >> /root/ua-calls\n" > /usr/bin/ua'
  - chmod 755 /usr/bin/ua

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -17,20 +17,20 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `ua status --wait` as non-root
         And I run `ua status` as non-root
         Then stdout matches regexp:
-            """
-            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
-            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
-            fips          +yes +enabled +NIST-certified core packages
-            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
-            livepatch     +yes +n/a  +Canonical Livepatch service
-            """
+        """
+        esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+        esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+        fips          +yes +enabled +NIST-certified core packages
+        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        livepatch     +yes +n/a  +Canonical Livepatch service
+        """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         When I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel-version>
-            """
+        """
+        <fips-kernel-version>
+        """
         When I run `apt-cache policy ubuntu-azure-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -99,26 +99,31 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         When I run `ua enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Disabling incompatible service: FIPS
-            Updating package lists
-            Installing FIPS Updates packages
-            FIPS Updates enabled
-            A reboot is required to complete install.
-            """
+        """
+        One moment, checking your subscription first
+        Disabling incompatible service: FIPS
+        Updating package lists
+        Installing FIPS Updates packages
+        FIPS Updates enabled
+        A reboot is required to complete install.
+        """
         When I run `ua status` with sudo
         Then stdout matches regexp:
-            """
-            fips          +yes +n/a +NIST-certified core packages
-            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
-            """
+        """
+        fips          +yes +n/a +NIST-certified core packages
+        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        """
+        And stdout matches regexp:
+        """
+        NOTICES
+        FIPS support requires system reboot to complete configuration.
+        """
         When I reboot the `<release>` machine
         And I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel-version>
-            """
+        """
+        <fips-kernel-version>
+        """
         When I run `apt-cache policy ubuntu-azure-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -128,6 +133,12 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then I will see the following on stdout:
         """
         1
+        """
+        When I run `ua status` with sudo
+        Then stdout does not match regexp:
+        """
+        NOTICES
+        FIPS support requires system reboot to complete configuration.
         """
 
         Examples: ubuntu release
@@ -225,20 +236,20 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `ua status --wait` as non-root
         And I run `ua status` as non-root
         Then stdout matches regexp:
-            """
-            esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
-            esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
-            fips          +yes +enabled +NIST-certified core packages
-            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
-            livepatch     +yes +n/a  +Canonical Livepatch service
-            """
+        """
+        esm-apps      +yes +enabled +UA Apps: Extended Security Maintenance \(ESM\)
+        esm-infra     +yes +enabled +UA Infra: Extended Security Maintenance \(ESM\)
+        fips          +yes +enabled +NIST-certified core packages
+        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        livepatch     +yes +n/a  +Canonical Livepatch service
+        """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         When I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel-version>
-            """
+        """
+        <fips-kernel-version>
+        """
         When I run `apt-cache policy ubuntu-aws-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -307,26 +318,31 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         When I run `ua enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Disabling incompatible service: FIPS
-            Updating package lists
-            Installing FIPS Updates packages
-            FIPS Updates enabled
-            A reboot is required to complete install.
-            """
+        """
+        One moment, checking your subscription first
+        Disabling incompatible service: FIPS
+        Updating package lists
+        Installing FIPS Updates packages
+        FIPS Updates enabled
+        A reboot is required to complete install.
+        """
         When I run `ua status` with sudo
         Then stdout matches regexp:
-            """
-            fips          +yes +n/a +NIST-certified core packages
-            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
-            """
+        """
+        fips          +yes +n/a +NIST-certified core packages
+        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        """
+        And stdout matches regexp:
+        """
+        NOTICES
+        FIPS support requires system reboot to complete configuration.
+        """
         When I reboot the `<release>` machine
         And I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel-version>
-            """
+        """
+        <fips-kernel-version>
+        """
         When I run `apt-cache policy ubuntu-aws-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -336,6 +352,12 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then I will see the following on stdout:
         """
         1
+        """
+        When I run `ua status` with sudo
+        Then stdout does not match regexp:
+        """
+        NOTICES
+        FIPS support requires system reboot to complete configuration.
         """
 
         Examples: ubuntu release
@@ -498,9 +520,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         When I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel-version>
-            """
+        """
+        <fips-kernel-version>
+        """
         When I run `apt-cache policy ubuntu-gcp-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -569,26 +591,31 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         When I run `ua enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Disabling incompatible service: FIPS
-            Updating package lists
-            Installing FIPS Updates packages
-            FIPS Updates enabled
-            A reboot is required to complete install.
-            """
+        """
+        One moment, checking your subscription first
+        Disabling incompatible service: FIPS
+        Updating package lists
+        Installing FIPS Updates packages
+        FIPS Updates enabled
+        A reboot is required to complete install.
+        """
         When I run `ua status` with sudo
         Then stdout matches regexp:
-            """
-            fips          +yes +n/a +NIST-certified core packages
-            fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
-            """
+        """
+        fips          +yes +n/a +NIST-certified core packages
+        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        """
+        And stdout matches regexp:
+        """
+        NOTICES
+        FIPS support requires system reboot to complete configuration.
+        """
         When I reboot the `<release>` machine
         And I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel-version>
-            """
+        """
+        <fips-kernel-version>
+        """
         When I run `apt-cache policy ubuntu-gcp-fips` as non-root
         Then stdout does not match regexp:
         """
@@ -598,6 +625,12 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then I will see the following on stdout:
         """
         1
+        """
+        When I run `ua status` with sudo
+        Then stdout does not match regexp:
+        """
+        NOTICES
+        FIPS support requires system reboot to complete configuration.
         """
 
         Examples: ubuntu release

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -311,9 +311,14 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             return super_status, super_msg
 
         if os.path.exists(self.FIPS_PROC_FILE):
-            self.cfg.remove_notice(
-                "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
-            )
+
+            # We are now only removing the notice if there is no reboot
+            # required information regarding the fips metapackage we install.
+            if not util.should_reboot(set(self.packages)):
+                self.cfg.remove_notice(
+                    "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
+                )
+
             self.cfg.remove_notice("", messages.FIPS_REBOOT_REQUIRED_MSG)
             if util.load_file(self.FIPS_PROC_FILE).strip() == "1":
                 self.cfg.remove_notice(
@@ -559,6 +564,7 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     def _perform_enable(self, silent: bool = False) -> bool:
         if super()._perform_enable(silent=silent):
+            self.cfg.remove_notice("", messages.FIPS_DISABLE_REBOOT_REQUIRED)
             services_once_enabled = (
                 self.cfg.read_cache("services-once-enabled") or {}
             )


### PR DESCRIPTION
## Proposed Commit Message
fips: remove message when enabling fips-updates

When we have fips enabled and we enable fips-updates, we don't want to emit a notice stating that to disable fips we need to reboot the system. However, we still want to warn users that a system reboot is needed to boot on the fips-updates kernel

## Test Steps
Run the modified ubuntu-pro-fips tests and also normal fips tests to confirm no behavior change

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
