### PR TITLE
api: adjustments to not require config as an arg

### DIFF
--- a/features/api_magic_attach.feature
+++ b/features/api_magic_attach.feature
@@ -15,7 +15,7 @@ Feature: Magic Attach endpoints
         And the json API response data matches the `magic_attach` schema
         And stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"_schema": "0.1", "expires": ".*", "expires_in": .*, "token": ".*", "user_code": ".*"}, "meta": {\"environment_vars\": \[]}, "type": "MagicAttachInitiate"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"expires": ".*", "expires_in": .*, "token": ".*", "user_code": ".*"}, "meta": {\"environment_vars\": \[]}, "type": "MagicAttachInitiate"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I create the file `/tmp/response-overlay.json` with the following:
         """
@@ -44,7 +44,7 @@ Feature: Magic Attach endpoints
         And the json API response data matches the `magic_attach` schema
         And stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"_schema": "0.1", "contract_id": "test-contract-id", "contract_token": "contract-token", "expires": "expire-date", "expires_in": 2000, "token": "testToken", "user_code": "123"}, "meta": {\"environment_vars\": \[]}, "type": "MagicAttachWait"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"contract_id": "test-contract-id", "contract_token": "contract-token", "expires": "expire-date", "expires_in": 2000, "token": "testToken", "user_code": "123"}, "meta": {\"environment_vars\": \[]}, "type": "MagicAttachWait"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I revoke the magic attach token
         Then stdout is a json matching the `api_response` schema

--- a/features/schemas/magic_attach.json
+++ b/features/schemas/magic_attach.json
@@ -1,10 +1,7 @@
 {
     "type": "object",
-    "required": [ "_schema", "user_code", "expires", "expires_in", "token" ],
+    "required": [ "user_code", "expires", "expires_in", "token" ],
     "properties": {
-        "_schema": {
-          "type": "string"
-        },
         "user_code": {
           "type": "string"
         },

--- a/uaclient/api/tests/test_api_u_pro_attach_auto_should_auto_attach.py
+++ b/uaclient/api/tests/test_api_u_pro_attach_auto_should_auto_attach.py
@@ -3,7 +3,7 @@ import pytest
 
 from uaclient import exceptions
 from uaclient.api.u.pro.attach.auto.should_auto_attach.v1 import (
-    should_auto_attach,
+    _should_auto_attach,
 )
 
 M_PATH = "uaclient.api.u.pro.attach.auto.should_auto_attach.v1"
@@ -28,7 +28,7 @@ class TestShouldAutoAttachV1:
         FakeConfig,
     ):
         m_get_installed_pkgs.return_value = installed_pkgs
-        assert expected == should_auto_attach(FakeConfig()).should_auto_attach
+        assert expected == _should_auto_attach(FakeConfig()).should_auto_attach
 
     @pytest.mark.parametrize(
         "cloud_exception",
@@ -46,4 +46,4 @@ class TestShouldAutoAttachV1:
         FakeConfig,
     ):
         m_cloud_factory.side_effect = cloud_exception(cloud_type="test")
-        assert False is should_auto_attach(FakeConfig()).should_auto_attach
+        assert False is _should_auto_attach(FakeConfig()).should_auto_attach

--- a/uaclient/api/tests/test_api_u_pro_attach_magic_wait_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_attach_magic_wait_v1.py
@@ -5,14 +5,14 @@ import uaclient.api.u.pro.attach.magic.wait.v1 as api_wait
 from uaclient import exceptions
 from uaclient.api.u.pro.attach.magic.wait.v1 import (
     MagicAttachWaitOptions,
-    wait,
+    _wait,
 )
 
 
 @mock.patch("uaclient.contract.UAContractClient.get_magic_attach_token_info")
 class TestMagicAttachWaitV1:
     @mock.patch("time.sleep")
-    def test_wait_succeds(self, m_sleep, m_attach_token_info, FakeConfig):
+    def test_wait_succeeds(self, m_sleep, m_attach_token_info, FakeConfig):
         magic_token = "test-id"
 
         m_attach_token_info.side_effect = [
@@ -29,7 +29,7 @@ class TestMagicAttachWaitV1:
         ]
 
         options = MagicAttachWaitOptions(magic_token=magic_token)
-        expected_response = wait(options, FakeConfig())
+        expected_response = _wait(options, FakeConfig())
 
         assert expected_response.contract_token == "ctoken"
         assert expected_response.contract_id == "cid"
@@ -46,7 +46,7 @@ class TestMagicAttachWaitV1:
         options = MagicAttachWaitOptions(magic_token=magic_token)
 
         with pytest.raises(exceptions.MagicAttachTokenError):
-            wait(options, FakeConfig())
+            _wait(options, FakeConfig())
 
     @mock.patch("time.sleep")
     def test_wait_fails_after_maximum_attempts(
@@ -59,7 +59,7 @@ class TestMagicAttachWaitV1:
 
         with pytest.raises(exceptions.MagicAttachTokenError):
             with mock.patch.object(api_wait, "MAXIMUM_ATTEMPTS", 2):
-                wait(options, FakeConfig())
+                _wait(options, FakeConfig())
 
     @mock.patch("time.sleep")
     def test_wait_fails_after_number_of_connectiviry_errors(
@@ -76,7 +76,7 @@ class TestMagicAttachWaitV1:
         options = MagicAttachWaitOptions(magic_token=magic_token)
 
         with pytest.raises(exceptions.ConnectivityError):
-            wait(options, FakeConfig())
+            _wait(options, FakeConfig())
 
         assert 3 == m_sleep.call_count
 
@@ -100,7 +100,7 @@ class TestMagicAttachWaitV1:
         ]
 
         options = MagicAttachWaitOptions(magic_token=magic_token)
-        expected_response = wait(options, FakeConfig())
+        expected_response = _wait(options, FakeConfig())
 
         assert expected_response.contract_token == "ctoken"
         assert expected_response.contract_id == "cid"

--- a/uaclient/api/tests/test_api_u_pro_version.py
+++ b/uaclient/api/tests/test_api_u_pro_version.py
@@ -1,14 +1,14 @@
 import mock
 import pytest
 
-from uaclient.api.u.pro.version.v1 import VersionError, VersionResult, version
+from uaclient.api.u.pro.version.v1 import VersionError, VersionResult, _version
 from uaclient.exceptions import UserFacingError
 
 
 class TestVersionV1:
     @mock.patch("uaclient.api.u.pro.version.v1.get_version", return_value="28")
     def test_version(self, _m_get_version, FakeConfig):
-        result = version(FakeConfig())
+        result = _version(cfg=FakeConfig())
         assert isinstance(result, VersionResult)
         assert result.installed_version == "28"
 
@@ -19,7 +19,7 @@ class TestVersionV1:
         )
 
         with pytest.raises(VersionError) as excinfo:
-            version(FakeConfig())
+            _version(FakeConfig())
 
         assert excinfo.errisinstance(VersionError)
         assert excinfo.value.msg == "('something wrong', 'fn-specific')"

--- a/uaclient/api/u/pro/attach/auto/should_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/should_auto_attach/v1.py
@@ -16,7 +16,11 @@ class ShouldAutoAttachResult(DataObject, AdditionalInfo):
         self.should_auto_attach = should_auto_attach
 
 
-def should_auto_attach(cfg: UAConfig):
+def should_auto_attach() -> ShouldAutoAttachResult:
+    return _should_auto_attach(UAConfig())
+
+
+def _should_auto_attach(cfg: UAConfig) -> ShouldAutoAttachResult:
     try:
         cloud_instance_factory()
     except exceptions.CloudFactoryError:
@@ -32,6 +36,6 @@ def should_auto_attach(cfg: UAConfig):
 endpoint = APIEndpoint(
     version="v1",
     name="ShouldAutoAttach",
-    fn=should_auto_attach,
+    fn=_should_auto_attach,
     options_cls=None,
 )

--- a/uaclient/api/u/pro/attach/magic/initiate/v1.py
+++ b/uaclient/api/u/pro/attach/magic/initiate/v1.py
@@ -12,7 +12,6 @@ from uaclient.data_types import (
 
 class MagicAttachInitiateResult(DataObject, AdditionalInfo):
     fields = [
-        Field("_schema", StringDataValue),
         Field("user_code", StringDataValue),
         Field("token", StringDataValue),
         Field("expires", StringDataValue),
@@ -21,25 +20,26 @@ class MagicAttachInitiateResult(DataObject, AdditionalInfo):
 
     def __init__(
         self,
-        _schema: str,
         user_code: str,
         token: str,
         expires: str,
         expires_in: int,
     ):
-        self._schema = _schema
         self.user_code = user_code
         self.token = token
         self.expires = expires
         self.expires_in = expires_in
 
 
-def initiate(cfg: UAConfig) -> MagicAttachInitiateResult:
+def initiate() -> MagicAttachInitiateResult:
+    return _initiate(UAConfig())
+
+
+def _initiate(cfg: UAConfig) -> MagicAttachInitiateResult:
     contract = UAContractClient(cfg)
     initiate_resp = contract.new_magic_attach_token()
 
     return MagicAttachInitiateResult(
-        _schema="0.1",
         user_code=initiate_resp["userCode"],
         token=initiate_resp["token"],
         expires=initiate_resp["expires"],
@@ -50,6 +50,6 @@ def initiate(cfg: UAConfig) -> MagicAttachInitiateResult:
 endpoint = APIEndpoint(
     version="v1",
     name="MagicAttachInitiate",
-    fn=initiate,
+    fn=_initiate,
     options_cls=None,
 )

--- a/uaclient/api/u/pro/attach/magic/revoke/v1.py
+++ b/uaclient/api/u/pro/attach/magic/revoke/v1.py
@@ -18,7 +18,13 @@ class MagicAttachRevokeResult(DataObject, AdditionalInfo):
     pass
 
 
-def revoke(options: MagicAttachRevokeOptions, cfg: UAConfig) -> DataObject:
+def revoke(options: MagicAttachRevokeOptions) -> MagicAttachRevokeResult:
+    return _revoke(options, UAConfig())
+
+
+def _revoke(
+    options: MagicAttachRevokeOptions, cfg: UAConfig
+) -> MagicAttachRevokeResult:
     contract = UAContractClient(cfg)
     contract.revoke_magic_attach_token(options.magic_token)
 
@@ -28,6 +34,6 @@ def revoke(options: MagicAttachRevokeOptions, cfg: UAConfig) -> DataObject:
 endpoint = APIEndpoint(
     version="v1",
     name="MagicAttachRevoke",
-    fn=revoke,
+    fn=_revoke,
     options_cls=MagicAttachRevokeOptions,
 )

--- a/uaclient/api/u/pro/attach/magic/wait/v1.py
+++ b/uaclient/api/u/pro/attach/magic/wait/v1.py
@@ -26,7 +26,6 @@ class MagicAttachWaitOptions(DataObject):
 
 class MagicAttachWaitResult(DataObject, AdditionalInfo):
     fields = [
-        Field("_schema", StringDataValue),
         Field("user_code", StringDataValue),
         Field("token", StringDataValue),
         Field("expires", StringDataValue),
@@ -37,7 +36,6 @@ class MagicAttachWaitResult(DataObject, AdditionalInfo):
 
     def __init__(
         self,
-        _schema: str,
         user_code: str,
         token: str,
         expires: str,
@@ -45,7 +43,6 @@ class MagicAttachWaitResult(DataObject, AdditionalInfo):
         contract_id: str,
         contract_token: str,
     ):
-        self._schema = _schema
         self.user_code = user_code
         self.token = token
         self.expires = expires
@@ -56,7 +53,12 @@ class MagicAttachWaitResult(DataObject, AdditionalInfo):
 
 def wait(
     options: MagicAttachWaitOptions,
-    cfg: UAConfig,
+) -> MagicAttachWaitResult:
+    return _wait(options, UAConfig())
+
+
+def _wait(
+    options: MagicAttachWaitOptions, cfg: UAConfig
 ) -> MagicAttachWaitResult:
     contract = UAContractClient(cfg)
 
@@ -83,7 +85,6 @@ def wait(
 
         if wait_resp and wait_resp.get("contractToken") is not None:
             return MagicAttachWaitResult(
-                _schema="0.1",
                 user_code=wait_resp["userCode"],
                 token=wait_resp["token"],
                 expires=wait_resp["expires"],
@@ -101,6 +102,6 @@ def wait(
 endpoint = APIEndpoint(
     version="v1",
     name="MagicAttachWait",
-    fn=wait,
+    fn=_wait,
     options_cls=MagicAttachWaitOptions,
 )

--- a/uaclient/api/u/pro/version/v1.py
+++ b/uaclient/api/u/pro/version/v1.py
@@ -19,7 +19,11 @@ class VersionResult(DataObject, AdditionalInfo):
         self.installed_version = installed_version
 
 
-def version(cfg: UAConfig) -> VersionResult:
+def version() -> VersionResult:
+    return _version(UAConfig())
+
+
+def _version(cfg: UAConfig) -> VersionResult:
     try:
         version = get_version()
     except Exception as e:
@@ -30,6 +34,6 @@ def version(cfg: UAConfig) -> VersionResult:
 endpoint = APIEndpoint(
     version="v1",
     name="Version",
-    fn=version,
+    fn=_version,
     options_cls=None,
 )


### PR DESCRIPTION
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
make sure the python script experience of using our api doesn't requiring touching any ua-internals like the UAConfig

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
