### PR TITLE
api: change magic-attach key names

### DIFF
--- a/features/schemas/magic_attach.json
+++ b/features/schemas/magic_attach.json
@@ -1,27 +1,27 @@
 {
     "type": "object",
-    "required": [ "_schema", "confirmation_code", "expires", "token", "user_email" ],
+    "required": [ "_schema", "user_code", "expires", "expires_in", "token" ],
     "properties": {
         "_schema": {
-            "type": "string"
+          "type": "string"
         },
-        "confirmation_code": {
-        "type": "string"
+        "user_code": {
+          "type": "string"
         },
         "token": {
-        "type": "string"
+          "type": "string"
         },
         "expires": {
-        "type": "string"
+          "type": "string"
         },
-        "user_email": {
-        "type": "string"
+        "expires_in": {
+          "type": "integer"
         },
         "contract_token": {
             "type": "string"
         },
         "contract_id": {
-        "type": "string"
+          "type": "string"
         }
     }
 }

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -298,13 +298,11 @@ def when_i_preflight(context, contract_token, user_spec, verify_return=True):
     )
 
 
-@when("I initiate the magic attach flow using the API for email `{email}`")
-def when_i_initiate_magic_attach(context, email):
+@when("I initiate the magic attach flow")
+def when_i_initiate_magic_attach(context):
     when_i_run_command(
         context=context,
-        command="pro api u.pro.attach.magic.initiate.v1 --args email={}".format(  # noqa
-            email
-        ),
+        command="pro api u.pro.attach.magic.initiate.v1",
         user_spec="as non-root",
     )
 
@@ -454,6 +452,7 @@ def when_i_update_contract_field_to_new_value(
     )
 
 
+@when("I change contract to staging {user_spec}")
 def change_contract_endpoint_to_staging(context, user_spec):
     when_i_run_command(
         context,

--- a/uaclient/api/tests/test_u_pro_attach_magic_wait_v1.py
+++ b/uaclient/api/tests/test_u_pro_attach_magic_wait_v1.py
@@ -21,8 +21,8 @@ class TestSimplifiedAttachWaitV1:
             {
                 "token": magic_token,
                 "expires": "2100-06-09T18:14:55.323733Z",
-                "userEmail": "test@test.com",
-                "confirmationCode": "1234",
+                "expiresIn": "2000",
+                "userCode": "1234",
                 "contractToken": "ctoken",
                 "contractID": "cid",
             },

--- a/uaclient/api/u/pro/attach/magic/initiate/v1.py
+++ b/uaclient/api/u/pro/attach/magic/initiate/v1.py
@@ -2,52 +2,48 @@ from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
-from uaclient.data_types import DataObject, Field, StringDataValue
-
-
-class MagicAttachInitiateOptions(DataObject):
-    fields = [Field("email", StringDataValue)]
-
-    def __init__(self, email):
-        self.email = email
+from uaclient.data_types import (
+    DataObject,
+    Field,
+    IntDataValue,
+    StringDataValue,
+)
 
 
 class MagicAttachInitiateResult(DataObject, AdditionalInfo):
     fields = [
         Field("_schema", StringDataValue),
-        Field("confirmation_code", StringDataValue),
+        Field("user_code", StringDataValue),
         Field("token", StringDataValue),
         Field("expires", StringDataValue),
-        Field("user_email", StringDataValue),
+        Field("expires_in", IntDataValue),
     ]
 
     def __init__(
         self,
         _schema: str,
-        confirmation_code: str,
+        user_code: str,
         token: str,
         expires: str,
-        user_email: str,
+        expires_in: int,
     ):
         self._schema = _schema
-        self.confirmation_code = confirmation_code
+        self.user_code = user_code
         self.token = token
         self.expires = expires
-        self.user_email = user_email
+        self.expires_in = expires_in
 
 
-def initiate(
-    options: MagicAttachInitiateOptions, cfg: UAConfig
-) -> MagicAttachInitiateResult:
+def initiate(cfg: UAConfig) -> MagicAttachInitiateResult:
     contract = UAContractClient(cfg)
-    initiate_resp = contract.new_magic_attach_token(options.email)
+    initiate_resp = contract.new_magic_attach_token()
 
     return MagicAttachInitiateResult(
         _schema="0.1",
-        confirmation_code=initiate_resp["confirmationCode"],
+        user_code=initiate_resp["userCode"],
         token=initiate_resp["token"],
         expires=initiate_resp["expires"],
-        user_email=initiate_resp["userEmail"],
+        expires_in=int(initiate_resp["expiresIn"]),
     )
 
 
@@ -55,5 +51,5 @@ endpoint = APIEndpoint(
     version="v1",
     name="MagicAttachInitiate",
     fn=initiate,
-    options_cls=MagicAttachInitiateOptions,
+    options_cls=None,
 )

--- a/uaclient/api/u/pro/attach/magic/wait/v1.py
+++ b/uaclient/api/u/pro/attach/magic/wait/v1.py
@@ -5,7 +5,12 @@ from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
-from uaclient.data_types import DataObject, Field, StringDataValue
+from uaclient.data_types import (
+    DataObject,
+    Field,
+    IntDataValue,
+    StringDataValue,
+)
 
 MAXIMUM_ATTEMPTS = 70
 
@@ -22,10 +27,10 @@ class MagicAttachWaitOptions(DataObject):
 class MagicAttachWaitResult(DataObject, AdditionalInfo):
     fields = [
         Field("_schema", StringDataValue),
-        Field("confirmation_code", StringDataValue),
+        Field("user_code", StringDataValue),
         Field("token", StringDataValue),
         Field("expires", StringDataValue),
-        Field("user_email", StringDataValue),
+        Field("expires_in", IntDataValue),
         Field("contract_id", StringDataValue),
         Field("contract_token", StringDataValue),
     ]
@@ -33,18 +38,18 @@ class MagicAttachWaitResult(DataObject, AdditionalInfo):
     def __init__(
         self,
         _schema: str,
-        confirmation_code: str,
+        user_code: str,
         token: str,
         expires: str,
-        user_email: str,
+        expires_in: int,
         contract_id: str,
         contract_token: str,
     ):
         self._schema = _schema
-        self.confirmation_code = confirmation_code
+        self.user_code = user_code
         self.token = token
         self.expires = expires
-        self.user_email = user_email
+        self.expires_in = expires_in
         self.contract_id = contract_id
         self.contract_token = contract_token
 
@@ -68,10 +73,10 @@ def wait(
         if wait_resp.get("contractToken") is not None:
             return MagicAttachWaitResult(
                 _schema="0.1",
-                confirmation_code=wait_resp["confirmationCode"],
+                user_code=wait_resp["userCode"],
                 token=wait_resp["token"],
                 expires=wait_resp["expires"],
-                user_email=wait_resp["userEmail"],
+                expires_in=int(wait_resp["expiresIn"]),
                 contract_id=wait_resp["contractID"],
                 contract_token=wait_resp["contractToken"],
             )

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -200,7 +200,7 @@ class UAContractClient(serviceclient.UAServiceClient):
 
         return response
 
-    def new_magic_attach_token(self, email: str) -> Dict[str, Any]:
+    def new_magic_attach_token(self) -> Dict[str, Any]:
         """Create a magic attach token for the user."""
         headers = self.headers()
 
@@ -209,13 +209,7 @@ class UAContractClient(serviceclient.UAServiceClient):
                 API_V1_MAGIC_ATTACH,
                 headers=headers,
                 method="POST",
-                data={"email": email},
             )
-        except exceptions.ContractAPIError as e:
-            if hasattr(e, "code"):
-                if e.code == 400:
-                    raise exceptions.MagicAttachInvalidEmail(email=email)
-            raise e
         except exceptions.UrlError as e:
             logging.exception(str(e))
             raise exceptions.UserFacingError(

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -352,44 +352,17 @@ class TestUAContractClient:
     ):
         cfg = FakeConfig()
         client = UAContractClient(cfg)
-        email = "test@test.com"
         magic_attach_token_resp = (
             {
                 "token": "token",
                 "expires": "2100-06-09T18:14:55.323733Z",
-                "userEmail": email,
-                "confirmationCode": "1234",
+                "expiresIn": 600,
+                "userCode": "1234",
             },
         )
         request_url.return_value = (magic_attach_token_resp, None)
 
-        assert (
-            client.new_magic_attach_token(email=email)
-            == magic_attach_token_resp
-        )
-
-    @pytest.mark.parametrize(
-        "error_code,expected_exception",
-        ((400, exceptions.MagicAttachInvalidEmail),),
-    )
-    def test_new_magic_attach_token_contract_error(
-        self,
-        get_machine_id,
-        request_url,
-        error_code,
-        expected_exception,
-        FakeConfig,
-    ):
-        cfg = FakeConfig()
-        client = UAContractClient(cfg)
-        email = "invalid email"
-        request_url.side_effect = exceptions.ContractAPIError(
-            exceptions.UrlError("test", error_code),
-            error_response={},
-        )
-
-        with pytest.raises(expected_exception):
-            client.new_magic_attach_token(email=email)
+        assert client.new_magic_attach_token() == magic_attach_token_resp
 
     def test_new_magic_attach_token_fails(
         self,
@@ -399,11 +372,10 @@ class TestUAContractClient:
     ):
         cfg = FakeConfig()
         client = UAContractClient(cfg)
-        email = "test@test.com"
         request_url.side_effect = exceptions.UrlError("test")
 
         with pytest.raises(exceptions.UserFacingError) as exc_error:
-            client.new_magic_attach_token(email=email)
+            client.new_magic_attach_token()
 
         assert messages.CONNECTIVITY_ERROR.msg == exc_error.value.msg
         assert messages.CONNECTIVITY_ERROR.name == exc_error.value.msg_code

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -1169,6 +1169,18 @@ class TestRedactSensitiveLogs:
                 "http://metadata/computeMetadata/v1/instance/service-accounts/"
                 "default/identity?audience=contracts.canon, data: <REDACTED>",
             ),
+            (
+                "'token': 'SEKRET'",
+                "'token': '<REDACTED>'",
+            ),
+            (
+                "'userCode': 'SEKRET'",
+                "'userCode': '<REDACTED>'",
+            ),
+            (
+                "'magic_token=SEKRET'",
+                "'magic_token=<REDACTED>'",
+            ),
         ),
     )
     def test_redact_all_matching_regexs(self, raw_log, expected):

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -784,6 +784,9 @@ REDACT_SENSITIVE_LOGS = [
     r"(\"identityToken\": \")[^\"]+",
     r"(response:\s+http://metadata/computeMetadata/v1/instance/"
     "service-accounts.*data: ).*",
+    r"(\'token\': \')[^\']+",
+    r"(\'userCode\': \')[^\']+",
+    r"(\'magic_token=)[^\']+",
 ]
 
 


### PR DESCRIPTION
## Proposed Commit Message
api: change magic-attach key names

The contract server has modified some key names in the response of some magic-attach endpoints. We are now reflecting those changes here as well.

## Test Steps
Run the modified unit and integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
