### PR TITLE
cli: add missing refresh option on help text

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -463,24 +463,30 @@ def refresh_parser(parser):
         "Refresh existing Ubuntu Advantage contract and update services."
     )
     parser.usage = USAGE_TMPL.format(
-        name=NAME, command="refresh [contract|config]"
+        name=NAME, command="refresh [contract|config|messages]"
     )
+
     parser._optionals.title = "Flags"
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    parser.description = textwrap.dedent(
+        """\
+        Refresh three distinct UA related artifacts in the system:
+
+        * contract: Update contract details from the server.
+        * config:   Reload the config file.
+        * messages: Update APT and MOTD messages related to UA.
+
+        You can individually target any of the three specific actions,
+        by passing it's target to nome to the command.  If no `target`
+        is specified, all targets are refreshed.
+        """
+    )
     parser.add_argument(
         "target",
         choices=["contract", "config", "messages"],
         nargs="?",
         default=None,
-        help=(
-            "Target to refresh. `ua refresh contract` will update contract"
-            " details from the server and perform any updates necessary."
-            " `ua refresh config` will reload"
-            " /etc/ubuntu-advantage/uaclient.conf and perform any changes"
-            " necessary. `ua refresh messages` will refresh"
-            " the APT and MOTD messages associated with UA."
-            " `ua refresh` is the equivalent of `ua refresh"
-            " config && ua refresh contract && ua refresh motd`."
-        ),
+        help="Target to refresh.",
     )
     return parser
 

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -5,20 +5,21 @@ from uaclient import exceptions, messages
 from uaclient.cli import action_refresh, main
 
 HELP_OUTPUT = """\
-usage: ua refresh [contract|config] [flags]
+usage: ua refresh [contract|config|messages] [flags]
 
-Refresh existing Ubuntu Advantage contract and update services.
+Refresh three distinct UA related artifacts in the system:
+
+* contract: Update contract details from the server.
+* config:   Reload the config file.
+* messages: Update APT and MOTD messages related to UA.
+
+You can individually target any of the three specific actions,
+by passing it's target to nome to the command.  If no `target`
+is specified, all targets are refreshed.
 
 positional arguments:
   {contract,config,messages}
-                        Target to refresh. `ua refresh contract` will update
-                        contract details from the server and perform any
-                        updates necessary. `ua refresh config` will reload
-                        /etc/ubuntu-advantage/uaclient.conf and perform any
-                        changes necessary. `ua refresh messages` will refresh
-                        the APT and MOTD messages associated with UA. `ua
-                        refresh` is the equivalent of `ua refresh config && ua
-                        refresh contract && ua refresh motd`.
+                        Target to refresh.
 
 Flags:
   -h, --help            show this help message and exit
@@ -33,7 +34,6 @@ class TestActionRefresh:
             with mock.patch("sys.argv", ["/usr/bin/ua", "refresh", "--help"]):
                 main()
         out, _err = capsys.readouterr()
-        print(out)
         assert HELP_OUTPUT in out
 
     def test_non_root_users_are_rejected(self, getuid, FakeConfig):


### PR DESCRIPTION
## Proposed Commit Message
cli: add missing refresh option on help text


## Test Steps
Verify that the `messages` option is now appearing

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
