### PR TITLE
status: don't show unavailable services by default

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -62,20 +62,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
         And stdout matches regexp:
         """
-        SERVICE      +ENTITLED  STATUS    DESCRIPTION
-        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
-        """
-        And stdout matches regexp:
-        """
         esm-apps     +yes      +enabled  +Extended Security Maintenance for Applications
         esm-infra    +yes      +enabled  +Extended Security Maintenance for Infrastructure
-        fips         +yes      +<fips> +NIST-certified core packages
-        fips-updates +yes      +<fips> +NIST-certified core packages with priority security updates
-        livepatch    +yes      +n/a      +<livepatch_desc>
-        """
-        And stdout matches regexp:
-        """
-        <cis_or_usg> +yes      +<cis>        +Security compliance and audit tools
         """
         And stderr matches regexp:
         """
@@ -311,19 +299,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
         And stdout matches regexp:
         """
-        SERVICE      +ENTITLED  STATUS    DESCRIPTION
-        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
-        """
-        And stdout matches regexp:
-        """
         esm-infra    +yes      +enabled  +Extended Security Maintenance for Infrastructure
-        fips         +yes      +<fips_status>      +NIST-certified core packages
-        fips-updates +yes      +<fips_status>      +NIST-certified core packages with priority security updates
-        livepatch    +yes      +<lp_status>  +<lp_desc>
-        """
-        And stdout matches regexp:
-        """
-        <cis_or_usg>          +yes      +<cis_status> +Security compliance and audit tools
         """
         And stderr matches regexp:
         """
@@ -372,19 +348,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
         And stdout matches regexp:
         """
-        SERVICE      +ENTITLED  STATUS    DESCRIPTION
-        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
-        """
-        And stdout matches regexp:
-        """
         esm-infra    +yes      +enabled  +Extended Security Maintenance for Infrastructure
-        fips         +yes      +<fips_status> +NIST-certified core packages
-        fips-updates +yes      +<fips_status> +NIST-certified core packages with priority security updates
-        livepatch    +yes      +<lp_status>  +Canonical Livepatch service
-        """
-        And stdout matches regexp:
-        """
-        <cis_or_usg>          +yes      +<cis_status> +Security compliance and audit tools
         """
         And stderr matches regexp:
         """
@@ -433,19 +397,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
         And stdout matches regexp:
         """
-        SERVICE      +ENTITLED  STATUS    DESCRIPTION
-        cc-eal       +yes      +<cc_status>     +Common Criteria EAL2 Provisioning Packages
-        """
-        And stdout matches regexp:
-        """
         esm-infra    +yes      +enabled  +Extended Security Maintenance for Infrastructure
-        fips         +yes      +<fips_status> +NIST-certified core packages
-        fips-updates +yes      +<fips_status> +NIST-certified core packages with priority security updates
-        livepatch    +yes      +<lp_status>  +Canonical Livepatch service
-        """
-        And stdout matches regexp:
-        """
-        <cis_or_usg>          +yes      +<cis_status> +Security compliance and audit tools
         """
         And stderr matches regexp:
         """
@@ -475,11 +427,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
             """
         When I run `pro status` with sudo
         Then stdout matches regexp:
-        """
-        SERVICE      +ENTITLED  STATUS    DESCRIPTION
-        cc-eal        +yes +<cc-eal>  +Common Criteria EAL2 Provisioning Packages
-        """
-        And stdout matches regexp:
         """
         esm-apps      +yes +enabled +Extended Security Maintenance for Applications
         esm-infra     +yes +enabled +Extended Security Maintenance for Infrastructure

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -18,3 +18,128 @@ Feature: Attached status
            | xenial  |
            | jammy   |
            | kinetic |
+
+    @series.xenial
+    @series.bionic
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Extended Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Extended Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified core packages
+        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        ros             +yes      +disabled +Security Updates for the Robot Operating System
+        ros-updates     +yes      +disabled +All Updates for the Robot Operating System
+
+        Enable services with: pro enable <service>
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Extended Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Extended Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified core packages
+        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        livepatch       +yes      +n/a      +Canonical Livepatch service
+        realtime-kernel +yes      +n/a      +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +yes      +disabled +Security Updates for the Robot Operating System
+        ros-updates     +yes      +disabled +All Updates for the Robot Operating System
+
+        Enable services with: pro enable <service>
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+
+    @series.focal
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        esm-apps        +yes      +enabled  +Extended Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Extended Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified core packages
+        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        usg             +yes      +disabled +Security compliance and audit tools
+
+        Enable services with: pro enable <service>
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes      +enabled  +Extended Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Extended Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified core packages
+        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        livepatch       +yes      +n/a      +Canonical Livepatch service
+        realtime-kernel +yes      +n/a      +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +yes      +n/a      +Security Updates for the Robot Operating System
+        ros-updates     +yes      +n/a      +All Updates for the Robot Operating System
+        usg             +yes      +disabled +Security compliance and audit tools
+
+        Enable services with: pro enable <service>
+        """
+
+        Examples: ubuntu release
+           | release |
+           | focal   |
+
+    @series.jammy
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached status in the latest LTS ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        esm-apps        +yes      +enabled  +Extended Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Extended Security Maintenance for Infrastructure
+
+        Enable services with: pro enable <service>
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes      +enabled  +Extended Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Extended Security Maintenance for Infrastructure
+        fips            +yes      +n/a      +NIST-certified core packages
+        fips-updates    +yes      +n/a      +NIST-certified core packages with priority security updates
+        livepatch       +yes      +n/a      +Canonical Livepatch service
+        realtime-kernel +yes      +n/a      +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +yes      +n/a      +Security Updates for the Robot Operating System
+        ros-updates     +yes      +n/a      +All Updates for the Robot Operating System
+        usg             +yes      +n/a      +Security compliance and audit tools
+
+        Enable services with: pro enable <service>
+        """
+
+        Examples: ubuntu release
+           | release |
+           | jammy   |

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1161,6 +1161,20 @@ def when_i_create_local_ppas(context, release, next_release):
     )
 
 
+@when("I verify root and non-root `{cmd}` calls have the same output")
+def root_vs_nonroot_cmd_comparison(context, cmd):
+    when_i_run_command(context, cmd, "with sudo")
+    root_status_stdout = context.process.stdout.strip()
+    root_status_stderr = context.process.stderr.strip()
+
+    when_i_run_command(context, cmd, "as non-root")
+    nonroot_status_stdout = context.process.stdout.strip()
+    nonroot_status_stderr = context.process.stderr.strip()
+
+    assert_that(root_status_stdout, nonroot_status_stdout)
+    assert root_status_stderr == nonroot_status_stderr
+
+
 def create_local_ppa(context, release):
     when_i_run_command_on_machine(
         context,

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -225,7 +225,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
+        And I run `pro status --all --wait` as non-root
         Then stdout matches regexp:
         """
         SERVICE       +ENTITLED  STATUS    DESCRIPTION
@@ -348,7 +348,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
+        And I run `pro status --all --wait` as non-root
         Then stdout matches regexp:
         """
         SERVICE       +ENTITLED  STATUS    DESCRIPTION
@@ -470,8 +470,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
+        And I run `pro status --all --wait` as non-root
         Then stdout matches regexp:
         """
         SERVICE       +ENTITLED  STATUS    DESCRIPTION

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -40,121 +40,209 @@ Feature: Unattached status
            | jammy   |
            | kinetic |
 
-    @series.all
+    @series.xenial
+    @series.bionic
     @uses.config.machine_type.lxd.container
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I run `pro status` as non-root
-        Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  DESCRIPTION
-            cc-eal        +<cc-eal>    +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +Extended Security Maintenance for Applications
-            ?esm-infra     +<esm-infra>     +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +NIST-certified core packages
-            fips-updates  +<fips>      +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +Canonical Livepatch service
-            ros           +<ros>       +Security Updates for the Robot Operating System
-            ros-updates   +<ros>       +All Updates for the Robot Operating System
-            ?<usg>( +<cis-available> +Security compliance and audit tools)?
-
-            This machine is not attached to an Ubuntu Pro subscription.
-            See https://ubuntu.com/pro
-            """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  DESCRIPTION
-            cc-eal        +<cc-eal>    +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +Security compliance and audit tools)?
-            ?esm-apps     +<esm-apps>  +Extended Security Maintenance for Applications
-            esm-infra     +<esm-infra>     +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +NIST-certified core packages
-            fips-updates  +<fips>      +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +Canonical Livepatch service
-            realtime-kernel +<realtime-kernel> +Beta-version Ubuntu Kernel with PREEMPT_RT patches
-            ros           +<ros>       +Security Updates for the Robot Operating System
-            ros-updates   +<ros>       +All Updates for the Robot Operating System
-            ?<usg>( +<cis-available> +Security compliance and audit tools)?
-
-            This machine is not attached to an Ubuntu Pro subscription.
-            See https://ubuntu.com/pro
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  DESCRIPTION
-            cc-eal        +<cc-eal>    +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +Extended Security Maintenance for Applications
-            ?esm-infra     +<esm-infra>     +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +NIST-certified core packages
-            fips-updates  +<fips>      +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +Canonical Livepatch service
-            ros           +<ros>       +Security Updates for the Robot Operating System
-            ros-updates   +<ros>       +All Updates for the Robot Operating System
-            ?<usg>( +<cis-available> +Security compliance and audit tools)?
-
-            This machine is not attached to an Ubuntu Pro subscription.
-            See https://ubuntu.com/pro
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  DESCRIPTION
-            cc-eal        +<cc-eal>    +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +Extended Security Maintenance for Applications
-            esm-infra     +<esm-infra>     +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +NIST-certified core packages
-            fips-updates  +<fips>      +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +Canonical Livepatch service
-            realtime-kernel +<realtime-kernel> +Beta-version Ubuntu Kernel with PREEMPT_RT patches
-            ros           +<ros>       +Security Updates for the Robot Operating System
-            ros-updates   +<ros>       +All Updates for the Robot Operating System
-            ?<usg>( +<cis-available> +Security compliance and audit tools)?
-
-            This machine is not attached to an Ubuntu Pro subscription.
-            See https://ubuntu.com/pro
-            """ 
-        When I append the following on uaclient config:
-            """
-            features:
-              allow_beta: true
-            """
+        When I verify root and non-root `pro status` calls have the same output
         And I run `pro status` as non-root
         Then stdout matches regexp:
-            """
-            SERVICE       +AVAILABLE  DESCRIPTION
-            cc-eal        +<cc-eal>    +Common Criteria EAL2 Provisioning Packages
-            ?<cis>( +<cis-available> +Security compliance and audit tools)?
-            ?esm-apps      +<esm-apps>  +Extended Security Maintenance for Applications
-            esm-infra     +<esm-infra>     +Extended Security Maintenance for Infrastructure
-            fips          +<fips>      +NIST-certified core packages
-            fips-updates  +<fips>      +NIST-certified core packages with priority security updates
-            livepatch     +<livepatch> +Canonical Livepatch service
-            realtime-kernel +<realtime-kernel> +Beta-version Ubuntu Kernel with PREEMPT_RT patches
-            ros           +<ros>       +Security Updates for the Robot Operating System
-            ros-updates   +<ros>       +All Updates for the Robot Operating System
-            ?<usg>( +<cis-available> +Security compliance and audit tools)?
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        cc-eal          +yes       +Common Criteria EAL2 Provisioning Packages
+        cis             +yes       +Security compliance and audit tools
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +yes       +NIST-certified core packages
+        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        ros             +yes       +Security Updates for the Robot Operating System
+        ros-updates     +yes       +All Updates for the Robot Operating System
 
-            FEATURES
-            allow_beta: True
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        cc-eal          +yes       +Common Criteria EAL2 Provisioning Packages
+        cis             +yes       +Security compliance and audit tools
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +yes       +NIST-certified core packages
+        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        realtime-kernel +no        +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +yes       +Security Updates for the Robot Operating System
+        ros-updates     +yes       +All Updates for the Robot Operating System
 
-            This machine is not attached to an Ubuntu Pro subscription.
-            See https://ubuntu.com/pro
-            """ 
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """
+        When I append the following on uaclient config:
+        """
+        features:
+            allow_beta: true
+        """
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        cc-eal          +yes       +Common Criteria EAL2 Provisioning Packages
+        cis             +yes       +Security compliance and audit tools
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +yes       +NIST-certified core packages
+        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        ros             +yes       +Security Updates for the Robot Operating System
+        ros-updates     +yes       +All Updates for the Robot Operating System
+
+        FEATURES
+        allow_beta: True
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """ 
 
         Examples: ubuntu release
-           | release | esm-apps | cc-eal | cis | cis-available | fips | esm-infra | ros | livepatch | usg | realtime-kernel |
-           | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
-           | bionic  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
-           | focal   | yes      | no     |     | yes           | yes  | yes       | no  | yes       | usg | no              |
-           | jammy   | yes      | no     |     | no            | no   | yes       | no  | yes       | usg | yes             |
-           | kinetic | no       | no     | cis | no            | no   | no        | no  | no        |     | no              |
+           | release |
+           | xenial  |
+           | bionic  |
 
-    @series.all
+    @series.focal
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Unattached status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I verify root and non-root `pro status` calls have the same output
+        When I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +yes       +NIST-certified core packages
+        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        usg             +yes       +Security compliance and audit tools
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        cc-eal          +no        +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +yes       +NIST-certified core packages
+        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        realtime-kernel +no        +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +no        +Security Updates for the Robot Operating System
+        ros-updates     +no        +All Updates for the Robot Operating System
+        usg             +yes       +Security compliance and audit tools
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """
+        When I append the following on uaclient config:
+        """
+        features:
+            allow_beta: true
+        """
+        When I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +yes       +NIST-certified core packages
+        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        usg             +yes       +Security compliance and audit tools
+
+        FEATURES
+        allow_beta: True
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """ 
+
+        Examples: ubuntu release
+           | release |
+           | focal   |
+
+    @series.jammy
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Unattached status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        livepatch       +yes       +Canonical Livepatch service
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        cc-eal          +no        +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        fips            +no        +NIST-certified core packages
+        fips-updates    +no        +NIST-certified core packages with priority security updates
+        livepatch       +yes       +Canonical Livepatch service
+        realtime-kernel +yes       +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +no        +Security Updates for the Robot Operating System
+        ros-updates     +no        +All Updates for the Robot Operating System
+        usg             +no        +Security compliance and audit tools
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """
+        When I append the following on uaclient config:
+        """
+        features:
+            allow_beta: true
+        """
+        When I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +DESCRIPTION
+        esm-apps        +yes       +Extended Security Maintenance for Applications
+        esm-infra       +yes       +Extended Security Maintenance for Infrastructure
+        livepatch       +yes       +Canonical Livepatch service
+        realtime-kernel +yes       +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+
+        FEATURES
+        allow_beta: True
+
+        This machine is not attached to an Ubuntu Pro subscription.
+        See https://ubuntu.com/pro
+        """ 
+
+        Examples: ubuntu release
+           | release |
+           | jammy   |
+
+    @series.xenial
+    @series.bionic
     @uses.config.machine_type.lxd.container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
@@ -162,33 +250,31 @@ Feature: Unattached status
         When I do a preflight check for `contract_token` without the all flag
         Then stdout matches regexp:
         """
-        SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
-        cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
-        ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
-        ?esm-apps      +<esm-apps>  +yes +yes +Extended Security Maintenance for Applications
-        ?esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
-        fips          +<fips>      +yes  +no   +NIST-certified core packages
-        fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
-        livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
-        ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
-        ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
-        ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        cc-eal          +yes       +yes       +no           +Common Criteria EAL2 Provisioning Packages
+        cis             +yes       +yes       +no           +Security compliance and audit tools
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
+        ros-updates     +yes       +yes       +no           +All Updates for the Robot Operating System
         """
         When I do a preflight check for `contract_token` with the all flag
         Then stdout matches regexp:
         """
-        SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
-        cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
-        ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
-        ?esm-apps      +<esm-apps>  +yes  +yes  +Extended Security Maintenance for Applications
-        esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
-        fips          +<fips>      +yes  +no   +NIST-certified core packages
-        fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
-        livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
-        realtime-kernel +<realtime-kernel> +yes  +no  +Beta-version Ubuntu Kernel with PREEMPT_RT patches
-        ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
-        ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
-        ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        cc-eal          +yes       +yes       +no           +Common Criteria EAL2 Provisioning Packages
+        cis             +yes       +yes       +no           +Security compliance and audit tools
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        realtime-kernel +no        +yes       +no           +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
+        ros-updates     +yes       +yes       +no           +All Updates for the Robot Operating System
         """
         When I do a preflight check for `contract_token` formatted as json
         Then stdout is a json matching the `ua_status` schema
@@ -216,15 +302,130 @@ Feature: Unattached status
         """
 
         Examples: ubuntu release
-           | release | esm-apps | cc-eal | cis | cis-available | fips | esm-infra | ros | livepatch | usg | realtime-kernel |
-           | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
-           | bionic  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
-           | focal   | yes      | no     |     | yes           | yes  | yes       | no  | yes       | usg | no              |
-           | jammy   | yes      | no     |     | no            | no   | yes       | no  | yes       | usg | yes             |
-           | kinetic | no       | no     | cis | no            | no   | no        | no  | no        |     | no              |
+           | release |
+           | xenial  |
+           | bionic  |
+
+    @series.focal
+    @uses.config.machine_type.lxd.container
+    @uses.config.contract_token
+    Scenario Outline: Simulate status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I do a preflight check for `contract_token` without the all flag
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        usg             +yes       +yes       +no           +Security compliance and audit tools
+        """
+        When I do a preflight check for `contract_token` with the all flag
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        cc-eal          +no        +yes       +no           +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        realtime-kernel +no        +yes       +no           +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +no        +yes       +no           +Security Updates for the Robot Operating System
+        ros-updates     +no        +yes       +no           +All Updates for the Robot Operating System
+        usg             +yes       +yes       +no           +Security compliance and audit tools
+        """
+        When I do a preflight check for `contract_token` formatted as json
+        Then stdout is a json matching the `ua_status` schema
+        When I do a preflight check for `contract_token` formatted as yaml
+        Then stdout is a yaml matching the `ua_status` schema
+        When I verify that a preflight check for `invalid_token` formatted as json exits 1
+        Then stdout is a json matching the `ua_status` schema
+        And I will see the following on stdout:
+        """
+        {"environment_vars": [], "errors": [{"message": "Invalid token. See https://ubuntu.com/pro", "message_code": "attach-invalid-token", "service": null, "type": "system"}], "result": "failure", "services": [], "warnings": []}
+        """
+        When I verify that a preflight check for `invalid_token` formatted as yaml exits 1
+        Then stdout is a yaml matching the `ua_status` schema
+        And I will see the following on stdout:
+        """
+        environment_vars: []
+        errors:
+        - message: Invalid token. See https://ubuntu.com/pro
+          message_code: attach-invalid-token
+          service: null
+          type: system
+        result: failure
+        services: []
+        warnings: []
+        """
+
+        Examples: ubuntu release
+           | release |
+           | focal   |
+
+    @series.jammy
+    @uses.config.machine_type.lxd.container
+    @uses.config.contract_token
+    Scenario Outline: Simulate status in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I do a preflight check for `contract_token` without the all flag
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        """
+        When I do a preflight check for `contract_token` with the all flag
+        Then stdout matches regexp:
+        """
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        cc-eal          +no        +yes       +no           +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +no        +yes       +no           +NIST-certified core packages
+        fips-updates    +no        +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        realtime-kernel +yes       +yes       +no           +Beta-version Ubuntu Kernel with PREEMPT_RT patches
+        ros             +no        +yes       +no           +Security Updates for the Robot Operating System
+        ros-updates     +no        +yes       +no           +All Updates for the Robot Operating System
+        usg             +no        +yes       +no           +Security compliance and audit tools
+        """
+        When I do a preflight check for `contract_token` formatted as json
+        Then stdout is a json matching the `ua_status` schema
+        When I do a preflight check for `contract_token` formatted as yaml
+        Then stdout is a yaml matching the `ua_status` schema
+        When I verify that a preflight check for `invalid_token` formatted as json exits 1
+        Then stdout is a json matching the `ua_status` schema
+        And I will see the following on stdout:
+        """
+        {"environment_vars": [], "errors": [{"message": "Invalid token. See https://ubuntu.com/pro", "message_code": "attach-invalid-token", "service": null, "type": "system"}], "result": "failure", "services": [], "warnings": []}
+        """
+        When I verify that a preflight check for `invalid_token` formatted as yaml exits 1
+        Then stdout is a yaml matching the `ua_status` schema
+        And I will see the following on stdout:
+        """
+        environment_vars: []
+        errors:
+        - message: Invalid token. See https://ubuntu.com/pro
+          message_code: attach-invalid-token
+          service: null
+          type: system
+        result: failure
+        services: []
+        warnings: []
+        """
+
+        Examples: ubuntu release
+           | release |
+           | jammy   |
 
 
-    @series.all
+    @series.xenial
+    @series.bionic
     @uses.config.machine_type.lxd.container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
@@ -253,23 +454,100 @@ Feature: Unattached status
         This token is not valid.
         Contract \".*\" expired on .*
 
-        SERVICE       +AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
-        cc-eal        +<cc-eal>    +yes  +no   +Common Criteria EAL2 Provisioning Packages
-        ?<cis>( +<cis-available> +yes +no +Security compliance and audit tools)?
-        ?esm-apps      +<esm-apps>  +yes +yes +Extended Security Maintenance for Applications
-        ?esm-infra     +<esm-infra> +yes  +yes  +Extended Security Maintenance for Infrastructure
-        fips          +<fips>      +yes  +no   +NIST-certified core packages
-        fips-updates  +<fips>      +yes  +no   +NIST-certified core packages with priority security updates
-        livepatch     +<livepatch> +yes  +yes  +Canonical Livepatch service
-        ros           +<ros>       +yes  +no   +Security Updates for the Robot Operating System
-        ros-updates   +<ros>       +yes  +no   +All Updates for the Robot Operating System
-        ?<usg>( +<cis-available> +yes +no +Security compliance and audit tools)?
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        cc-eal          +yes       +yes       +no           +Common Criteria EAL2 Provisioning Packages
+        cis             +yes       +yes       +no           +Security compliance and audit tools
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
+        ros-updates     +yes       +yes       +no           +All Updates for the Robot Operating System
         """
 
         Examples: ubuntu release
-           | release | esm-apps | cc-eal | cis | cis-available | fips | esm-infra | ros | livepatch | usg |
-           | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     |
-           | bionic  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     |
-           | focal   | yes      | no     |     | yes           | yes  | yes       | no  | yes       | usg |
-           | jammy   | yes      | no     |     | no            | no   | yes       | no  | yes       | usg |
-           | kinetic | no       | no     | cis | no            | no   | no        | no  | no        |     |
+           | release |
+           | xenial  |
+           | bionic  |
+
+    @series.focal
+    @uses.config.machine_type.lxd.container
+    @uses.config.contract_token_staging_expired
+    Scenario Outline: Simulate status with expired token in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `sed -i 's/contracts.can/contracts.staging.can/' /etc/ubuntu-advantage/uaclient.conf` with sudo
+        And I verify that a preflight check for `contract_token_staging_expired` formatted as json exits 1
+        Then stdout is a json matching the `ua_status` schema
+        And stdout matches regexp:
+        """
+        \"result\": \"failure\"
+        """
+        And stdout matches regexp:
+        """
+        \"message\": \"Contract .* expired on .*\"
+        """
+        When I verify that a preflight check for `contract_token_staging_expired` formatted as yaml exits 1
+        Then stdout is a yaml matching the `ua_status` schema
+        Then stdout matches regexp:
+        """
+        errors:
+        - message: Contract .* expired on .*
+        """
+        When I verify that a preflight check for `contract_token_staging_expired` without the all flag exits 1
+        Then stdout matches regexp:
+        """
+        This token is not valid.
+        Contract \".*\" expired on .*
+
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        usg             +yes       +yes       +no           +Security compliance and audit tools
+        """
+
+        Examples: ubuntu release
+           | release |
+           | focal   |
+
+    @series.jammy
+    @uses.config.machine_type.lxd.container
+    @uses.config.contract_token_staging_expired
+    Scenario Outline: Simulate status with expired token in a ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `sed -i 's/contracts.can/contracts.staging.can/' /etc/ubuntu-advantage/uaclient.conf` with sudo
+        And I verify that a preflight check for `contract_token_staging_expired` formatted as json exits 1
+        Then stdout is a json matching the `ua_status` schema
+        And stdout matches regexp:
+        """
+        \"result\": \"failure\"
+        """
+        And stdout matches regexp:
+        """
+        \"message\": \"Contract .* expired on .*\"
+        """
+        When I verify that a preflight check for `contract_token_staging_expired` formatted as yaml exits 1
+        Then stdout is a yaml matching the `ua_status` schema
+        Then stdout matches regexp:
+        """
+        errors:
+        - message: Contract .* expired on .*
+        """
+        When I verify that a preflight check for `contract_token_staging_expired` without the all flag exits 1
+        Then stdout matches regexp:
+        """
+        This token is not valid.
+        Contract \".*\" expired on .*
+
+        SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +yes       +yes          +Extended Security Maintenance for Applications
+        esm-infra       +yes       +yes       +yes          +Extended Security Maintenance for Infrastructure
+        livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        """
+
+        Examples: ubuntu release
+           | release |
+           | jammy   |

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -122,7 +122,6 @@ def status(
     cfg: config.UAConfig,
     *,
     simulate_with_token: Optional[str] = None,
-    show_beta: bool = False,
     show_all: bool = False
 ):
     """
@@ -132,13 +131,10 @@ def status(
         status, ret = ua_status.simulate_status(
             cfg=cfg,
             token=simulate_with_token,
-            show_beta=show_beta,
             show_all=show_all,
         )
     else:
-        status = ua_status.status(
-            cfg=cfg, show_beta=show_beta, show_all=show_all
-        )
+        status = ua_status.status(cfg=cfg, show_all=show_all)
         ret = 0
 
     return status, ret

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -122,17 +122,23 @@ def status(
     cfg: config.UAConfig,
     *,
     simulate_with_token: Optional[str] = None,
-    show_beta: bool = False
+    show_beta: bool = False,
+    show_all: bool = False
 ):
     """
     Construct the current Pro status dictionary.
     """
     if simulate_with_token:
         status, ret = ua_status.simulate_status(
-            cfg=cfg, token=simulate_with_token, show_beta=show_beta
+            cfg=cfg,
+            token=simulate_with_token,
+            show_beta=show_beta,
+            show_all=show_all,
         )
     else:
-        status = ua_status.status(cfg=cfg, show_beta=show_beta)
+        status = ua_status.status(
+            cfg=cfg, show_beta=show_beta, show_all=show_all
+        )
         ret = 0
 
     return status, ret

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1550,7 +1550,6 @@ def get_parser(cfg: config.UAConfig):
 def action_status(args, *, cfg):
     if not cfg:
         cfg = config.UAConfig()
-    show_beta = args.all if args else False
     show_all = args.all if args else False
     token = args.simulate_with_token if args else None
     active_value = ua_status.UserFacingConfigStatus.ACTIVE.value
@@ -1568,7 +1567,7 @@ def action_status(args, *, cfg):
                 logging.warning(err_msg)
                 event.warning(err_msg)
     status, ret = actions.status(
-        cfg, simulate_with_token=token, show_beta=show_beta, show_all=show_all
+        cfg, simulate_with_token=token, show_all=show_all
     )
     config_active = bool(status["execution_status"] == active_value)
 
@@ -1579,7 +1578,6 @@ def action_status(args, *, cfg):
             status, ret = actions.status(
                 cfg,
                 simulate_with_token=token,
-                show_beta=show_beta,
                 show_all=show_all,
             )
         event.info("")

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1551,6 +1551,7 @@ def action_status(args, *, cfg):
     if not cfg:
         cfg = config.UAConfig()
     show_beta = args.all if args else False
+    show_all = args.all if args else False
     token = args.simulate_with_token if args else None
     active_value = ua_status.UserFacingConfigStatus.ACTIVE.value
     if cfg.is_attached:
@@ -1567,7 +1568,7 @@ def action_status(args, *, cfg):
                 logging.warning(err_msg)
                 event.warning(err_msg)
     status, ret = actions.status(
-        cfg, simulate_with_token=token, show_beta=show_beta
+        cfg, simulate_with_token=token, show_beta=show_beta, show_all=show_all
     )
     config_active = bool(status["execution_status"] == active_value)
 
@@ -1576,7 +1577,10 @@ def action_status(args, *, cfg):
             event.info(".", end="")
             time.sleep(1)
             status, ret = actions.status(
-                cfg, simulate_with_token=token, show_beta=show_beta
+                cfg,
+                simulate_with_token=token,
+                show_beta=show_beta,
+                show_all=show_all,
             )
         event.info("")
 

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -47,16 +47,12 @@ def format_machine_readable_output(status: Dict[str, Any]) -> Dict[str, Any]:
         for name, value in sorted(get_pro_environment().items())
     ]
 
-    if not status.get("simulated"):
-        available_services = [
-            service
-            for service in status.get("services", [])
-            if service.get("available", "yes") == "yes"
-        ]
-        status["services"] = available_services
-
     # We don't need the origin info in the json output
     status.pop("origin", "")
+
+    # In case there is an error during status and the services were
+    # not processed
+    status.setdefault("services", [])
 
     return status
 

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -119,7 +119,7 @@ def get_ua_info(cfg: UAConfig) -> Dict[str, Any]:
         "entitled_services": [],
     }  # type: Dict[str, Any]
 
-    status_dict = status(cfg=cfg, show_beta=True)
+    status_dict = status(cfg=cfg, show_all=True)
     if status_dict["attached"]:
         ua_info["attached"] = True
         for service in status_dict["services"]:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -258,13 +258,13 @@ def _unattached_status(cfg: UAConfig) -> Dict[str, Any]:
     return response
 
 
-def _handle_beta_resources(cfg, show_beta, response) -> Dict[str, Any]:
+def _handle_beta_resources(cfg, show_all, response) -> Dict[str, Any]:
     """Remove beta services from response dict if needed"""
     config_allow_beta = util.is_config_value_true(
         config=cfg.cfg, path_to_value="features.allow_beta"
     )
-    show_beta |= config_allow_beta
-    if show_beta:
+    show_all |= config_allow_beta
+    if show_all:
         return response
 
     new_response = copy.deepcopy(response)
@@ -333,9 +333,7 @@ def _get_config_status(cfg) -> Dict[str, Any]:
     }
 
 
-def status(
-    cfg: UAConfig, show_beta: bool = False, show_all: bool = False
-) -> Dict[str, Any]:
+def status(cfg: UAConfig, show_all: bool = False) -> Dict[str, Any]:
     """Return status as a dict, using a cache for non-root users
 
     When unattached, get available resources from the contract service
@@ -363,7 +361,7 @@ def status(
                 ),
             )
 
-    response = _handle_beta_resources(cfg, show_beta or show_all, response)
+    response = _handle_beta_resources(cfg, show_all, response)
 
     if not show_all:
         available_services = [
@@ -393,7 +391,7 @@ def _get_entitlement_information(
 
 
 def simulate_status(
-    cfg, token: str, show_beta: bool = False, show_all: bool = False
+    cfg, token: str, show_all: bool = False
 ) -> Tuple[Dict[str, Any], int]:
     """Get a status dictionary based on a token.
 
@@ -506,7 +504,7 @@ def simulate_status(
             response["contract"]["tech_support_level"] = supportLevel
 
     response.update(_get_config_status(cfg))
-    response = _handle_beta_resources(cfg, show_beta, response)
+    response = _handle_beta_resources(cfg, show_all, response)
 
     if not show_all:
         available_services = [

--- a/uaclient/tests/test_event_logger.py
+++ b/uaclient/tests/test_event_logger.py
@@ -121,6 +121,7 @@ class TestEventLogger:
                     {
                         "some_status_key": "some_status_information",
                         "a_list_of_things": ["first", "second", "third"],
+                        "services": [],
                     }
                 )
                 event.info(info_msg="test")

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -277,8 +277,8 @@ def realtime_desc(FakeConfig):
 @mock.patch("uaclient.files.NoticeFile.remove")
 @mock.patch("uaclient.system.should_reboot", return_value=False)
 class TestStatus:
-    def check_beta(self, cls, show_beta, uacfg=None, status=""):
-        if not show_beta:
+    def check_beta(self, cls, show_all, uacfg=None, status=""):
+        if not show_all:
             if status == "enabled":
                 return False
 
@@ -340,9 +340,7 @@ class TestStatus:
             "uaclient.status._get_config_status"
         ) as m_get_cfg_status:
             m_get_cfg_status.return_value = DEFAULT_CFG_STATUS
-            assert expected == status.status(
-                cfg=cfg, show_beta=False, show_all=show_all
-            )
+            assert expected == status.status(cfg=cfg, show_all=show_all)
 
             expected_calls = [
                 mock.call(
@@ -578,7 +576,6 @@ class TestStatus:
         assert expected_calls == m_remove_notice.call_args_list
 
     @pytest.mark.parametrize("show_all", (True, False))
-    @pytest.mark.parametrize("show_beta", (True, False))
     @pytest.mark.parametrize(
         "features_override", ((None), ({"allow_beta": False}))
     )
@@ -625,7 +622,6 @@ class TestStatus:
         all_resources_available,
         entitlements,
         features_override,
-        show_beta,
         show_all,
         FakeConfig,
     ):
@@ -716,7 +712,7 @@ class TestStatus:
                 continue
 
             if not show_all and self.check_beta(
-                cls, show_beta, cfg, expected_status
+                cls, show_all, cfg, expected_status
             ):
                 continue
 
@@ -738,9 +734,7 @@ class TestStatus:
             "uaclient.status._get_config_status"
         ) as m_get_cfg_status:
             m_get_cfg_status.return_value = DEFAULT_CFG_STATUS
-            assert expected == status.status(
-                cfg=cfg, show_beta=show_beta, show_all=show_all
-            )
+            assert expected == status.status(cfg=cfg, show_all=show_all)
 
         assert len(ENTITLEMENT_CLASSES) - 2 == m_repo_uf_status.call_count
         assert 1 == m_livepatch_uf_status.call_count


### PR DESCRIPTION
## Proposed Commit Message
status: don't show unavailable services by default

We are not only showing unavailable services if the user provides
the --all flag to status.

Fixes: #2156
Fixes: #2159


## Test Steps
Run the modified unit and integration tests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
