### PR TITLE
Added livepatch check in fix_security_issue_id

### DIFF
--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -74,7 +74,8 @@ SECURITY_AFFECTED_PKGS = (
 USN_FIXED = "{issue} is addressed."
 CVE_FIXED = "{issue} is resolved."
 CVE_FIXED_BY_LIVEPATCH = (
-    "{issue} is resolved by livepatch patch version: {version}."
+    OKGREEN_CHECK
+    + " {issue} is resolved by livepatch patch version: {version}."
 )
 SECURITY_URL = "{issue}: {title}\nhttps://ubuntu.com/security/{url_path}"
 SECURITY_DRY_RUN_UA_SERVICE_NOT_ENABLED = """\

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -73,6 +73,9 @@ SECURITY_AFFECTED_PKGS = (
 )
 USN_FIXED = "{issue} is addressed."
 CVE_FIXED = "{issue} is resolved."
+CVE_FIXED_BY_LIVEPATCH = (
+    "{issue} is resolved by livepatch patch version: {version}."
+)
 SECURITY_URL = "{issue}: {title}\nhttps://ubuntu.com/security/{url_path}"
 SECURITY_DRY_RUN_UA_SERVICE_NOT_ENABLED = """\
 {bold}Ubuntu Pro service: {{service}} is not enabled.

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -564,6 +564,7 @@ def fix_security_issue_id(
 
     if "CVE" in issue_id:
         # Check livepatch status for CVE in fixes before checking CVE api
+        status_stdout = None
         try:
             status_stdout, _ = system.subp(
                 [

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -584,7 +584,7 @@ def fix_security_issue_id(
                 if parsed_patch:
                     fixes = parsed_patch.get("Fixes", [])
                     if any(
-                        fix.Name is issue_id.lower() and fix.Patched
+                        fix["Name"] is issue_id.lower() and fix["Patched"]
                         for fix in fixes
                     ):
                         print(

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -584,7 +584,7 @@ def fix_security_issue_id(
                 if parsed_patch:
                     fixes = parsed_patch.get("Fixes", [])
                     if any(
-                        fix["Name"] is issue_id.lower() and fix["Patched"]
+                        fix["Name"] == issue_id.lower() and fix["Patched"]
                         for fix in fixes
                     ):
                         print(

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -2296,7 +2296,7 @@ class TestFixSecurityIssueId:
                                 "Fixes": [
                                     {
                                         "Name": "cve-2013-1798",
-                                        "Description": "Andrew Honig reported a flaw in the way KVM (Kernel-based Virtual \nMachine) emulated the IOAPIC. A privileged guest user could exploit \nthis flaw to read host memory or cause a denial of service (crash the \nhost).",
+                                        "Description": "Mock Description",
                                         "Bug": "",
                                         "Patched": True,
                                     }
@@ -2318,7 +2318,8 @@ class TestFixSecurityIssueId:
         exp_ret,
         FakeConfig,
     ):
-        """fix_security_id returns system not vulnerable when issue_id fixed by livepatch"""
+        """fix_security_id returns system not vulnerable when issue_id fixed
+        by livepatch"""
         subp.return_value = json.dumps(livepatch_status), ""
         with mock.patch(
             "uaclient.security.query_installed_source_pkg_versions"

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import json
 import textwrap
 from collections import defaultdict
 
@@ -2278,6 +2279,52 @@ class TestGetUSNAffectedPackagesStatus:
 
 
 class TestFixSecurityIssueId:
+    @pytest.mark.parametrize(
+        "issue_id,livepatch_status,exp_ret",
+        (
+            (
+                "cve-2013-1798",
+                {
+                    "Status": [
+                        {
+                            "Kernel": "4.4.0-210.242-generic",
+                            "Running": True,
+                            "Livepatch": {
+                                "CheckState": "checked",
+                                "State": "applied",
+                                "Version": "87.1",
+                                "Fixes": [
+                                    {
+                                        "Name": "cve-2013-1798",
+                                        "Description": "Andrew Honig reported a flaw in the way KVM (Kernel-based Virtual \nMachine) emulated the IOAPIC. A privileged guest user could exploit \nthis flaw to read host memory or cause a denial of service (crash the \nhost).",
+                                        "Bug": "",
+                                        "Patched": True,
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                },
+                FixStatus.SYSTEM_NON_VULNERABLE,
+            ),
+        ),
+    )
+    @mock.patch("uaclient.system.subp")
+    def test_patched_msg_when_issue_id_fixed_by_livepatch(
+        self,
+        subp,
+        issue_id,
+        livepatch_status,
+        exp_ret,
+        FakeConfig,
+    ):
+        """fix_security_id returns system not vulnerable when issue_id fixed by livepatch"""
+        subp.return_value = json.dumps(livepatch_status), ""
+        with mock.patch(
+            "uaclient.security.query_installed_source_pkg_versions"
+        ):
+            assert exp_ret == fix_security_issue_id(FakeConfig(), issue_id)
+
     @pytest.mark.parametrize(
         "issue_id", (("CVE-1800-123456"), ("USN-12345-12"))
     )


### PR DESCRIPTION
## Proposed Commit Message

Adds a check of livepatch output during ua fix

Adds a subprocess call of canonical-livepatch with verbose flag
within the fix_security_issue_id method, parses the output as json,
and checks for the presence of the cve issue id in the output's fixes
property, if present.
Resolves #2181 

## Test Steps

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
