### PR TITLE
Warn about new versions (SC-552)

### DIFF
--- a/features/staging_commands.feature
+++ b/features/staging_commands.feature
@@ -33,19 +33,19 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro staging subscri
         When I run `mkdir -p /var/lib/ubuntu-advantage/messages` with sudo
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-no-packages-infra.tmpl` with the following
         """
-        esm-infra-no {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
+        esm-infra-no {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}\n
         """
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-infra.tmpl` with the following
         """
-        esm-infra {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}
+        esm-infra {ESM_INFRA_PKG_COUNT}:{ESM_INFRA_PACKAGES}\n
         """
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-apps.tmpl` with the following
         """
-        esm-apps {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}
+        esm-apps {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}\n
         """
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-no-packages-apps.tmpl` with the following
         """
-        esm-apps-no {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}
+        esm-apps-no {ESM_APPS_PKG_COUNT}:{ESM_APPS_PACKAGES}\n
         """
         When I run `/usr/lib/ubuntu-advantage/apt-esm-hook process-templates` with sudo
         When I run `cat /var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-apps` with sudo
@@ -60,15 +60,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro staging subscri
         """
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-infra.tmpl` with the following
         """
-        esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        esm-infra {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}\n
         """
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-no-packages-infra.tmpl` with the following
         """
-        esm-infra-no {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}
+        esm-infra-no {ESM_INFRA_PKG_COUNT} {ESM_INFRA_PACKAGES}\n
         """
         When I create the file `/var/lib/ubuntu-advantage/messages/apt-pre-invoke-packages-apps.tmpl` with the following
         """
-        esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}
+        esm-apps {ESM_APPS_PKG_COUNT} {ESM_APPS_PACKAGES}\n
         """
         When I run `apt upgrade --dry-run` with sudo
         Then stdout matches regexp:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -559,7 +559,7 @@ def when_i_create_file_with_content(context, file_path):
     text = context.text.replace('"', '\\"')
     if "<ci-proxy-ip>" in text and "proxy" in context.instances:
         text = text.replace("<ci-proxy-ip>", context.instances["proxy"].ip)
-    cmd = "printf '{}\n' > {}".format(text, file_path)
+    cmd = "printf '{}' > {}".format(text, file_path)
     cmd = 'sh -c "{}"'.format(cmd)
     when_i_run_command(context, cmd, "with sudo")
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -259,6 +259,16 @@ Feature: Command behaviour when unattached
         to get the latest version with new features and bug fixes.
         """
         When I run `pro api u.pro.version.v1` as non-root
+        Then stdout matches regexp
+        """
+        \"code\": \"new-version-available\"
+        """
+        When I verify that running `pro api u.pro.version.inexistent` `as non-root` exits `1`
+        Then stdout matches regexp
+        """
+        \"code\": \"new-version-available\"
+        """
+        When I run `pro api u.pro.version.v1` as non-root
         Then I will see the following on stderr
         """
         """

--- a/uaclient/api/api.py
+++ b/uaclient/api/api.py
@@ -11,7 +11,9 @@ from uaclient.messages import (
     API_MISSING_ARG,
     API_NO_ARG_FOR_ENDPOINT,
     API_UNKNOWN_ARG,
+    WARN_NEW_VERSION_AVAILABLE,
 )
+from uaclient.version import check_for_new_version
 
 VALID_ENDPOINTS = [
     "u.pro.version.v1",
@@ -103,6 +105,18 @@ def call_api(
             result = endpoint.fn(cfg)
         except Exception as e:
             return error_out(e)
+
+    new_version = check_for_new_version()
+    if new_version:
+        option_warnings.append(
+            ErrorWarningObject(
+                title=WARN_NEW_VERSION_AVAILABLE.format(
+                    version=new_version
+                ).msg,
+                code=WARN_NEW_VERSION_AVAILABLE.name,
+                meta={},
+            )
+        )
 
     return APIResponse(
         _schema_version=endpoint.version,

--- a/uaclient/api/errors.py
+++ b/uaclient/api/errors.py
@@ -2,7 +2,9 @@ from typing import Dict, Optional
 
 from uaclient.api.data_types import APIResponse, ErrorWarningObject
 from uaclient.exceptions import UserFacingError
+from uaclient.messages import WARN_NEW_VERSION_AVAILABLE
 from uaclient.util import get_pro_environment
+from uaclient.version import check_for_new_version
 
 
 def error_out(exception: Exception) -> APIResponse:
@@ -19,6 +21,20 @@ def error_out(exception: Exception) -> APIResponse:
             code="generic-" + exception.__class__.__name__,
             meta={},
         )
+
+    warnings = []
+    new_version = check_for_new_version()
+    if new_version:
+        warnings.append(
+            ErrorWarningObject(
+                title=WARN_NEW_VERSION_AVAILABLE.format(
+                    version=new_version
+                ).msg,
+                code=WARN_NEW_VERSION_AVAILABLE.name,
+                meta={},
+            )
+        )
+
     return APIResponse(
         _schema_version="v1",
         result="failure",
@@ -31,6 +47,7 @@ def error_out(exception: Exception) -> APIResponse:
             }
         },
         errors=[error],
+        warnings=warnings,
     )
 
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -570,3 +570,14 @@ def setup_unauthenticated_repo(
         apt_origin,
         "never",
     )
+
+
+def compare_versions(version1: str, version2: str, relation: str) -> bool:
+    """Return True comparing version1 to version2 with the given relation."""
+    try:
+        system.subp(
+            ["dpkg", "--compare-versions", version1, relation, version2]
+        )
+        return True
+    except exceptions.ProcessExecutionError:
+        return False

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -30,6 +30,9 @@ APT_METHOD_HTTPS_FILE = "/usr/lib/apt/methods/https"
 CA_CERTIFICATES_FILE = "/usr/sbin/update-ca-certificates"
 APT_PROXY_CONF_FILE = "/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy"
 
+APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
+APT_LISTS_PATH = "/var/lib/apt/lists"
+
 # Since we generally have a person at the command line prompt. Don't loop
 # for 5 minutes like charmhelpers because we expect the human to notice and
 # resolve to apt conflict or try again.
@@ -581,3 +584,12 @@ def compare_versions(version1: str, version2: str, relation: str) -> bool:
         return True
     except exceptions.ProcessExecutionError:
         return False
+
+
+def get_apt_cache_time() -> Optional[float]:
+    cache_time = None
+    if os.path.exists(APT_UPDATE_SUCCESS_STAMP_PATH):
+        cache_time = os.stat(APT_UPDATE_SUCCESS_STAMP_PATH).st_mtime
+    elif os.path.exists(APT_LISTS_PATH):
+        cache_time = os.stat(APT_LISTS_PATH).st_mtime
+    return cache_time

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -182,12 +182,22 @@ def run_apt_command(
 
 
 @lru_cache(maxsize=None)
-def run_apt_cache_policy_command(
+def get_apt_cache_policy(
     error_msg: Optional[str] = None,
     env: Optional[Dict[str, str]] = {},
 ) -> str:
     return run_apt_command(
         cmd=["apt-cache", "policy"], error_msg=error_msg, env=env
+    )
+
+
+def get_apt_cache_policy_for_package(
+    package: str,
+    error_msg: Optional[str] = None,
+    env: Optional[Dict[str, str]] = {},
+) -> str:
+    return run_apt_command(
+        cmd=["apt-cache", "policy", package], error_msg=error_msg, env=env
     )
 
 
@@ -207,7 +217,7 @@ def run_apt_update_command(env: Optional[Dict[str, str]] = {}) -> str:
         # Whenever we run an apt-get update command, we must invalidate
         # the existing apt-cache policy cache. Otherwise, we could provide
         # users with incorrect values.
-        run_apt_cache_policy_command.cache_clear()
+        get_apt_cache_policy.cache_clear()
 
     return out
 

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -30,6 +30,20 @@ def _subp():
         yield original
 
 
+@pytest.yield_fixture(scope="session", autouse=True)
+def _warn_about_new_version():
+    """
+    A fixture that mocks cli._warn_about_new_version for all tests.
+    If a test needs the actual _warn_about_new_version, this fixture yields it,
+    so just add an argument to the test named "_warn_about_new_version".
+    """
+    from uaclient.cli import _warn_about_new_version
+
+    original = _warn_about_new_version
+    with mock.patch("uaclient.cli._warn_about_new_version"):
+        yield original
+
+
 @pytest.fixture
 def caplog_text(request):
     """

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -6,12 +6,14 @@ any of our dependencies installed.
 """
 
 UAC_ETC_PATH = "/etc/ubuntu-advantage/"
+UAC_TMP_PATH = "/tmp/ubuntu-advantage/"
 DEFAULT_DATA_DIR = "/var/lib/ubuntu-advantage"
 MACHINE_TOKEN_FILE = "machine-token.json"
 PRIVATE_SUBDIR = "/private"
 DEFAULT_PRIVATE_MACHINE_TOKEN_PATH = (
     DEFAULT_DATA_DIR + PRIVATE_SUBDIR + "/" + MACHINE_TOKEN_FILE
 )
+CANDIDATE_CACHE_PATH = UAC_TMP_PATH + "candidate-version"
 DEFAULT_CONFIG_FILE = UAC_ETC_PATH + "uaclient.conf"
 DEFAULT_HELP_FILE = UAC_ETC_PATH + "help_data.yaml"
 DEFAULT_UPGRADE_CONTRACT_FLAG_FILE = UAC_ETC_PATH + "request-update-contract"

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -115,7 +115,7 @@ class RepoEntitlement(base.UAEntitlement):
                 messages.NO_APT_URL_FOR_SERVICE.format(title=self.title),
             )
         protocol, repo_path = repo_url.split("://")
-        policy = apt.run_apt_cache_policy_command(
+        policy = apt.get_apt_cache_policy(
             error_msg=messages.APT_POLICY_FAILED.msg
         )
         match = re.search(

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -118,7 +118,7 @@ class TestCommonCriteriaEntitlementEnable:
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch("uaclient.system.should_reboot")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.apt.run_apt_cache_policy_command")
+    @mock.patch("uaclient.apt.get_apt_cache_policy")
     @mock.patch("uaclient.system.get_platform_info")
     @mock.patch("uaclient.contract.apply_contract_overrides")
     def test_enable_configures_apt_sources_and_auth_files(

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -36,7 +36,7 @@ class TestCISEntitlementCanEnable:
 
 
 class TestCISEntitlementEnable:
-    @mock.patch("uaclient.apt.run_apt_cache_policy_command")
+    @mock.patch("uaclient.apt.get_apt_cache_policy")
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch("uaclient.system.should_reboot")
     @mock.patch("uaclient.system.subp")

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1029,9 +1029,7 @@ class TestFIPSEntitlementApplicationStatus:
     def test_fips_does_not_show_enabled_when_fips_updates_is(
         self, _m_should_reboot, entitlement
     ):
-        with mock.patch(
-            "uaclient.apt.run_apt_cache_policy_command"
-        ) as m_apt_policy:
+        with mock.patch("uaclient.apt.get_apt_cache_policy") as m_apt_policy:
             m_apt_policy.return_value = (
                 "1001 http://FIPS-UPDATES/ubuntu"
                 " xenial-updates/main amd64 Packages\n"

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1036,7 +1036,7 @@ class TestApplicationStatus:
             (500, "https://esm.ubuntu.com/ubuntu", True),
         ),
     )
-    @mock.patch(M_PATH + "apt.run_apt_cache_policy_command")
+    @mock.patch(M_PATH + "apt.get_apt_cache_policy")
     def test_enabled_status_by_apt_policy(
         self, m_run_apt_policy, pin, policy_url, enabled, entitlement_factory
     ):

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -27,6 +27,7 @@ class FormattedNamedMessage(NamedMessage):
 class TxtColor:
     OKGREEN = "\033[92m"
     DISABLEGREY = "\033[37m"
+    INFOBLUE = "\033[94m"
     FAIL = "\033[91m"
     BOLD = "\033[1m"
     ENDC = "\033[0m"
@@ -34,6 +35,7 @@ class TxtColor:
 
 OKGREEN_CHECK = TxtColor.OKGREEN + "✔" + TxtColor.ENDC
 FAIL_X = TxtColor.FAIL + "✘" + TxtColor.ENDC
+BLUE_INFO = TxtColor.INFOBLUE + "[info]" + TxtColor.ENDC
 
 ERROR_INVALID_CONFIG_VALUE = """\
 Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. \

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -933,3 +933,10 @@ LSCPU_ARCH_PARSE_ERROR = NamedMessage(
     name="lscpu-arch-parse-error",
     msg="Failed to parse architecture from output of lscpu",
 )
+
+WARN_NEW_VERSION_AVAILABLE = FormattedNamedMessage(
+    name="new-version-available",
+    msg="A new version of the client is available: {version}. \
+Please upgrade to the latest version to get the new features \
+and bug fixes.",
+)

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -515,7 +515,9 @@ def merge_usn_released_binary_package_versions(
                     else:
                         prev_version = usn_src_pkg[bin_pkg]["version"]
                         current_version = binary_pkg_md["version"]
-                        if not version_cmp_le(current_version, prev_version):
+                        if not apt.compare_versions(
+                            current_version, prev_version, "le"
+                        ):
                             # binary_version is greater than prev_version
                             usn_src_pkg[bin_pkg] = binary_pkg_md
     return usn_pkg_versions
@@ -664,7 +666,9 @@ def get_affected_packages_from_cves(cves, installed_packages):
                 affected_pkgs[pkg_name] = pkg_status
             else:
                 current_ver = affected_pkgs[pkg_name].fixed_version
-                if not version_cmp_le(current_ver, pkg_status.fixed_version):
+                if not apt.compare_versions(
+                    current_ver, pkg_status.fixed_version, "le"
+                ):
                     affected_pkgs[pkg_name] = pkg_status
 
     return affected_pkgs
@@ -1019,7 +1023,7 @@ def prompt_for_affected_packages(
                         )
                     fixed_pkg = usn_released_src[binary_pkg]
                     fixed_version = fixed_pkg["version"]  # type: ignore
-                    if not version_cmp_le(fixed_version, version):
+                    if not apt.compare_versions(fixed_version, version, "le"):
                         binary_pocket_pkgs[pkg_status.pocket_source].append(
                             binary_pkg
                         )
@@ -1336,12 +1340,3 @@ def upgrade_packages_and_attach(
         )
 
     return True
-
-
-def version_cmp_le(version1: str, version2: str) -> bool:
-    """Return True when version1 is less than or equal to version2."""
-    try:
-        system.subp(["dpkg", "--compare-versions", version1, "le", version2])
-        return True
-    except exceptions.ProcessExecutionError:
-        return False

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -27,6 +27,7 @@ from uaclient.apt import (
     compare_versions,
     find_apt_list_files,
     get_apt_cache_policy,
+    get_apt_cache_time,
     get_installed_packages,
     is_installed,
     remove_apt_list_files,
@@ -1076,3 +1077,15 @@ class TestCompareVersion:
         """compare_versions returns True when the comparison is accurate."""
         with mock.patch("uaclient.system._subp", side_effect=_subp):
             assert expected_result is compare_versions(ver1, ver2, relation)
+
+
+class TestAptCacheTime:
+    @pytest.mark.parametrize(
+        "file_exists,expected", ((True, 1.23), (False, None))
+    )
+    @mock.patch("os.stat")
+    @mock.patch("os.path.exists")
+    def test_get_apt_cache_time(self, m_exists, m_stat, file_exists, expected):
+        m_stat.return_value.st_mtime = 1.23
+        m_exists.return_value = file_exists
+        assert expected == get_apt_cache_time()

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -24,12 +24,12 @@ from uaclient.apt import (
     assert_valid_apt_credentials,
     clean_apt_files,
     find_apt_list_files,
+    get_apt_cache_policy,
     get_installed_packages,
     is_installed,
     remove_apt_list_files,
     remove_auth_apt_repo,
     remove_repo_from_apt_auth_file,
-    run_apt_cache_policy_command,
     run_apt_update_command,
     setup_apt_proxy,
 )
@@ -929,15 +929,15 @@ class TestRunAptCommand:
             ("policy2", ""),
         ]
 
-        assert "policy1" == run_apt_cache_policy_command()
+        assert "policy1" == get_apt_cache_policy()
         # Confirming that caching is happening
-        assert "policy1" == run_apt_cache_policy_command()
+        assert "policy1" == get_apt_cache_policy()
 
         run_apt_update_command()
 
         # Confirm cache was cleared
-        assert "policy2" == run_apt_cache_policy_command()
-        run_apt_cache_policy_command.cache_clear()
+        assert "policy2" == get_apt_cache_policy()
+        get_apt_cache_policy.cache_clear()
 
     @mock.patch("uaclient.apt.system.subp")
     def test_failed_run_update_command_clean_apt_cache_policy_cache(
@@ -949,16 +949,16 @@ class TestRunAptCommand:
             ("policy2", ""),
         ]
 
-        assert "policy1" == run_apt_cache_policy_command()
+        assert "policy1" == get_apt_cache_policy()
         # Confirming that caching is happening
-        assert "policy1" == run_apt_cache_policy_command()
+        assert "policy1" == get_apt_cache_policy()
 
         with pytest.raises(exceptions.UserFacingError):
             run_apt_update_command()
 
         # Confirm cache was cleared
-        assert "policy2" == run_apt_cache_policy_command()
-        run_apt_cache_policy_command.cache_clear()
+        assert "policy2" == get_apt_cache_policy()
+        get_apt_cache_policy.cache_clear()
 
 
 class TestAptProxyConfig:

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -53,7 +53,6 @@ from uaclient.security import (
     prompt_for_affected_packages,
     query_installed_source_pkg_versions,
     upgrade_packages_and_attach,
-    version_cmp_le,
 )
 from uaclient.status import colorize_commands
 
@@ -244,23 +243,6 @@ class TestGetCVEAffectedPackageStatus:
             assert expected_status == package_status.response
         else:
             assert expected_status == affected_packages
-
-
-class TestVersionCmpLe:
-    @pytest.mark.parametrize(
-        "ver1,ver2,is_lessorequal",
-        (
-            ("1.0", "2.0", True),
-            ("2.0", "2.0", True),
-            ("2.1~18.04.1", "2.1", True),
-            ("2.1", "2.1~18.04.1", False),
-            ("2.1", "2.0", False),
-        ),
-    )
-    def test_version_cmp_le(self, ver1, ver2, is_lessorequal, _subp):
-        """version_cmp_le returns True when ver1 less than or equal to ver2."""
-        with mock.patch("uaclient.system._subp", side_effect=_subp):
-            assert is_lessorequal is version_cmp_le(ver1, ver2)
 
 
 class TestCVE:

--- a/uaclient/tests/test_version.py
+++ b/uaclient/tests/test_version.py
@@ -1,11 +1,16 @@
 import os.path
 
 import mock
+import pytest
 
-from uaclient.version import get_version
+from uaclient.version import (
+    check_for_new_version,
+    get_last_known_candidate,
+    get_version,
+)
 
 
-@mock.patch("uaclient.system.subp")
+@mock.patch("uaclient.version.subp")
 class TestGetVersion:
     @mock.patch("uaclient.version.os.path.exists", return_value=True)
     def test_get_version_returns_packaged_version(self, m_exists, m_subp):
@@ -30,3 +35,66 @@ class TestGetVersion:
         top_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         top_dir_git = os.path.join(top_dir, ".git")
         assert [mock.call(top_dir_git)] == m_exists.call_args_list
+
+
+class TestGetLastKnownCandidate:
+    @mock.patch("builtins.open", mock.mock_open(read_data="1.2.3"))
+    @mock.patch("os.stat")
+    @mock.patch("os.path.exists", return_value=True)
+    @mock.patch("uaclient.version.get_apt_cache_time", return_value=2)
+    def test_get_known_candidate_from_cache(
+        self, _m_apt_cache_time, _m_exists, m_stat
+    ):
+        m_stat.return_value.st_mtime = 1
+        assert "1.2.3" == get_last_known_candidate()
+
+    @mock.patch("builtins.open")
+    @mock.patch("os.stat")
+    @mock.patch("os.path.exists", return_value=True)
+    @mock.patch("uaclient.version.get_apt_cache_time", return_value=2)
+    def test_cant_open_cache_file(
+        self, _m_apt_cache_time, _m_exists, m_stat, m_open
+    ):
+        m_stat.return_value.st_mtime = 1
+        m_open.side_effect = OSError()
+        assert None is get_last_known_candidate()
+
+    @mock.patch("uaclient.version.get_apt_cache_policy_for_package")
+    @mock.patch("os.path.exists", return_value=False)
+    def test_create_cache_before_returning(self, _m_exists, m_policy):
+        m_policy.return_value = """
+            Installed: 1.1.2
+            Candidate: 1.2.3
+            Version table:
+        """
+        with mock.patch("builtins.open", mock.mock_open()) as m_open:
+            get_last_known_candidate()
+            assert m_open.return_value.write.call_args_list == [
+                mock.call("1.2.3")
+            ]
+
+    @mock.patch("builtins.open")
+    @mock.patch("uaclient.version.get_apt_cache_policy_for_package")
+    @mock.patch("os.path.exists", return_value=False)
+    def test_problem_updating_file(self, _m_exists, m_policy, m_open):
+        m_policy.return_value = """
+            Installed: 1.1.2
+            Candidate: 1.2.3
+            Version table:
+        """
+        m_open.side_effect = OSError()
+        assert None is get_last_known_candidate()
+
+
+class TestCheckForNewVersion:
+    @pytest.mark.parametrize("compare_return", (True, False))
+    @mock.patch("uaclient.version.compare_versions")
+    @mock.patch("uaclient.version.get_last_known_candidate")
+    def test_check_for_new_version(
+        self, m_candidate, m_compare, compare_return
+    ):
+        m_compare.return_value = compare_return
+        if compare_return:
+            assert m_candidate.return_value == check_for_new_version()
+        else:
+            assert None is check_for_new_version()

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -5,14 +5,26 @@ These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
 import os.path
+import re
+from math import inf
+from typing import Optional
 
-from uaclient import exceptions, system
+from uaclient.apt import (
+    compare_versions,
+    get_apt_cache_policy_for_package,
+    get_apt_cache_time,
+)
+from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_TMP_PATH
+from uaclient.exceptions import ProcessExecutionError
+from uaclient.system import subp
 
 __VERSION__ = "28.0"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
+CANDIDATE_REGEX = r"Candidate: (?P<candidate>.*?)\n"
 
-def get_version():
+
+def get_version() -> str:
     """Return the packaged version as a string
 
     Prefer the binary PACKAGED_VESION set by debian/rules to DEB_VERSION.
@@ -29,8 +41,44 @@ def get_version():
     if os.path.exists(os.path.join(topdir, ".git")):
         cmd = ["git", "describe", "--abbrev=8", "--match=[0-9]*", "--long"]
         try:
-            out, _ = system.subp(cmd)
+            out, _ = subp(cmd)
             return out.strip()
-        except exceptions.ProcessExecutionError:
+        except ProcessExecutionError:
             pass
     return __VERSION__
+
+
+def get_last_known_candidate() -> Optional[str]:
+    # If we can't determine when the cache was updated for the last time,
+    # We always assume it was as recent as possible - thus `inf`.
+    last_apt_cache_update = get_apt_cache_time() or inf
+    if (
+        not os.path.exists(CANDIDATE_CACHE_PATH)
+        or os.stat(CANDIDATE_CACHE_PATH).st_mtime < last_apt_cache_update
+    ):
+        try:
+            policy = get_apt_cache_policy_for_package("ubuntu-advantage-tools")
+            match = re.search(CANDIDATE_REGEX, policy)
+            if match:
+                candidate_version = match.group("candidate")
+                os.makedirs(UAC_TMP_PATH, exist_ok=True)
+                with open(CANDIDATE_CACHE_PATH, "w") as f:
+                    f.write(candidate_version)
+                os.chmod(CANDIDATE_CACHE_PATH, 0o777)
+        except Exception:
+            pass
+
+    try:
+        with open(CANDIDATE_CACHE_PATH, "r") as f:
+            return f.read().strip()
+    except Exception:
+        pass
+
+    return None
+
+
+def check_for_new_version() -> Optional[str]:
+    candidate = get_last_known_candidate()
+    if candidate and compare_versions(candidate, get_version(), "gt"):
+        return candidate
+    return None


### PR DESCRIPTION
Warn users about a new version of the client being available.
If executed from the CLI, print a warning to stderr.
If it's an API call, include a warning in the JSON.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
