### PR TITLE
contract: send platform info for resource requests

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -61,14 +61,8 @@ class UAContractClient(serviceclient.UAServiceClient):
 
     def request_resources(self) -> Dict[str, Any]:
         """Requests list of entitlements available to this machine type."""
-        platform = util.get_platform_info()
-        query_params = {
-            "architecture": platform["arch"],
-            "series": platform["series"],
-            "kernel": platform["kernel"],
-        }
         resource_response, headers = self.request_url(
-            API_V1_RESOURCES, query_params=query_params
+            API_V1_RESOURCES, query_params=self._get_platform_basic_info()
         )
         return resource_response
 
@@ -198,10 +192,14 @@ class UAContractClient(serviceclient.UAServiceClient):
         headers = self.headers()
         headers.update({"Authorization": "Bearer {}".format(machine_token)})
         url = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE.format(
-            contract=contract_id, machine=machine_id
+            contract=contract_id,
+            machine=machine_id,
         )
         response, headers = self.request_url(
-            url, method="GET", headers=headers
+            url,
+            method="GET",
+            headers=headers,
+            query_params=self._get_platform_basic_info(),
         )
         if headers.get("expires"):
             response["expires"] = headers["expires"]
@@ -262,6 +260,15 @@ class UAContractClient(serviceclient.UAServiceClient):
             "machineId": machine_id,
             "architecture": arch,
             "os": platform_os,
+        }
+
+    def _get_platform_basic_info(self):
+        """Return a dict of platform basic info for some contract requests"""
+        platform = util.get_platform_info()
+        return {
+            "architecture": platform["arch"],
+            "series": platform["series"],
+            "kernel": platform["kernel"],
         }
 
     def _get_activity_info(self, machine_id: Optional[str] = None):

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -156,7 +156,12 @@ class TestUAContractClient:
             return {"machineId": machine_id}
 
         m_platform_data.side_effect = fake_platform_data
-        get_platform_info.return_value = {"arch": "arch", "kernel": "kernel"}
+        get_platform_info.return_value = {
+            "arch": "arch",
+            "kernel": "kernel",
+            "series": "series",
+        }
+
         get_machine_id.return_value = "machineId"
         machine_token = {"machineTokenInfo": {}}
         if machine_id_response:


### PR DESCRIPTION
## Proposed Commit Message
contract: send platform info for resource requests

Right now, when attached, we don't send any platform information when requesting machine token resources. This is because the contract side that information stored on their side. To make this process better, can send that request directly to the contract backend.

## Test Steps
Verify that the commands that use the modified endpoint still work as expected

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
