### PR TITLE
status: correct data in non-root

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1546,7 +1546,7 @@ def action_status(args, *, cfg):
     if cfg.is_attached:
         try:
             if contract.is_contract_changed(cfg):
-                cfg.notice_file.add(
+                cfg.notice_file.try_add(
                     "", messages.NOTICE_REFRESH_CONTRACT_WARNING
                 )
         except exceptions.UrlError as e:

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -127,7 +127,7 @@ def FakeConfig(tmpdir):
                             "name": account_name,
                             "createdAt": "2019-06-14T06:45:50Z",
                             "externalAccountIDs": [
-                                {"IDs": ["id1"], "Origin": "AWS"}
+                                {"IDs": ["id1"], "origin": "AWS"}
                             ],
                         },
                         "contractInfo": {

--- a/uaclient/contract_data_types.py
+++ b/uaclient/contract_data_types.py
@@ -52,6 +52,17 @@ class AvailableResource(DataObject):
         self.presentedAs = presentedAs
 
 
+class ExternalID(DataObject):
+    fields = [
+        Field("origin", StringDataValue, False),
+        Field("IDs", data_list(StringDataValue), False),
+    ]
+
+    def __init__(self, origin: Optional[str], IDs: Optional[List[str]]):
+        self.origin = origin
+        self.IDs = IDs
+
+
 class AccountInfo(DataObject):
     fields = [
         Field("name", StringDataValue, False),
@@ -59,6 +70,7 @@ class AccountInfo(DataObject):
         Field("createdAt", StringDataValue, False),
         Field("type", StringDataValue, False),
         Field("userRoleOnAccount", StringDataValue, False),
+        Field("externalAccountIDs", data_list(ExternalID), False),
     ]
 
     def __init__(
@@ -68,12 +80,14 @@ class AccountInfo(DataObject):
         createdAt: Optional[str],
         type: Optional[str],
         userRoleOnAccount: Optional[str],
+        externalAccountIDs: Optional[List[str]],
     ):
         self.name = name
         self.id = id
-        self.createAt = createdAt
+        self.createdAt = createdAt
         self.type = type
         self.userRoleOnAccount = userRoleOnAccount
+        self.externalAccountIDs = externalAccountIDs
 
 
 class Affordances(DataObject):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -307,7 +307,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         super_status, super_msg = super().application_status()
 
         if system.is_container() and not system.should_reboot():
-            self.cfg.notice_file.remove(
+            self.cfg.notice_file.try_remove(
                 "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
             )
             return super_status, super_msg
@@ -317,21 +317,23 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             # We are now only removing the notice if there is no reboot
             # required information regarding the fips metapackage we install.
             if not system.should_reboot(set(self.packages)):
-                self.cfg.notice_file.remove(
+                self.cfg.notice_file.try_remove(
                     "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
                 )
 
-            self.cfg.notice_file.remove("", messages.FIPS_REBOOT_REQUIRED_MSG)
+            self.cfg.notice_file.try_remove(
+                "", messages.FIPS_REBOOT_REQUIRED_MSG
+            )
             if system.load_file(self.FIPS_PROC_FILE).strip() == "1":
-                self.cfg.notice_file.remove(
+                self.cfg.notice_file.try_remove(
                     "", messages.NOTICE_FIPS_MANUAL_DISABLE_URL
                 )
                 return super_status, super_msg
             else:
-                self.cfg.notice_file.remove(
+                self.cfg.notice_file.try_remove(
                     "", messages.FIPS_DISABLE_REBOOT_REQUIRED
                 )
-                self.cfg.notice_file.add(
+                self.cfg.notice_file.try_add(
                     "", messages.NOTICE_FIPS_MANUAL_DISABLE_URL
                 )
                 return (
@@ -341,7 +343,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     ),
                 )
         else:
-            self.cfg.notice_file.remove(
+            self.cfg.notice_file.try_remove(
                 "", messages.FIPS_DISABLE_REBOOT_REQUIRED
             )
 
@@ -379,10 +381,12 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     def _perform_enable(self, silent: bool = False) -> bool:
         if super()._perform_enable(silent=silent):
-            self.cfg.notice_file.remove(
+            self.cfg.notice_file.try_remove(
                 "", messages.NOTICE_WRONG_FIPS_METAPACKAGE_ON_CLOUD
             )
-            self.cfg.notice_file.remove("", messages.FIPS_REBOOT_REQUIRED_MSG)
+            self.cfg.notice_file.try_remove(
+                "", messages.FIPS_REBOOT_REQUIRED_MSG
+            )
             return True
 
         return False
@@ -507,7 +511,9 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                 "defaulting to generic FIPS package."
             )
         if super()._perform_enable(silent=silent):
-            self.cfg.notice_file.remove("", messages.FIPS_INSTALL_OUT_OF_DATE)
+            self.cfg.notice_file.try_remove(
+                "", messages.FIPS_INSTALL_OUT_OF_DATE
+            )
             return True
 
         return False
@@ -568,7 +574,7 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     def _perform_enable(self, silent: bool = False) -> bool:
         if super()._perform_enable(silent=silent):
-            self.cfg.notice_file.remove(
+            self.cfg.notice_file.try_remove(
                 "", messages.FIPS_DISABLE_REBOOT_REQUIRED
             )
             services_once_enabled = (

--- a/uaclient/files.py
+++ b/uaclient/files.py
@@ -350,6 +350,10 @@ class NoticeFile:
         self.is_root = root_mode
 
     def add(self, label: str, description: str):
+        """
+        Adds a notice to the notices.json file.
+        Raises a NonRootUserError if the user is not root.
+        """
         if self.is_root:
             notices = self.read() or []
             notice = [label, description]
@@ -359,7 +363,21 @@ class NoticeFile:
         else:
             raise exceptions.NonRootUserError
 
+    def try_add(self, label: str, description: str):
+        """
+        Adds a notice to the notices.json file.
+        Logs a warning when adding as non-root
+        """
+        try:
+            self.add(label, description)
+        except exceptions.NonRootUserError:
+            event.warning("Trying to add notice as non-root user")
+
     def remove(self, label_regex: str, descr_regex: str):
+        """
+        Removes a notice to the notices.json file.
+        Raises a NonRootUserError if the user is not root.
+        """
         if self.is_root:
             notices = []
             cached_notices = self.read() or []
@@ -375,6 +393,16 @@ class NoticeFile:
                 self.file.delete()
         else:
             raise exceptions.NonRootUserError
+
+    def try_remove(self, label_regex: str, descr_regex: str):
+        """
+        Removes a notice to the notices.json file.
+        Logs  a warning when removing as non-root
+        """
+        try:
+            self.remove(label_regex, descr_regex)
+        except exceptions.NonRootUserError:
+            event.warning("Trying to remove notice as non-root user")
 
     def read(self):
         content = self.file.read()

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -570,7 +570,7 @@ class TestActionAttach:
                         "name": "acc-name",
                         "createdAt": "2019-06-14T06:45:50Z",
                         "externalAccountIDs": [
-                            {"IDs": ["id1"], "Origin": "AWS"}
+                            {"IDs": ["id1"], "origin": "AWS"}
                         ],
                     },
                     "contractInfo": {

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -676,7 +676,7 @@ class TestActionStatus:
                 "id": "acct-1",
                 "name": "test_account",
                 "created_at": account_created_at,
-                "external_account_ids": [{"IDs": ["id1"], "Origin": "AWS"}],
+                "external_account_ids": [{"IDs": ["id1"], "origin": "AWS"}],
             },
             "config_path": None,
             "config": {"data_dir": mock.ANY},


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

status: correct data in non-root

Currently, when `ua status` as non-root it gets its status from status cache file.
Incase of any changes on the contract server concerning the machine's account,
we do not get up to date info.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
