### PR TITLE
refactor: use remove_file fn everywhere

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -317,7 +317,7 @@ class UAConfig:
                 lock_pid,
                 lock_holder,
             )
-            os.unlink(lock_path)
+            util.remove_file(lock_path)
             return no_lock
 
     @property
@@ -569,8 +569,7 @@ class UAConfig:
         (This is a separate method to allow easier disabling of deletion during
         tests.)
         """
-        if os.path.exists(cache_path):
-            os.unlink(cache_path)
+        util.remove_file(cache_path)
 
     def delete_cache_key(self, key: str) -> None:
         """Remove specific cache file."""

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -352,8 +352,9 @@ class RepoEntitlement(base.UAEntitlement):
                     self.origin,
                     self.repo_pin_priority,
                 )
-            elif os.path.exists(repo_pref_file):
-                os.unlink(repo_pref_file)  # Remove disabling apt pref file
+            else:
+                # Remove disabling apt pref file
+                util.remove_file(repo_pref_file)
 
         prerequisite_pkgs = []
         if not os.path.exists(apt.APT_METHOD_HTTPS_FILE):
@@ -424,8 +425,8 @@ class RepoEntitlement(base.UAEntitlement):
                     self.origin,
                     self.repo_pin_priority,
                 )
-            elif os.path.exists(repo_pref_file):
-                os.unlink(repo_pref_file)
+            else:
+                util.remove_file(repo_pref_file)
 
         if run_apt_update:
             if not silent:

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -230,8 +230,8 @@ class TestESMInfraEntitlementEnable:
                     M_REPOPATH + "os.path.exists", side_effect=fake_exists
                 )
             )
-            m_unlink = stack.enter_context(
-                mock.patch("uaclient.apt.os.unlink")
+            m_remove_file = stack.enter_context(
+                mock.patch("uaclient.util.remove_file")
             )
             # Note that this patch uses a PropertyMock and happens on the
             # entitlement's type because packages is a property
@@ -284,14 +284,14 @@ class TestESMInfraEntitlementEnable:
         assert 0 == m_add_pinning.call_count
         assert subp_calls == m_subp.call_args_list
         if entitlement.name == "esm-infra":  # Remove "never" apt pref pin
-            unlink_calls = [
+            remove_file_calls = [
                 mock.call(
                     "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name)
                 )
             ]
         else:
-            unlink_calls = []  # esm-apps doesn't write an apt pref file
-        assert unlink_calls == m_unlink.call_args_list
+            remove_file_calls = []  # esm-apps doesn't write an apt pref file
+        assert remove_file_calls == m_remove_file.call_args_list
         assert [
             mock.call(entitlement.cfg)
         ] == m_update_apt_and_motd_msgs.call_args_list
@@ -349,8 +349,8 @@ class TestESMInfraEntitlementEnable:
                     M_REPOPATH + "os.path.exists", side_effect=fake_exists
                 )
             )
-            m_unlink = stack.enter_context(
-                mock.patch("uaclient.apt.os.unlink")
+            m_remove_file = stack.enter_context(
+                mock.patch("uaclient.util.remove_file")
             )
 
             m_can_enable.return_value = (True, None)
@@ -386,14 +386,16 @@ class TestESMInfraEntitlementEnable:
         assert subp_calls == m_subp.call_args_list
         if entitlement.name == "esm-infra":
             # Enable esm-infra xenial removes apt preferences pin 'never' file
-            unlink_calls = [
+            remove_file_calls = [
                 mock.call(
                     "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name)
                 )
             ]
         else:
-            unlink_calls = []  # esm-apps there is no apt pref file to remove
-        assert unlink_calls == m_unlink.call_args_list
+            remove_file_calls = (
+                []
+            )  # esm-apps there is no apt pref file to remove
+        assert remove_file_calls == m_remove_file.call_args_list
         assert [
             mock.call(run_apt_update=False)
         ] == m_remove_apt_config.call_args_list

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -736,7 +736,7 @@ class TestRemoveAptConfig:
             )
         ] == m_add_ppa_pinning.call_args_list
 
-    @mock.patch(M_PATH + "os.unlink")
+    @mock.patch(M_PATH + "util.remove_file")
     @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
     @mock.patch(M_PATH + "apt.remove_apt_list_files")
     @mock.patch(M_PATH + "apt.run_apt_command")
@@ -749,7 +749,7 @@ class TestRemoveAptConfig:
         _m_run_apt_command,
         _m_remove_apt_list_files,
         _m_remove_auth_apt_repo,
-        m_unlink,
+        m_remove_file,
         entitlement_factory,
     ):
         """Remove apt preferences file when repo_pin_priority is an int."""
@@ -760,12 +760,10 @@ class TestRemoveAptConfig:
         )
 
         assert 1000 == entitlement.repo_pin_priority
-        with mock.patch(M_PATH + "os.path.exists") as m_exists:
-            m_exists.return_value = True
-            entitlement.remove_apt_config()
-        expected_call = [mock.call("/etc/apt/preferences.d/ubuntu-repotest")]
-        assert expected_call == m_exists.call_args_list
-        assert expected_call == m_unlink.call_args_list
+        entitlement.remove_apt_config()
+        assert [
+            mock.call("/etc/apt/preferences.d/ubuntu-repotest")
+        ] == m_remove_file.call_args_list
 
 
 class TestSetupAptConfig:
@@ -915,7 +913,7 @@ class TestSetupAptConfig:
         )
 
     @mock.patch("uaclient.apt.setup_apt_proxy")
-    @mock.patch(M_PATH + "os.unlink")
+    @mock.patch(M_PATH + "util.remove_file")
     @mock.patch(M_PATH + "apt.add_auth_apt_repo")
     @mock.patch(M_PATH + "apt.run_apt_command")
     @mock.patch(M_PATH + "util.get_platform_info")
@@ -926,7 +924,7 @@ class TestSetupAptConfig:
         m_get_platform_info,
         m_run_apt_command,
         m_add_auth_repo,
-        m_unlink,
+        m_remove_file,
         _m_setup_apt_proxy,
         entitlement_factory,
     ):
@@ -940,13 +938,12 @@ class TestSetupAptConfig:
             m_exists.return_value = True
             entitlement.setup_apt_config()
         assert [
-            mock.call("/etc/apt/preferences.d/ubuntu-repotest"),
             mock.call("/usr/lib/apt/methods/https"),
             mock.call("/usr/sbin/update-ca-certificates"),
         ] == m_exists.call_args_list
         assert [
             mock.call("/etc/apt/preferences.d/ubuntu-repotest")
-        ] == m_unlink.call_args_list
+        ] == m_remove_file.call_args_list
 
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch(M_PATH + "apt.add_auth_apt_repo")

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -578,14 +578,17 @@ class TestCleanAptFiles:
 
         return TestRepo
 
-    @mock.patch("uaclient.apt.os.unlink")
-    def test_no_removals_for_no_repo_entitlements(self, m_os_unlink):
+    @mock.patch("os.path.exists", return_value=True)
+    @mock.patch("uaclient.util.remove_file")
+    def test_removals_for_repo_entitlements(
+        self, m_remove_file, _m_path_exists
+    ):
         m_entitlements = mock.Mock()
         m_entitlements.ENTITLEMENT_CLASSES = [RepoTestEntitlement]
 
         clean_apt_files(_entitlements=m_entitlements)
 
-        assert 0 == m_os_unlink.call_count
+        assert 2 == m_remove_file.call_count
 
     def test_files_for_all_series_removed(self, mock_apt_entitlement, tmpdir):
         m_entitlements = mock.Mock()
@@ -639,9 +642,9 @@ def remove_auth_apt_repo_kwargs(request):
 class TestRemoveAuthAptRepo:
     @mock.patch("uaclient.apt.util.subp")
     @mock.patch("uaclient.apt.remove_repo_from_apt_auth_file")
-    @mock.patch("uaclient.apt.util.del_file")
+    @mock.patch("uaclient.apt.util.remove_file")
     def test_repo_file_deleted(
-        self, m_del_file, _mock, __mock, remove_auth_apt_repo_kwargs
+        self, m_remove_file, _mock, __mock, remove_auth_apt_repo_kwargs
     ):
         """Ensure that repo_filename is deleted, regardless of other params."""
         repo_filename, repo_url = mock.sentinel.filename, mock.sentinel.url
@@ -650,10 +653,10 @@ class TestRemoveAuthAptRepo:
             repo_filename, repo_url, **remove_auth_apt_repo_kwargs
         )
 
-        assert mock.call(repo_filename) in m_del_file.call_args_list
+        assert mock.call(repo_filename) in m_remove_file.call_args_list
 
     @mock.patch("uaclient.apt.util.subp")
-    @mock.patch("uaclient.apt.util.del_file")
+    @mock.patch("uaclient.apt.util.remove_file")
     @mock.patch("uaclient.apt.remove_repo_from_apt_auth_file")
     def test_remove_from_auth_file_called(
         self, m_remove_repo, _mock, __mock, remove_auth_apt_repo_kwargs
@@ -669,9 +672,9 @@ class TestRemoveAuthAptRepo:
 
     @mock.patch("uaclient.apt.util.subp")
     @mock.patch("uaclient.apt.remove_repo_from_apt_auth_file")
-    @mock.patch("uaclient.apt.util.del_file")
+    @mock.patch("uaclient.apt.util.remove_file")
     def test_keyring_file_deleted_if_given(
-        self, m_del_file, _mock, __mock, remove_auth_apt_repo_kwargs
+        self, m_remove_file, _mock, __mock, remove_auth_apt_repo_kwargs
     ):
         """We should always delete the keyring file if it is given"""
         repo_filename, repo_url = mock.sentinel.filename, mock.sentinel.url
@@ -684,18 +687,18 @@ class TestRemoveAuthAptRepo:
         if keyring_file:
             assert (
                 mock.call(os.path.join(APT_KEYS_DIR, keyring_file))
-                in m_del_file.call_args_list
+                in m_remove_file.call_args_list
             )
         else:
-            assert mock.call(keyring_file) not in m_del_file.call_args_list
+            assert mock.call(keyring_file) not in m_remove_file.call_args_list
 
 
 class TestRemoveRepoFromAptAuthFile:
-    @mock.patch("uaclient.apt.os.unlink")
+    @mock.patch("uaclient.util.remove_file")
     @mock.patch("uaclient.apt.util.write_file")
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     def test_auth_file_doesnt_exist_means_we_dont_remove_or_write_it(
-        self, m_get_apt_auth_file, m_write_file, m_unlink, tmpdir
+        self, m_get_apt_auth_file, m_write_file, m_remove_file, tmpdir
     ):
         """If the auth file doesn't exist, we shouldn't do anything to it"""
         m_get_apt_auth_file.return_value = tmpdir.join("nonexistent").strpath
@@ -703,7 +706,7 @@ class TestRemoveRepoFromAptAuthFile:
         remove_repo_from_apt_auth_file("http://url")
 
         assert 0 == m_write_file.call_count
-        assert 0 == m_unlink.call_count
+        assert 0 == m_remove_file.call_count
 
     @pytest.mark.parametrize("trailing_slash", (True, False))
     @pytest.mark.parametrize(
@@ -719,14 +722,14 @@ class TestRemoveRepoFromAptAuthFile:
             ),
         ),
     )
-    @mock.patch("uaclient.apt.os.unlink")
+    @mock.patch("uaclient.util.remove_file")
     @mock.patch("uaclient.apt.util.write_file")
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     def test_file_removal(
         self,
         m_get_apt_auth_file,
         m_write_file,
-        m_unlink,
+        m_remove_file,
         tmpdir,
         trailing_slash,
         repo_url,
@@ -742,7 +745,7 @@ class TestRemoveRepoFromAptAuthFile:
         )
 
         assert 0 == m_write_file.call_count
-        assert [mock.call(auth_file.strpath)] == m_unlink.call_args_list
+        assert [mock.call(auth_file.strpath)] == m_remove_file.call_args_list
 
     @pytest.mark.parametrize("trailing_slash", (True, False))
     @pytest.mark.parametrize(
@@ -771,12 +774,12 @@ class TestRemoveRepoFromAptAuthFile:
             ),
         ),
     )
-    @mock.patch("uaclient.apt.os.unlink")
+    @mock.patch("uaclient.util.remove_file")
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     def test_file_rewrite(
         self,
         m_get_apt_auth_file,
-        m_unlink,
+        m_remove_file,
         tmpdir,
         repo_url,
         before_content,
@@ -792,7 +795,7 @@ class TestRemoveRepoFromAptAuthFile:
             repo_url + ("" if not trailing_slash else "/")
         )
 
-        assert 0 == m_unlink.call_count
+        assert 0 == m_remove_file.call_count
         assert 0o600 == stat.S_IMODE(os.lstat(auth_file.strpath).st_mode)
         assert after_content == auth_file.read("rb")
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -9,7 +9,6 @@ import sys
 import time
 import uuid
 from contextlib import contextmanager
-from errno import ENOENT
 from functools import lru_cache, wraps
 from http.client import HTTPMessage
 from typing import (
@@ -179,14 +178,6 @@ def apply_contract_overrides(
             else:
                 # Otherwise, replace it wholesale
                 orig_access["entitlement"][key] = value
-
-
-def del_file(path: str) -> None:
-    try:
-        os.unlink(path)
-    except OSError as e:
-        if e.errno != ENOENT:
-            raise e
 
 
 @contextmanager


### PR DESCRIPTION
By using the util.remove_file everywhere we are removing files, we get
consistent logging whenever we remove a file. This will help debug
future issues.

I noticed we weren't logging the removal of some files while debugging a recent issue. I had to check the source to verify my understanding of what was happening. It would've been easier if we just logged it. I also noticed some duplicate functionality that this will simplify.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
All tests should still pass

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
