### PR TITLE
data_types: safer error messages

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -232,7 +232,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Then stderr matches regexp:
         """
         Error while reading /tmp/attach.yaml: Got value with incorrect type for field
-        "token": Expected value with type StringDataValue but got value: None
+        "token": Expected value with type StringDataValue but got type: null
         """
         # other schema error
         When I create the file `/tmp/attach.yaml` with the following
@@ -245,7 +245,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         Then stderr matches regexp:
         """
         Error while reading /tmp/attach.yaml: Got value with incorrect type for field
-        "enable_services": Expected value with type list but got value: {\'cis\': True}
+        "enable_services": Expected value with type list but got type: dict
         """
         # invalid service name
         When I create the file `/tmp/attach.yaml` with the following

--- a/uaclient/data_types.py
+++ b/uaclient/data_types.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional, Type, TypeVar, Union
 from uaclient import exceptions
 
 INCORRECT_TYPE_ERROR_MESSAGE = (
-    "Expected value with type {type} but got value: {value}"
+    "Expected value with type {expected_type} but got type: {got_type}"
 )
 INCORRECT_LIST_ELEMENT_TYPE_ERROR_MESSAGE = (
     "Got value with incorrect type at index {index}: {nested_msg}"
@@ -14,10 +14,10 @@ INCORRECT_FIELD_TYPE_ERROR_MESSAGE = (
 
 
 class IncorrectTypeError(exceptions.UserFacingError):
-    def __init__(self, expected_type: str, got_value: Any):
+    def __init__(self, expected_type: str, got_type: str):
         super().__init__(
             INCORRECT_TYPE_ERROR_MESSAGE.format(
-                type=expected_type, value=repr(got_value)
+                expected_type=expected_type, got_type=got_type
             )
         )
 
@@ -58,7 +58,7 @@ class StringDataValue(DataValue):
     @staticmethod
     def from_value(val: Any) -> str:
         if not isinstance(val, str):
-            raise IncorrectTypeError("string", val)
+            raise IncorrectTypeError("str", type(val).__name__)
         return val
 
 
@@ -72,7 +72,7 @@ class IntDataValue(DataValue):
     @staticmethod
     def from_value(val: Any) -> int:
         if not isinstance(val, int) or isinstance(val, bool):
-            raise IncorrectTypeError("int", val)
+            raise IncorrectTypeError("int", type(val).__name__)
         return val
 
 
@@ -86,7 +86,7 @@ class BoolDataValue(DataValue):
     @staticmethod
     def from_value(val: Any) -> bool:
         if not isinstance(val, bool):
-            raise IncorrectTypeError("bool", val)
+            raise IncorrectTypeError("bool", type(val).__name__)
         return val
 
 
@@ -101,7 +101,7 @@ def data_list(data_cls: Type[DataValue]) -> Type[DataValue]:
         @staticmethod
         def from_value(val: Any) -> List:
             if not isinstance(val, list):
-                raise IncorrectTypeError("list", val)
+                raise IncorrectTypeError("list", type(val).__name__)
             new_val = []
             for i, item in enumerate(val):
                 try:
@@ -193,7 +193,7 @@ class DataObject(DataValue):
             except KeyError:
                 if field.required:
                     raise IncorrectFieldTypeError(
-                        IncorrectTypeError(field.data_cls.__name__, None),
+                        IncorrectTypeError(field.data_cls.__name__, "null"),
                         field.key,
                     )
                 else:
@@ -209,7 +209,7 @@ class DataObject(DataValue):
     @classmethod
     def from_value(cls, val: Any):
         if not isinstance(val, dict):
-            raise IncorrectTypeError("dict", val)
+            raise IncorrectTypeError("dict", type(val).__name__)
         return cls.from_dict(val)
 
 

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -443,7 +443,7 @@ class TestActionAttach:
             error=(
                 "Got value with "
                 'incorrect type for field\n"enable_services": '
-                "Expected value with type list but got value: 'cis'"
+                "Expected value with type list but got type: str"
             ),
         )
 

--- a/uaclient/tests/test_data_types.py
+++ b/uaclient/tests/test_data_types.py
@@ -34,10 +34,10 @@ class TestDataValues:
     @pytest.mark.parametrize(
         "val, error",
         (
-            (True, IncorrectTypeError("string", True)),
-            (1, IncorrectTypeError("string", 1)),
-            ([], IncorrectTypeError("string", [])),
-            ({}, IncorrectTypeError("string", {})),
+            (True, IncorrectTypeError("str", "bool")),
+            (1, IncorrectTypeError("str", "int")),
+            ([], IncorrectTypeError("str", "list")),
+            ({}, IncorrectTypeError("str", "dict")),
         ),
     )
     def test_string_data_value_error(self, val, error):
@@ -54,11 +54,11 @@ class TestDataValues:
     @pytest.mark.parametrize(
         "val, error",
         (
-            (True, IncorrectTypeError("int", True)),
-            ("hello", IncorrectTypeError("int", "hello")),
-            ("1", IncorrectTypeError("int", "1")),
-            ([], IncorrectTypeError("int", [])),
-            ({}, IncorrectTypeError("int", {})),
+            (True, IncorrectTypeError("int", "bool")),
+            ("hello", IncorrectTypeError("int", "str")),
+            ("1", IncorrectTypeError("int", "str")),
+            ([], IncorrectTypeError("int", "list")),
+            ({}, IncorrectTypeError("int", "dict")),
         ),
     )
     def test_int_data_value_error(self, val, error):
@@ -75,10 +75,10 @@ class TestDataValues:
     @pytest.mark.parametrize(
         "val, error",
         (
-            ("hello", IncorrectTypeError("bool", "hello")),
-            (1, IncorrectTypeError("bool", 1)),
-            ([], IncorrectTypeError("bool", [])),
-            ({}, IncorrectTypeError("bool", {})),
+            ("hello", IncorrectTypeError("bool", "str")),
+            (1, IncorrectTypeError("bool", "int")),
+            ([], IncorrectTypeError("bool", "list")),
+            ({}, IncorrectTypeError("bool", "dict")),
         ),
     )
     def test_bool_data_value_error(self, val, error):
@@ -106,28 +106,28 @@ class TestDataList:
     @pytest.mark.parametrize(
         "data_cls, val, error",
         (
-            (IntDataValue, "hello", IncorrectTypeError("list", "hello")),
-            (IntDataValue, 1, IncorrectTypeError("list", 1)),
-            (IntDataValue, {}, IncorrectTypeError("list", {})),
+            (IntDataValue, "hello", IncorrectTypeError("list", "str")),
+            (IntDataValue, 1, IncorrectTypeError("list", "int")),
+            (IntDataValue, {}, IncorrectTypeError("list", "dict")),
             (
                 IntDataValue,
                 ["one"],
                 IncorrectListElementTypeError(
-                    IncorrectTypeError("int", "one"), 0
+                    IncorrectTypeError("int", "str"), 0
                 ),
             ),
             (
                 IntDataValue,
                 [1, 2, 3, []],
                 IncorrectListElementTypeError(
-                    IncorrectTypeError("int", []), 3
+                    IncorrectTypeError("int", "list"), 3
                 ),
             ),
             (
                 StringDataValue,
                 ["one", "two", "three", {}],
                 IncorrectListElementTypeError(
-                    IncorrectTypeError("string", {}), 3
+                    IncorrectTypeError("str", "dict"), 3
                 ),
             ),
             (
@@ -135,7 +135,7 @@ class TestDataList:
                 [["one", "two"], ["three"], ["four", 5]],
                 IncorrectListElementTypeError(
                     IncorrectListElementTypeError(
-                        IncorrectTypeError("string", 5), 1
+                        IncorrectTypeError("str", "int"), 1
                     ),
                     2,
                 ),
@@ -316,7 +316,7 @@ class TestDataObject:
                     ],
                 },
                 IncorrectFieldTypeError(
-                    IncorrectTypeError("StringDataValue", None), "string"
+                    IncorrectTypeError("StringDataValue", "null"), "string"
                 ),
             ),
             (
@@ -332,7 +332,7 @@ class TestDataObject:
                     ],
                 },
                 IncorrectFieldTypeError(
-                    IncorrectTypeError("int", "1"), "integer"
+                    IncorrectTypeError("int", "str"), "integer"
                 ),
             ),
             (
@@ -349,7 +349,7 @@ class TestDataObject:
                 },
                 IncorrectFieldTypeError(
                     IncorrectFieldTypeError(
-                        IncorrectTypeError("string", 8), "string"
+                        IncorrectTypeError("str", "int"), "string"
                     ),
                     "obj",
                 ),
@@ -368,7 +368,7 @@ class TestDataObject:
                 },
                 IncorrectFieldTypeError(
                     IncorrectListElementTypeError(
-                        IncorrectTypeError("string", 2), 1
+                        IncorrectTypeError("str", "int"), 1
                     ),
                     "stringlist",
                 ),
@@ -388,17 +388,17 @@ class TestDataObject:
                 IncorrectFieldTypeError(
                     IncorrectListElementTypeError(
                         IncorrectFieldTypeError(
-                            IncorrectTypeError("int", "6"), "integer"
+                            IncorrectTypeError("int", "str"), "integer"
                         ),
                         0,
                     ),
                     "objlist",
                 ),
             ),
-            ("string", IncorrectTypeError("dict", "string")),
-            (1, IncorrectTypeError("dict", 1)),
-            (True, IncorrectTypeError("dict", True)),
-            ([], IncorrectTypeError("dict", [])),
+            ("string", IncorrectTypeError("dict", "str")),
+            (1, IncorrectTypeError("dict", "int")),
+            (True, IncorrectTypeError("dict", "bool")),
+            ([], IncorrectTypeError("dict", "list")),
         ),
     )
     def test_error(self, val, error):


### PR DESCRIPTION
As we start to rely on data types more, we should avoid printing values of things we're parsing, in case we end up using these for sensitive information in the future.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
