### PR TITLE
ros: make service non-beta

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -550,6 +550,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/certifications#fips\)
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
+         - ros-updates: All Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
+         - ros: Security Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
         """
         When I run `pro help` with sudo
         Then stdout matches regexp:
@@ -569,6 +573,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/certifications#fips\)
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
+         - ros-updates: All Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
+         - ros: Security Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
         """
         When I run `pro help --all` as non-root
         Then stdout matches regexp:
@@ -654,6 +662,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/certifications#fips\)
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
+         - ros-updates: All Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
+         - ros: Security Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
          - usg: Security compliance and audit tools
            \(https://ubuntu.com/security/certifications/docs/usg\)
         """
@@ -673,6 +685,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/certifications#fips\)
          - livepatch: Canonical Livepatch service
            \(https://ubuntu.com/security/livepatch\)
+         - ros-updates: All Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
+         - ros: Security Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
          - usg: Security compliance and audit tools
            \(https://ubuntu.com/security/certifications/docs/usg\)
         """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -144,11 +144,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
             {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
-        And I verify that running `pro enable ros foobar --format json --assume-yes` `with sudo` exits `1`
+        And I verify that running `pro enable realtime-kernel foobar --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
         """
-        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar, ros'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": ["foobar", "ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar, realtime-kernel'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": ["foobar", "realtime-kernel"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
         """
         And I verify that running `pro enable esm-infra --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
@@ -179,11 +179,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                         |
-           | xenial  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch. |
-           | bionic  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch. |
-           | focal   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, usg. |
-           | jammy   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, usg. |
+           | release | valid_services                                                                       |
+           | xenial  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates. |
+           | bionic  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates. |
+           | focal   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates, usg. |
+           | jammy   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates, usg. |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -192,36 +192,36 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable foobar` `as non-root` exits `1`
         And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo).
-            """
+        """
+        This command must be run as root (try using sudo).
+        """
         And I verify that running `pro enable foobar` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
+        """
+        One moment, checking your subscription first
+        """
         And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar'.
-            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch.
-            """
-        And I verify that running `pro enable ros foobar` `with sudo` exits `1`
+        """
+        Cannot enable unknown service 'foobar'.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates.
+        """
+        And I verify that running `pro enable realtime-kernel foobar` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
+        """
+        One moment, checking your subscription first
+        """
         And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar, ros'.
-            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch.
-            """
+        """
+        Cannot enable unknown service 'foobar, realtime-kernel'.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates.
+        """
         And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Ubuntu Pro: ESM Infra is already enabled.
-            See: sudo pro status
-            """
+        """
+        One moment, checking your subscription first
+        Ubuntu Pro: ESM Infra is already enabled.
+        See: sudo pro status
+        """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
         """
@@ -248,36 +248,36 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable foobar` `as non-root` exits `1`
         And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo).
-            """
+        """
+        This command must be run as root (try using sudo).
+        """
         And I verify that running `pro enable foobar` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
+        """
+        One moment, checking your subscription first
+        """
         And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar'.
-            Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, usg.
-            """
-        And I verify that running `pro enable ros foobar` `with sudo` exits `1`
+        """
+        Cannot enable unknown service 'foobar'.
+        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates, usg.
+        """
+        And I verify that running `pro enable realtime-kernel foobar` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
+        """
+        One moment, checking your subscription first
+        """
         And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar, ros'.
-            Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, usg.
-            """
+        """
+        Cannot enable unknown service 'foobar, realtime-kernel'.
+        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates, usg.
+        """
         And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Ubuntu Pro: ESM Infra is already enabled.
-            See: sudo pro status
-            """
+        """
+        One moment, checking your subscription first
+        Ubuntu Pro: ESM Infra is already enabled.
+        See: sudo pro status
+        """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
         """
@@ -527,10 +527,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
             One moment, checking your subscription first
             """
-        Then I will see the following on stderr:
+        And stderr matches regexp:
             """
             Cannot enable unknown service 'usg'.
-            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch.
+            Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch, ros,\nros-updates.
             """
 
         Examples: cis service
@@ -831,7 +831,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         ros           +yes                disabled           Security Updates for the Robot Operating System
         """
-        When I run `pro enable ros --assume-yes --beta` with sudo
+        When I run `pro enable ros --assume-yes` with sudo
         And I run `pro status --all` as non-root
         Then stdout matches regexp
         """
@@ -867,13 +867,13 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         esm-apps      +yes                disabled           Extended Security Maintenance for Applications
         """
-        When I verify that running `pro enable ros --beta` `with sudo` and stdin `N` exits `1`
+        When I verify that running `pro enable ros` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp
         """
         ROS ESM Security Updates cannot be enabled with Ubuntu Pro: ESM Apps disabled.
         Enable Ubuntu Pro: ESM Apps and proceed to enable ROS ESM Security Updates\? \(y\/N\) Cannot enable ROS ESM Security Updates when Ubuntu Pro: ESM Apps is disabled.
         """
-        When I run `pro enable ros --beta` `with sudo` and stdin `y`
+        When I run `pro enable ros` `with sudo` and stdin `y`
         Then stdout matches regexp
         """
         One moment, checking your subscription first
@@ -904,7 +904,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I run `apt install python3-catkin-pkg -y` with sudo
         Then I verify that `python3-catkin-pkg` is installed from apt source `<ros-security-source>`
 
-        When I run `pro enable ros-updates --assume-yes --beta` with sudo
+        When I run `pro enable ros-updates --assume-yes` with sudo
         And I run `pro status --all` as non-root
         Then stdout matches regexp
         """
@@ -924,7 +924,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Disable ROS ESM All Updates and proceed to disable ROS ESM Security Updates\? \(y\/N\) Disabling dependent service: ROS ESM All Updates
         Updating package lists
         """
-        When I run `pro enable ros-updates --beta` `with sudo` and stdin `y`
+        When I run `pro enable ros-updates` `with sudo` and stdin `y`
         Then stdout matches regexp
         """
         One moment, checking your subscription first
@@ -947,7 +947,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I run `pro disable ros --assume-yes` with sudo
         When I run `pro disable esm-apps --assume-yes` with sudo
         When I run `pro disable esm-infra --assume-yes` with sudo
-        When I run `pro enable ros-updates --assume-yes --beta` with sudo
+        When I run `pro enable ros-updates --assume-yes` with sudo
         When I run `pro status --all` as non-root
         Then stdout matches regexp
         """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -55,6 +55,8 @@ Feature: Unattached status
             fips          +<fips>      +NIST-certified core packages
             fips-updates  +<fips>      +NIST-certified core packages with priority security updates
             livepatch     +<livepatch> +Canonical Livepatch service
+            ros           +<ros>       +Security Updates for the Robot Operating System
+            ros-updates   +<ros>       +All Updates for the Robot Operating System
             ?<usg>( +<cis-available> +Security compliance and audit tools)?
 
             This machine is not attached to an Ubuntu Pro subscription.
@@ -90,6 +92,8 @@ Feature: Unattached status
             fips          +<fips>      +NIST-certified core packages
             fips-updates  +<fips>      +NIST-certified core packages with priority security updates
             livepatch     +<livepatch> +Canonical Livepatch service
+            ros           +<ros>       +Security Updates for the Robot Operating System
+            ros-updates   +<ros>       +All Updates for the Robot Operating System
             ?<usg>( +<cis-available> +Security compliance and audit tools)?
 
             This machine is not attached to an Ubuntu Pro subscription.
@@ -157,33 +161,35 @@ Feature: Unattached status
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I do a preflight check for `contract_token` without the all flag
         Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
-            cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +yes +yes +Extended Security Maintenance for Applications
-            ?esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +yes  +no   +NIST-certified core packages
-            fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
-            ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
-            """
+        """
+        SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
+        cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
+        ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        ?esm-apps      +<esm-apps>  +yes +yes +Extended Security Maintenance for Applications
+        ?esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
+        fips          +<fips>      +yes  +no   +NIST-certified core packages
+        fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
+        livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
+        ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
+        ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
+        ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        """
         When I do a preflight check for `contract_token` with the all flag
         Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
-            cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +yes  +yes  +Extended Security Maintenance for Applications
-            esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +yes  +no   +NIST-certified core packages
-            fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
-            realtime-kernel +<realtime-kernel> +yes  +no  +Beta-version Ubuntu Kernel with PREEMPT_RT patches
-            ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
-            ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
-            ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
-            """
+        """
+        SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
+        cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
+        ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        ?esm-apps      +<esm-apps>  +yes  +yes  +Extended Security Maintenance for Applications
+        esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
+        fips          +<fips>      +yes  +no   +NIST-certified core packages
+        fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
+        livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
+        realtime-kernel +<realtime-kernel> +yes  +no  +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
+        ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
+        ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        """
         When I do a preflight check for `contract_token` formatted as json
         Then stdout is a json matching the `ua_status` schema
         When I do a preflight check for `contract_token` formatted as yaml
@@ -191,23 +197,24 @@ Feature: Unattached status
         When I verify that a preflight check for `invalid_token` formatted as json exits 1
         Then stdout is a json matching the `ua_status` schema
         And I will see the following on stdout:
-            """
-            {"environment_vars": [], "errors": [{"message": "Invalid token. See https://ubuntu.com/pro", "message_code": "attach-invalid-token", "service": null, "type": "system"}], "result": "failure", "services": [], "warnings": []}
-            """
+        """
+        {"environment_vars": [], "errors": [{"message": "Invalid token. See https://ubuntu.com/pro", "message_code": "attach-invalid-token", "service": null, "type": "system"}], "result": "failure", "services": [], "warnings": []}
+        """
         When I verify that a preflight check for `invalid_token` formatted as yaml exits 1
         Then stdout is a yaml matching the `ua_status` schema
         And I will see the following on stdout:
-            """
-            environment_vars: []
-            errors:
-            - message: Invalid token. See https://ubuntu.com/pro
-              message_code: attach-invalid-token
-              service: null
-              type: system
-            result: failure
-            services: []
-            warnings: []
-            """
+        """
+        environment_vars: []
+        errors:
+        - message: Invalid token. See https://ubuntu.com/pro
+          message_code: attach-invalid-token
+          service: null
+          type: system
+        result: failure
+        services: []
+        warnings: []
+        """
+
         Examples: ubuntu release
            | release | esm-apps | cc-eal | cis | cis-available | fips | esm-infra | ros | livepatch | usg | realtime-kernel |
            | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
@@ -226,36 +233,38 @@ Feature: Unattached status
         And I verify that a preflight check for `contract_token_staging_expired` formatted as json exits 1
         Then stdout is a json matching the `ua_status` schema
         And stdout matches regexp:
-            """
-            \"result\": \"failure\"
-            """
+        """
+        \"result\": \"failure\"
+        """
         And stdout matches regexp:
-            """
-            \"message\": \"Contract .* expired on .*\"
-            """
+        """
+        \"message\": \"Contract .* expired on .*\"
+        """
         When I verify that a preflight check for `contract_token_staging_expired` formatted as yaml exits 1
         Then stdout is a yaml matching the `ua_status` schema
         Then stdout matches regexp:
-            """
-            errors:
-            - message: Contract .* expired on .*
-            """
+        """
+        errors:
+        - message: Contract .* expired on .*
+        """
         When I verify that a preflight check for `contract_token_staging_expired` without the all flag exits 1
         Then stdout matches regexp:
-            """
-            This token is not valid.
-            Contract \".*\" expired on .*
+        """
+        This token is not valid.
+        Contract \".*\" expired on .*
 
-            SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
-            cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +yes +yes +Extended Security Maintenance for Applications
-            ?esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +yes  +no   +NIST-certified core packages
-            fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
-            ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
-            """
+        SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
+        cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
+        ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        ?esm-apps      +<esm-apps>  +yes +yes +Extended Security Maintenance for Applications
+        ?esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
+        fips          +<fips>      +yes  +no   +NIST-certified core packages
+        fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
+        livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
+        ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
+        ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
+        ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        """
 
         Examples: ubuntu release
            | release | esm-apps | cc-eal | cis | cis-available | fips | esm-infra | ros | livepatch | usg |

--- a/uaclient/entitlements/ros.py
+++ b/uaclient/entitlements/ros.py
@@ -7,7 +7,6 @@ from uaclient.entitlements.base import UAEntitlement
 class ROSCommonEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/robotics/ros-esm"
     repo_key_file = "ubuntu-advantage-ros.gpg"
-    is_beta = True
 
 
 class ROSEntitlement(ROSCommonEntitlement):

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -40,7 +40,7 @@ Disable an Ubuntu Pro service.
 Arguments:
   service              the name(s) of the Ubuntu Pro services to disable. One
                        of: cc-eal, cis, esm-apps, esm-infra, fips, fips-
-                       updates, livepatch
+                       updates, livepatch, ros, ros-updates
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -21,7 +21,7 @@ Enable an Ubuntu Pro service.
 Arguments:
   service              the name(s) of the Ubuntu Pro services to enable. One
                        of: cc-eal, cis, esm-apps, esm-infra, fips, fips-
-                       updates, livepatch
+                       updates, livepatch, ros, ros-updates
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -76,6 +76,8 @@ esm-infra        no         yes        yes           Extended Security Maintenan
 fips             no         no         no            NIST-certified core packages
 fips-updates     no         no         no            NIST-certified core packages with priority security updates
 livepatch        yes        yes        no            Canonical Livepatch service
+ros              no         no         no            Security Updates for the Robot Operating System
+ros-updates      no         no         no            All Updates for the Robot Operating System
 """  # noqa: E501
 
 UNATTACHED_STATUS = """\
@@ -85,6 +87,8 @@ esm-infra        no         Extended Security Maintenance for Infrastructure
 fips             no         NIST-certified core packages
 fips-updates     no         NIST-certified core packages with priority security updates
 livepatch        yes        Canonical Livepatch service
+ros              no         Security Updates for the Robot Operating System
+ros-updates      no         All Updates for the Robot Operating System
 
 This machine is not attached to an Ubuntu Pro subscription.
 See https://ubuntu.com/pro
@@ -117,6 +121,8 @@ esm-infra        no        {dash}         Extended Security Maintenance for Infr
 fips             no        {dash}         NIST-certified core packages
 fips-updates     no        {dash}         NIST-certified core packages with priority security updates
 livepatch        no        {dash}         Canonical Livepatch service
+ros              no        {dash}         Security Updates for the Robot Operating System
+ros-updates      no        {dash}         All Updates for the Robot Operating System
 {notices}{features}
 Enable services with: pro enable <service>
 
@@ -126,7 +132,7 @@ Enable services with: pro enable <service>
 Technical support level: n/a
 """  # noqa: E501
 
-BETA_SVC_NAMES = ["realtime-kernel", "ros", "ros-updates"]
+BETA_SVC_NAMES = ["realtime-kernel"]
 
 SERVICES_JSON_ALL = [
     {
@@ -738,7 +744,18 @@ class TestActionStatus:
         ), mock.patch.object(event, "_command", "status"):
             assert 0 == action_status(args, cfg=cfg)
 
-        expected_services = [
+        beta_services = [
+            {
+                "auto_enabled": "no",
+                "available": "no",
+                "description": "Beta-version Ubuntu Kernel with PREEMPT_RT"
+                " patches",
+                "entitled": "no",
+                "name": "realtime-kernel",
+            },
+        ]
+
+        services = [
             {
                 "auto_enabled": "yes",
                 "available": "yes",
@@ -778,14 +795,6 @@ class TestActionStatus:
             {
                 "auto_enabled": "no",
                 "available": "no",
-                "description": "Beta-version Ubuntu Kernel with PREEMPT_RT"
-                " patches",
-                "entitled": "no",
-                "name": "realtime-kernel",
-            },
-            {
-                "auto_enabled": "no",
-                "available": "no",
                 "description": "Security Updates for the Robot Operating"
                 " System",
                 "entitled": "no",
@@ -800,8 +809,11 @@ class TestActionStatus:
             },
         ]
 
+        expected_services = sorted(
+            services + beta_services, key=lambda x: x["name"]
+        )
         if not use_all:
-            expected_services = expected_services[:-3]
+            expected_services = services
 
         expected = {
             "_doc": "Content provided in json response is currently considered"

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -268,8 +268,10 @@ def esm_desc(FakeConfig):
 
 
 @pytest.fixture
-def ros_desc(FakeConfig):
-    return entitlement_factory(cfg=FakeConfig(), name="ros").description
+def realtime_desc(FakeConfig):
+    return entitlement_factory(
+        cfg=FakeConfig(), name="realtime-kernel"
+    ).description
 
 
 @mock.patch("uaclient.config.UAConfig.remove_notice")
@@ -293,8 +295,6 @@ class TestStatus:
         return False
 
     @pytest.mark.parametrize("show_beta", (True, False))
-    @pytest.mark.usefixtures("esm_desc")
-    @pytest.mark.usefixtures("ros_desc")
     @mock.patch("uaclient.status.get_available_resources")
     @mock.patch("uaclient.status.os.getuid", return_value=0)
     def test_root_unattached(
@@ -303,7 +303,7 @@ class TestStatus:
         m_get_available_resources,
         _m_should_reboot,
         m_remove_notice,
-        ros_desc,
+        realtime_desc,
         esm_desc,
         show_beta,
         FakeConfig,
@@ -318,8 +318,8 @@ class TestStatus:
                 },
                 {
                     "available": "no",
-                    "name": "ros",
-                    "description": ros_desc,
+                    "name": "realtime-kernel",
+                    "description": realtime_desc,
                 },
             ]
         else:
@@ -333,7 +333,7 @@ class TestStatus:
         cfg = FakeConfig()
         m_get_available_resources.return_value = [
             {"name": "esm-infra", "available": True},
-            {"name": "ros", "available": False},
+            {"name": "realtime-kernel", "available": False},
         ]
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected["version"] = mock.ANY


### PR DESCRIPTION
## Proposed Commit Message
ros: make service non-beta

Make `ros` and `ros-updates` non beta services

## Test Steps
Verify we can enable those services without the `--beta` flag in the integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
