### PR TITLE
prevent unneeded daemon activation and mitigate stalled daemon bug

### DIFF
--- a/sru/daemon_stall_cloned_machine.py
+++ b/sru/daemon_stall_cloned_machine.py
@@ -1,0 +1,65 @@
+import logging
+import os
+
+import pycloudlib
+from pycloudlib.cloud import ImageType
+
+
+def handle_ssh_key(ec2, key_name):
+    """Manage ssh keys to be used in the instances."""
+    if key_name in ec2.list_keys():
+        ec2.delete_key(key_name)
+
+    key_pair = ec2.client.create_key_pair(KeyName=key_name)
+    private_key_path = "ec2-test.pem"
+    with open(private_key_path, "w", encoding="utf-8") as stream:
+        stream.write(key_pair["KeyMaterial"])
+    os.chmod(private_key_path, 0o600)
+
+    # Since we are using a pem file, we don't have distinct public and
+    # private key paths
+    ec2.use_key(
+        public_key_path=private_key_path,
+        private_key_path=private_key_path,
+        name=key_name,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    ec2 = pycloudlib.EC2(tag="examples")
+    key_name = "test-ec2"
+    handle_ssh_key(ec2, key_name)
+
+    daily_pro = ec2.daily_image(release="focal", image_type=ImageType.PRO)
+
+    print("Launching Pro instance...")
+    instance = ec2.launch(daily_pro, instance_type="m5.large")
+    instance.execute("touch custom_config_file")
+    print(instance.execute("sudo ua status --wait"))
+    print(instance.execute("sudo apt update"))
+    print(instance.execute("sudo apt install ubuntu-advantage-tools"))
+
+    print("")
+    print("install ua version with the fix (must be at ./ua.deb)")
+    print("")
+    instance.push_file("./ua.deb", "/tmp/ua.deb")
+    print(instance.execute("sudo dpkg -i /tmp/ua.deb"))
+
+    print("")
+    print("snapshotting")
+    print("")
+    image = ec2.snapshot(instance)
+
+    print("")
+    print("launching clone  - if this finishes, then success!")
+    print("")
+    new_instance = ec2.launch(image, instance_type="m5.large")
+    print(new_instance.execute("sudo ua status --wait"))
+
+    print("")
+    print("Deleting Pro instances and image")
+    print("")
+    new_instance.delete()
+    ec2.delete_image(image)
+    instance.delete()

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1216,7 +1216,10 @@ def action_detach(args, *, cfg) -> int:
 
     @return: 0 on success, 1 otherwise
     """
-    return _detach(cfg, assume_yes=args.assume_yes)
+    ret = _detach(cfg, assume_yes=args.assume_yes)
+    daemon.start()
+    event.process_events()
+    return ret
 
 
 def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
@@ -1257,10 +1260,8 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
         _perform_disable(ent, cfg, assume_yes=assume_yes, update_status=False)
 
     cfg.delete_cache()
-    daemon.start()
     update_apt_and_motd_messages(cfg)
     event.info(messages.DETACH_SUCCESS)
-    event.process_events()
     return 0
 
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1217,7 +1217,8 @@ def action_detach(args, *, cfg) -> int:
     @return: 0 on success, 1 otherwise
     """
     ret = _detach(cfg, assume_yes=args.assume_yes)
-    daemon.start()
+    if ret == 0:
+        daemon.start()
     event.process_events()
     return ret
 

--- a/uaclient/daemon.py
+++ b/uaclient/daemon.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from subprocess import TimeoutExpired
 
 from uaclient import actions, exceptions, lock, messages, util
 from uaclient.clouds import AutoAttachCloudInstance
@@ -12,15 +13,19 @@ LOG = logging.getLogger("ua.daemon")
 
 def start():
     try:
-        util.subp(["systemctl", "start", "ubuntu-advantage.service"])
-    except exceptions.ProcessExecutionError as e:
+        util.subp(
+            ["systemctl", "start", "ubuntu-advantage.service"], timeout=2.0
+        )
+    except (exceptions.ProcessExecutionError, TimeoutExpired) as e:
         LOG.warning(e)
 
 
 def stop():
     try:
-        util.subp(["systemctl", "stop", "ubuntu-advantage.service"])
-    except exceptions.ProcessExecutionError as e:
+        util.subp(
+            ["systemctl", "stop", "ubuntu-advantage.service"], timeout=2.0
+        )
+    except (exceptions.ProcessExecutionError, TimeoutExpired) as e:
         LOG.warning(e)
 
 

--- a/uaclient/tests/test_daemon.py
+++ b/uaclient/tests/test_daemon.py
@@ -1,3 +1,5 @@
+from subprocess import TimeoutExpired
+
 import mock
 import pytest
 
@@ -19,16 +21,26 @@ class TestStart:
     def test_start_success(self, m_subp):
         start()
         assert [
-            mock.call(["systemctl", "start", "ubuntu-advantage.service"])
+            mock.call(
+                ["systemctl", "start", "ubuntu-advantage.service"], timeout=2.0
+            )
         ] == m_subp.call_args_list
 
+    @pytest.mark.parametrize(
+        "err",
+        (
+            exceptions.ProcessExecutionError("cmd"),
+            TimeoutExpired("cmd", 2.0),
+        ),
+    )
     @mock.patch(M_PATH + "LOG.warning")
-    def test_start_warning(self, m_log_warning, m_subp):
-        err = exceptions.ProcessExecutionError("cmd")
+    def test_start_warning(self, m_log_warning, m_subp, err):
         m_subp.side_effect = err
         start()
         assert [
-            mock.call(["systemctl", "start", "ubuntu-advantage.service"])
+            mock.call(
+                ["systemctl", "start", "ubuntu-advantage.service"], timeout=2.0
+            )
         ] == m_subp.call_args_list
         assert [mock.call(err)] == m_log_warning.call_args_list
 
@@ -38,16 +50,26 @@ class TestStop:
     def test_stop_success(self, m_subp):
         stop()
         assert [
-            mock.call(["systemctl", "stop", "ubuntu-advantage.service"])
+            mock.call(
+                ["systemctl", "stop", "ubuntu-advantage.service"], timeout=2.0
+            )
         ] == m_subp.call_args_list
 
+    @pytest.mark.parametrize(
+        "err",
+        (
+            exceptions.ProcessExecutionError("cmd"),
+            TimeoutExpired("cmd", 2.0),
+        ),
+    )
     @mock.patch(M_PATH + "LOG.warning")
-    def test_stop_warning(self, m_log_warning, m_subp):
-        err = exceptions.ProcessExecutionError("cmd")
+    def test_stop_warning(self, m_log_warning, m_subp, err):
         m_subp.side_effect = err
         stop()
         assert [
-            mock.call(["systemctl", "stop", "ubuntu-advantage.service"])
+            mock.call(
+                ["systemctl", "stop", "ubuntu-advantage.service"], timeout=2.0
+            )
         ] == m_subp.call_args_list
         assert [mock.call(err)] == m_log_warning.call_args_list
 


### PR DESCRIPTION
~~Note that this does not fix the root cause of the stalled daemon reported in https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1980865~~

~~Debugging that may take some more time and I think we should include this mitigation in the upcoming release.~~

The daemon was stalling because it is configured "After: ua-auto-attach.service" but was started during that service. This results in a deadlock. So simply not starting the daemon during the auto attach service is the full fix here.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
build the deb and store at `./ua.deb`. Then run the test script here using this branch of pycloudlib: https://github.com/canonical/pycloudlib/pull/204

It should successfully boot the snapshotted image.

If you comment out the lines that install the deb, then the snapshotted image would never finish booting

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
