### PR TITLE
eol-check: check if unattached system is eol

### DIFF
--- a/lib/timer.py
+++ b/lib/timer.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
+from uaclient.jobs.eol_status import check_eol_and_update
 from uaclient.jobs.metering import metering_enabled_resources
 from uaclient.jobs.update_messaging import update_apt_and_motd_messages
 from uaclient.jobs.update_state import update_status
@@ -16,6 +17,7 @@ LOG = logging.getLogger(__name__)
 UPDATE_MESSAGING_INTERVAL = 21600  # 6 hours
 UPDATE_STATUS_INTERVAL = 43200  # 12 hours
 METERING_INTERVAL = 14400  # 4 hours
+EOL_STATUS_INTERVAL = 604800  # weekly
 
 
 class TimedJob:
@@ -101,6 +103,7 @@ UACLIENT_JOBS = [
         UPDATE_MESSAGING_INTERVAL,
     ),
     TimedJob("update_status", update_status, UPDATE_STATUS_INTERVAL),
+    TimedJob("eol_status", check_eol_and_update, EOL_STATUS_INTERVAL),
     MeteringTimedJob(metering_enabled_resources, METERING_INTERVAL),
 ]
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -528,3 +528,29 @@ def setup_apt_proxy(
         util.remove_file(APT_PROXY_CONF_FILE)
     else:
         util.write_file(APT_PROXY_CONF_FILE, apt_proxy_config)
+
+
+def setup_unauthenticated_repo(
+    repo_filename: str,
+    repo_pref_filename: str,
+    repo_url: str,
+    keyring_file: str,
+    apt_origin: str,
+    suites: List[str],
+) -> None:
+    content = "# Written by ubuntu-advantage-tools"
+    for suite in suites:
+        content += "\n"
+        content += messages.REPO_FILE_CONTENT.format(
+            url=repo_url, apt_suite=suite
+        )
+    util.write_file(repo_filename, content)
+    source_keyring_file = os.path.join(KEYRINGS_DIR, keyring_file)
+    destination_keyring_file = os.path.join(APT_KEYS_DIR, keyring_file)
+    gpg.export_gpg_key(source_keyring_file, destination_keyring_file)
+    add_ppa_pinning(
+        repo_pref_filename,
+        repo_url,
+        apt_origin,
+        "never",
+    )

--- a/uaclient/jobs/eol_status.py
+++ b/uaclient/jobs/eol_status.py
@@ -1,0 +1,13 @@
+from uaclient import util
+from uaclient.config import UAConfig
+from uaclient.entitlements.esm import ESMInfraEntitlement
+
+
+def check_eol_and_update(cfg: UAConfig) -> bool:
+    if cfg.is_attached:
+        return True
+    series = util.get_platform_info()["series"]
+    if not util.is_active_esm(series):
+        return True
+    ESMInfraEntitlement().setup_unauthenticated_repo()
+    return True

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -281,6 +281,11 @@ APT_PROXY_CONFIG_HEADER = """\
  */
 """
 
+REPO_FILE_CONTENT = """\
+deb {url}/ubuntu {apt_suite} main
+# deb-src {url}/ubuntu {apt_suite} main
+"""
+
 UACLIENT_CONF_HEADER = """\
 # Ubuntu Pro client config file.
 # If you modify this file, run "pro refresh config" to ensure changes are

--- a/uaclient/tests/test_eol_status.py
+++ b/uaclient/tests/test_eol_status.py
@@ -1,0 +1,83 @@
+import mock
+
+from uaclient.entitlements.esm import ESMInfraEntitlement
+from uaclient.jobs.eol_status import check_eol_and_update
+
+M_ENT = "uaclient.entitlements.esm."
+
+
+class TestEOLStatus:
+    @mock.patch(M_ENT + "ESMBaseEntitlement.setup_unauthenticated_repo")
+    @mock.patch("uaclient.util.get_platform_info")
+    @mock.patch("uaclient.util.is_active_esm", return_value=False)
+    def test_repo_not_set_on_attached_machine(
+        self,
+        _is_active_esm,
+        get_platform_info,
+        setup_unauthenticated_repo,
+        FakeConfig,
+    ):
+        cfg = FakeConfig().for_attached_machine()
+        with mock.patch("os.path.exists", return_value=False):
+            check_eol_and_update(cfg)
+        assert get_platform_info.call_count == 0
+        assert setup_unauthenticated_repo.call_count == 0
+
+    @mock.patch(M_ENT + "ESMBaseEntitlement.setup_unauthenticated_repo")
+    @mock.patch("uaclient.util.get_platform_info")
+    @mock.patch("uaclient.util.is_active_esm", return_value=False)
+    def test_repo_not_set_on_active_esm(
+        self,
+        _is_active_esm,
+        get_platform_info,
+        setup_unauthenticated_repo,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        with mock.patch("os.path.exists", return_value=False):
+            check_eol_and_update(cfg)
+        assert get_platform_info.call_count == 1
+        assert setup_unauthenticated_repo.call_count == 0
+
+    @mock.patch("uaclient.util.get_platform_info")
+    @mock.patch(M_ENT + "apt.setup_unauthenticated_repo")
+    @mock.patch("uaclient.util.is_active_esm", return_value=True)
+    def test_esm_infra_repo_set_on_unattached(
+        self,
+        _is_active_esm,
+        apt_setup_unauthenticated_repo,
+        get_platform_info,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        series = "eol-series"
+        get_platform_info.return_value = {"series": series}
+        with mock.patch("os.path.exists", return_value=False):
+            check_eol_and_update(cfg)
+        suite_prefix = series + "-" + "infra"
+        infra_repo_fn = "/etc/apt/sources.list.d/ubuntu-{name}.list".format(
+            name=ESMInfraEntitlement.name
+        )
+        infra_repo_pref_fn = "/etc/apt/preferences.d/ubuntu-{name}".format(
+            name=ESMInfraEntitlement.name
+        )
+        expected = [
+            mock.call(
+                repo_filename=infra_repo_fn,
+                repo_pref_filename=infra_repo_pref_fn,
+                repo_url="https://esm.ubuntu.com/{service}".format(
+                    service=ESMInfraEntitlement.apt_repo_name
+                ),
+                keyring_file=ESMInfraEntitlement.repo_key_file,
+                apt_origin=ESMInfraEntitlement.origin,
+                suites=[
+                    "{suite_prefix}-security".format(
+                        suite_prefix=suite_prefix
+                    ),
+                    "{suite_prefix}-updates".format(suite_prefix=suite_prefix),
+                ],
+            )
+        ]
+        assert get_platform_info.call_count == 2
+        assert apt_setup_unauthenticated_repo.call_count == 1
+        assert expected == apt_setup_unauthenticated_repo.call_args_list


### PR DESCRIPTION
eol-check: check if unattached system is eol

Adding a timer job to check if the system has reached EOL.
This is specifically for an unattached system.

Fixes: #1587


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
