### PR TITLE
auto-attach: no-op when ua info on cloud-init data

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -648,7 +648,8 @@ def create_instance_with_uat_installed(
     user_data = _get_user_data_for_instance(context.config, series)
 
     if custom_user_data:
-        user_data += "\n{}".format(custom_user_data)
+        prefix = "" if user_data else "#cloud-config"
+        user_data += "{}\n{}".format(prefix, custom_user_data)
 
     logging.info(
         "--- Launching VM to create a base image with ubuntu-advantage"

--- a/features/environment.py
+++ b/features/environment.py
@@ -614,7 +614,10 @@ def build_debs_from_sbuild(context: Context, series: str) -> List[str]:
 
 
 def create_instance_with_uat_installed(
-    context: Context, series: str, name: str
+    context: Context,
+    series: str,
+    name: str,
+    custom_user_data: Optional[str] = None,
 ) -> pycloudlib.instance.BaseInstance:
     """Create a given series lxd image with ubuntu-advantage-tools installed
 
@@ -627,6 +630,10 @@ def create_instance_with_uat_installed(
         it.
     :param series:
        A string representing the series name to create
+    :param name:
+       A string representing the instance name
+    :param custom_user_data:
+       A string representing custom userdata to be added to the instance
 
     :return: A pycloudlib Instance
     """
@@ -639,6 +646,9 @@ def create_instance_with_uat_installed(
         return
 
     user_data = _get_user_data_for_instance(context.config, series)
+
+    if custom_user_data:
+        user_data += "\n{}".format(custom_user_data)
 
     logging.info(
         "--- Launching VM to create a base image with ubuntu-advantage"
@@ -714,7 +724,7 @@ def _get_user_data_for_instance(
         ppa_url=ppa, ppa_keyid=ppa_keyid
     )
 
-    logging.debug("User data:\n" + user_data)
+    logging.info("-- user data:\n" + user_data)
     return user_data
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -59,7 +59,7 @@ def add_test_name_suffix(context, series, prefix):
 
 
 @given("a `{series}` machine with ubuntu-advantage-tools installed")
-def given_a_machine(context, series):
+def given_a_machine(context, series, custom_user_data=None):
     if series in context.reuse_container:
         context.instances = {}
         context.container_name = context.reuse_container[series]
@@ -103,7 +103,7 @@ def given_a_machine(context, series):
         )
     else:
         inst = create_instance_with_uat_installed(
-            context, series, instance_name
+            context, series, instance_name, custom_user_data
         )
 
     context.series = series
@@ -141,6 +141,14 @@ def when_i_take_a_snapshot(context):
             )
 
     context.add_cleanup(cleanup_image)
+
+
+@given(
+    "a `{series}` machine with ubuntu-advantage-tools installed adding this cloud-init user_data"  # noqa
+)
+def given_a_machine_with_user_data(context, series):
+    custom_user_data = context.text
+    given_a_machine(context, series, custom_user_data)
 
 
 @when("I have the `{series}` debs under test in `{dest}`")

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -74,13 +74,13 @@ def given_a_machine(context, series, custom_user_data=None):
 
     instance_name = add_test_name_suffix(context, series, CONTAINER_PREFIX)
 
-    if context.config.snapshot_strategy:
+    if context.config.snapshot_strategy and not custom_user_data:
         if series not in context.series_image_name:
             build_container_name = add_test_name_suffix(
                 context, series, IMAGE_BUILD_PREFIX
             )
             image_inst = create_instance_with_uat_installed(
-                context, series, build_container_name
+                context, series, build_container_name, custom_user_data
             )
 
             image_name = add_test_name_suffix(context, series, IMAGE_PREFIX)
@@ -92,6 +92,7 @@ def given_a_machine(context, series, custom_user_data=None):
                 image_name=image_name,
                 cloud_api=context.config.cloud_api,
             )
+
             context.series_image_name[series] = image_id
             image_inst.delete(wait=False)
 

--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""
+Perform auto-attach operation
+
+On Ubuntu Pro machines, we try to perform an auto-attach operation
+on first boot. This happens through a systemd unit that triggers
+that executes this script on every boot. However, if we detect
+that cloud-init has user data related to ua, we cannot run
+auto-attach here, since cloud-init will drive this operation on
+their side.
+"""
+import logging
+
+import yaml
+
+from uaclient.cli import action_auto_attach, setup_logging
+from uaclient.config import UAConfig
+from uaclient.exceptions import (
+    AlreadyAttachedOnPROError,
+    ProcessExecutionError,
+)
+from uaclient.util import subp, which
+
+
+def check_cloudinit_userdata_for_ua_info():
+    if not which("cloud-init"):
+        return False
+
+    try:
+        userdata, _ = subp(["cloud-init", "query", "userdata"])
+    except ProcessExecutionError:
+        # if we cannot query the userdata, we should not block auto-attach
+        return False
+
+    try:
+        userdata_dict = yaml.safe_load(userdata)
+    except Exception:
+        # if there is any error parsing the userdata, we should not block
+        # auto-attach
+        return False
+
+    if userdata_dict and "ubuntu_advantage" in userdata_dict.keys():
+        return True
+
+    return False
+
+
+def main(cfg: UAConfig):
+    if not check_cloudinit_userdata_for_ua_info():
+        # Once we have the api functions ready, we should
+        # update this part of the code to not call the cli
+        # function directly
+        try:
+            action_auto_attach(args=None, cfg=cfg)
+        except AlreadyAttachedOnPROError as e:
+            logging.info(e.msg)
+    else:
+        auto_attach_msg = (
+            "Skipping auto-attach and deferring to cloud-init "
+            "to setup and configure auto-attach"
+        )
+
+        logging.info("cloud-init userdata has ubuntu-advantage key.")
+        logging.info(auto_attach_msg)
+
+
+if __name__ == "__main__":
+    cfg = UAConfig(root_mode=True)
+    setup_logging(logging.INFO, logging.DEBUG, log_file=cfg.log_file)
+    main(cfg=cfg)

--- a/systemd/ua-auto-attach.path
+++ b/systemd/ua-auto-attach.path
@@ -1,9 +1,0 @@
-[Unit]
-Description=Ubuntu Advantage auto attach trigger
-
-[Path]
-PathExists=/run/cloud-init/instance-data.json
-Unit=ua-auto-attach.service
-
-[Install]
-WantedBy=multi-user.target

--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Ubuntu Advantage auto attach
 Before=cloud-config.service
+After=cloud-config.target
 
 [Service]
 Type=oneshot

--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -4,7 +4,7 @@ Before=cloud-config.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ua auto-attach
+ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/auto_attach.py
 TimeoutSec=0
 
 [Install]

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -35,7 +35,7 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
     # mypy does not handle @property around inner decorators
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
-    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
+    @util.retry(HTTPError, retry_sleeps=[0.5, 1, 1])
     def identity_doc(self) -> Dict[str, Any]:
         response, _headers = self._get_imds_url_response()
         return {"pkcs7": response}

--- a/uaclient/clouds/azure.py
+++ b/uaclient/clouds/azure.py
@@ -23,12 +23,12 @@ class UAAutoAttachAzureInstance(AutoAttachCloudInstance):
     # mypy does not handle @property around inner decorators
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
-    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
+    @util.retry(HTTPError, retry_sleeps=[1, 1, 1])
     def identity_doc(self) -> Dict[str, Any]:
         responses = {}
         for key, url in sorted(IMDS_URLS.items()):
             url_response, _headers = util.readurl(
-                url, headers={"Metadata": "true"}
+                url, headers={"Metadata": "true"}, timeout=1
             )
             if key == "pkcs7":
                 responses[key] = url_response["signature"]

--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -42,11 +42,13 @@ class UAAutoAttachGCPInstance(AutoAttachCloudInstance):
     # mypy does not handle @property around inner decorators
     # https://github.com/python/mypy/issues/1362
     @property  # type: ignore
-    @util.retry(exceptions.GCPProAccountError, retry_sleeps=[1, 2, 5])
+    @util.retry(exceptions.GCPProAccountError, retry_sleeps=[0.5, 1, 1])
     def identity_doc(self) -> Dict[str, Any]:
         try:
             headers = {"Metadata-Flavor": "Google"}
-            url_response, _headers = util.readurl(TOKEN_URL, headers=headers)
+            url_response, _headers = util.readurl(
+                TOKEN_URL, headers=headers, timeout=1
+            )
         except HTTPError as e:
             body = getattr(e, "body", None)
             error_desc = None

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -159,7 +159,7 @@ class TestUAAutoAttachAWSInstance:
         else:
             assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
 
-        expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
+        expected_sleep_calls = [mock.call(0.5), mock.call(1), mock.call(1)]
         assert expected_sleep_calls == sleep.call_args_list
         expected_logs = [
             "HTTP Error 702: funky error msg Retrying 3 more times.",

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -30,7 +30,9 @@ class TestUAAutoAttachGCPInstance:
         instance = UAAutoAttachGCPInstance()
         assert {"identityToken": "attestedWOOT!==="} == instance.identity_doc
         assert [
-            mock.call(TOKEN_URL, headers={"Metadata-Flavor": "Google"})
+            mock.call(
+                TOKEN_URL, headers={"Metadata-Flavor": "Google"}, timeout=1
+            )
         ] == readurl.call_args_list
 
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
@@ -42,7 +44,7 @@ class TestUAAutoAttachGCPInstance:
     ):
         """Retries backoff before failing to get GCP.identity_doc"""
 
-        def fake_someurlerrors(url, headers):
+        def fake_someurlerrors(url, headers, timeout):
             if readurl.call_count <= fail_count:
                 raise HTTPError(
                     "http://me",
@@ -66,7 +68,7 @@ class TestUAAutoAttachGCPInstance:
                 "identityToken": "attestedWOOT!==="
             } == instance.identity_doc
 
-        expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
+        expected_sleep_calls = [mock.call(0.5), mock.call(1), mock.call(1)]
         assert expected_sleep_calls == sleep.call_args_list
 
         expected_logs = [

--- a/uaclient/tests/test_lib_auto_attach.py
+++ b/uaclient/tests/test_lib_auto_attach.py
@@ -1,0 +1,128 @@
+import mock
+import pytest
+
+from lib.auto_attach import check_cloudinit_userdata_for_ua_info, main
+from uaclient.exceptions import (
+    AlreadyAttachedOnPROError,
+    ProcessExecutionError,
+)
+
+
+class TestCheckCloudinitUserdataForUAInfo:
+    @mock.patch("lib.auto_attach.which")
+    def test_check_cloudinit_data_returns_false_if_no_cloudinit(self, m_which):
+        m_which.return_value = False
+        assert False is check_cloudinit_userdata_for_ua_info()
+
+    @mock.patch("lib.auto_attach.subp")
+    @mock.patch("lib.auto_attach.which")
+    def test_check_cloudinit_data_returns_false_if_query_error(
+        self, m_which, m_subp
+    ):
+        m_which.return_value = True
+        m_subp.side_effect = ProcessExecutionError("test")
+
+        assert False is check_cloudinit_userdata_for_ua_info()
+
+    @mock.patch("lib.auto_attach.subp")
+    @mock.patch("lib.auto_attach.which")
+    def test_check_cloudinit_data_returns_false_if_yaml_error(
+        self, m_which, m_subp
+    ):
+        m_which.return_value = True
+        m_subp.return_value = (
+            """\
+            [invalid, yaml]:
+              - test
+            """,
+            "",
+        )
+
+        assert False is check_cloudinit_userdata_for_ua_info()
+
+    @pytest.mark.parametrize(
+        "expected,userdata",
+        (
+            (
+                False,
+                "",
+            ),
+            (
+                False,
+                """\
+                #cloud-config
+                runcmd:
+                  - echo "test"
+                """,
+            ),
+            (
+                True,
+                """\
+                #cloud-config
+                ubuntu_advantage:
+                 - echo "test"
+                """,
+            ),
+        ),
+    )
+    @mock.patch("lib.auto_attach.subp")
+    @mock.patch("lib.auto_attach.which")
+    def test_check_cloudinit_data(self, m_which, m_subp, expected, userdata):
+        m_which.return_value = True
+        m_subp.return_value = (userdata, "")
+
+        assert expected is check_cloudinit_userdata_for_ua_info()
+
+
+class TestMain:
+    @pytest.mark.parametrize(
+        "ubuntu_advantage_in_userdata",
+        (
+            (True,),
+            (False,),
+        ),
+    )
+    @mock.patch("lib.auto_attach.check_cloudinit_userdata_for_ua_info")
+    @mock.patch("lib.auto_attach.action_auto_attach")
+    def test_main(
+        self,
+        m_cli_auto_attach,
+        m_check_cloudinit,
+        ubuntu_advantage_in_userdata,
+        caplog_text,
+        FakeConfig,
+    ):
+        m_check_cloudinit.return_value = ubuntu_advantage_in_userdata
+        main(cfg=FakeConfig())
+
+        if not ubuntu_advantage_in_userdata:
+            assert 1 == m_cli_auto_attach.call_count
+        else:
+            assert 0 == m_cli_auto_attach.call_count
+            assert (
+                "cloud-init userdata has ubuntu-advantage key."
+            ) in caplog_text()
+            assert (
+                "Skipping auto-attach and deferring to cloud-init "
+                "to setup and configure auto-attach"
+            ) in caplog_text()
+
+    @mock.patch("lib.auto_attach.check_cloudinit_userdata_for_ua_info")
+    @mock.patch("lib.auto_attach.action_auto_attach")
+    def test_main_when_already_attached(
+        self,
+        m_cli_auto_attach,
+        m_check_cloudinit,
+        FakeConfig,
+        caplog_text,
+    ):
+        m_check_cloudinit.return_value = False
+        m_cli_auto_attach.side_effect = AlreadyAttachedOnPROError(
+            instance_id="inst"
+        )
+        main(cfg=FakeConfig())
+
+        assert (
+            "Skipping attach: Instance 'inst' is already attached."
+            in caplog_text()
+        )


### PR DESCRIPTION
## Proposed Commit Message
auto-attach: no-op when ua info on cloud-init data

When we detect the ubuntu_advantage key on cloud-init userdata, we should no-op the ua-auto-attach service. That's because if we detect that key, cloud-init will be responsible for orchestrating the auto-attach operation on their side.

## Test Steps
Run the new integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
