### PR TITLE
magic-attach: Don't fail on first connection error

### DIFF
--- a/uaclient/api/tests/test_u_pro_attach_magic_wait_v1.py
+++ b/uaclient/api/tests/test_u_pro_attach_magic_wait_v1.py
@@ -60,3 +60,49 @@ class TestSimplifiedAttachWaitV1:
         with pytest.raises(exceptions.MagicAttachTokenError):
             with mock.patch.object(api_wait, "MAXIMUM_ATTEMPTS", 2):
                 wait(options, FakeConfig())
+
+    @mock.patch("time.sleep")
+    def test_wait_fails_after_number_of_connectiviry_errors(
+        self, m_sleep, m_attach_token_info, FakeConfig
+    ):
+        magic_token = "test-id"
+        m_attach_token_info.side_effect = [
+            exceptions.ConnectivityError(),
+            exceptions.ConnectivityError(),
+            exceptions.ConnectivityError(),
+            exceptions.ConnectivityError(),
+        ]
+
+        options = MagicAttachWaitOptions(magic_token=magic_token)
+
+        with pytest.raises(exceptions.ConnectivityError):
+            wait(options, FakeConfig())
+
+        assert 3 == m_sleep.call_count
+
+    @mock.patch("time.sleep")
+    def test_wait_succeds_after_number_of_connectiviry_errors(
+        self, m_sleep, m_attach_token_info, FakeConfig
+    ):
+        magic_token = "test-id"
+        m_attach_token_info.side_effect = [
+            exceptions.ConnectivityError(),
+            exceptions.ConnectivityError(),
+            exceptions.ConnectivityError(),
+            {
+                "token": magic_token,
+                "expires": "2100-06-09T18:14:55.323733Z",
+                "expiresIn": "2000",
+                "userCode": "1234",
+                "contractToken": "ctoken",
+                "contractID": "cid",
+            },
+        ]
+
+        options = MagicAttachWaitOptions(magic_token=magic_token)
+        expected_response = wait(options, FakeConfig())
+
+        assert expected_response.contract_token == "ctoken"
+        assert expected_response.contract_id == "cid"
+        assert 4 == m_attach_token_info.call_count
+        assert 3 == m_sleep.call_count

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -193,10 +193,7 @@ class UAContractClient(serviceclient.UAServiceClient):
             raise e
         except exceptions.UrlError as e:
             logging.exception(str(e))
-            raise exceptions.UserFacingError(
-                msg=messages.CONNECTIVITY_ERROR.msg,
-                msg_code=messages.CONNECTIVITY_ERROR.name,
-            )
+            raise exceptions.ConnectivityError()
 
         return response
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -202,6 +202,14 @@ class AttachInvalidTokenError(UserFacingError):
         )
 
 
+class ConnectivityError(UserFacingError):
+    def __init__(self):
+        super().__init__(
+            msg=messages.CONNECTIVITY_ERROR.msg,
+            msg_code=messages.CONNECTIVITY_ERROR.name,
+        )
+
+
 class MagicAttachTokenAlreadyActivated(UserFacingError):
     def __init__(self):
         msg = messages.MAGIC_ATTACH_TOKEN_ALREADY_ACTIVATED


### PR DESCRIPTION
## Proposed Commit Message
magic-attach: Don't fail on first connection error

When running the wait endpoint, we will now try at least 3 times if we receive a connectivity error. The rationale for that is
to avoid flake connectivity errors to stop the execution of the command

## Test Steps
Run the new unit test and check that the integration test for magic attach is still working as expected

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
