### PR TITLE
chore: change Impish to Kinetic in tests

### DIFF
--- a/dev-docs/howtoguides/testing.md
+++ b/dev-docs/howtoguides/testing.md
@@ -67,8 +67,8 @@ tox -e behave-lxd-20.04 features/unattached_commands.feature:55
 As can be seen, this will run behave tests only for release 20.04 (Focal Fossa). We are currently
 supporting 5 distinct releases:
 
+* 21.10 (Kinetic Kudu)
 * 22.04 (Jammy Jellyfish)
-* 21.10 (Impish Indri)
 * 20.04 (Focal Fossa)
 * 18.04 (Bionic Beaver)
 * 16.04 (Xenial Xerus)

--- a/docs/source/references/support_matrix.md
+++ b/docs/source/references/support_matrix.md
@@ -14,6 +14,8 @@ Below is a list of platforms and releases ubuntu-advantage-tools supports
 | Focal          | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Active SRU of all features |
 | Groovy         | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Last release 27.1          |
 | Hirsute        | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Last release 27.5          |
-| Impish         | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Active SRU of all features |
+| Impish         | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Last release 27.9          |
+| Jammy          | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Active SRU of all features |
+| Kinetic        | amd64, arm64, armhf, ppc64el, riscv64, s390x       | Active SRU of all features |
 
 Note: ppc64el will not have all APT messaging due to insufficient golang support

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -30,8 +30,8 @@ Feature: Pro is expected version
             | xenial  |
             | bionic  |
             | focal   |
-            | impish  |
             | jammy   |
+            | kinetic |
 
     @series.all
     @uses.config.check_version
@@ -54,5 +54,5 @@ Feature: Pro is expected version
             | xenial  |
             | bionic  |
             | focal   |
-            | impish  |
-            | jammy  |
+            | jammy   |
+            | kinetic |

--- a/features/api.feature
+++ b/features/api.feature
@@ -20,8 +20,8 @@ Feature: Client behaviour for the API endpoints
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -48,5 +48,5 @@ Feature: Client behaviour for the API endpoints
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -27,8 +27,8 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | xenial  |
            | bionic  |
            | focal   |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -54,5 +54,5 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | xenial  |
            | bionic  |
            | focal   |
-           | impish  |
            | jammy   |
+           | kinetic |

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -2,7 +2,7 @@
 Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         subscription using a valid token
 
-    @series.impish
+    @series.kinetic
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached command in a non-lts ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -22,7 +22,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
 
         Examples: ubuntu release
             | release |
-            | impish  |
+            | kinetic |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -55,9 +55,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
-
+           | kinetic |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -81,8 +80,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -316,8 +315,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -338,8 +337,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -406,8 +405,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.xenial
     @series.bionic
@@ -526,7 +525,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         When I run `pro help esm-infra --format json` with sudo
         Then I will see the following on stdout:
         """
-        {"name": "esm-infra", "entitled": "yes", "status": "enabled", "help": "Extended Security Maintenance for Infrastructure provides access\nto a private ppa which includes available high and critical CVE fixes\nfor Ubuntu LTS packages in the Ubuntu Main repository between the end\nof the standard Ubuntu LTS security maintenance and its end of life.\nIt is enabled by default with Ubuntu Pro. You can find out more about\nthe service at https://ubuntu.com/security/esm\n"}
+        {"name": "esm-infra", "entitled": "yes", "status": "<infra-status>", "help": "Extended Security Maintenance for Infrastructure provides access\nto a private ppa which includes available high and critical CVE fixes\nfor Ubuntu LTS packages in the Ubuntu Main repository between the end\nof the standard Ubuntu LTS security maintenance and its end of life.\nIt is enabled by default with Ubuntu Pro. You can find out more about\nthe service at https://ubuntu.com/security/esm\n"}
         """
         And I verify that running `pro help invalid-service` `with sudo` exits `1`
         And I will see the following on stderr:
@@ -609,7 +608,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | release | infra-status |
            | bionic  | enabled      |
            | xenial  | enabled      |
-           | impish  | n/a          |
+           | kinetic | n/a          |
 
     @series.jammy
     @series.focal
@@ -844,8 +843,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | bionic  |
            | focal   |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -29,7 +29,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | bionic  |
 
     @series.focal
-    @series.impish
+    @series.jammy
+    @series.kinetic
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -48,8 +49,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Examples: ubuntu release
             | release | version    | full_name        |
             | focal   | 20.04 LTS  | Focal Fossa      |
-            | impish  | 21.10      | Impish Indri     |
-            | jammy   | 22.04      | Jammy Jellyfish  |
+            | jammy   | 22.04 LTS  | Jammy Jellyfish  |
+            | kinetic | 22.10      | Kinetic Kudu     |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -314,8 +315,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -16,5 +16,5 @@ Feature: Attached status
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -46,8 +46,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
           | xenial  |
           | bionic  |
           | focal   |
-          | impish  |
           | jammy   |
+          | kinetic |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -14,8 +14,8 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | release |
             | bionic  |
             | focal   |
-            | impish  |
             | jammy   |
+            | kinetic |
 
     @series.lts
     @uses.config.contract_token
@@ -207,7 +207,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | focal   |
             | jammy   |
 
-    @series.impish
+    @series.kinetic
     @uses.config.contract_token
     @uses.config.machine_type.gcp.generic
     Scenario Outline: daemon does not start on gcp generic non lts
@@ -228,7 +228,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         """
         Examples: version
             | release |
-            | impish  |
+            | kinetic |
 
     @series.all
     @uses.config.contract_token
@@ -262,8 +262,8 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | xenial  |
             | bionic  |
             | focal   |
-            | impish  |
             | jammy   |
+            | kinetic |
 
     @series.lts
     @uses.config.machine_type.aws.pro

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -17,8 +17,8 @@ Feature: Ua fix command behaviour
            | xenial  |
            | bionic  |
            | focal   |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.focal
     @uses.config.machine_type.lxd.container

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -12,8 +12,8 @@ Feature: Pro Install and Uninstall related tests
            | xenial  |
            | bionic  |
            | focal   |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.lts
     @uses.config.contract_token

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -52,9 +52,7 @@ Feature: Upgrade between releases when uaclient is attached
         | xenial  | bionic       | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
         | bionic  | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
         | bionic  | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
-        | focal   | impish       | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
         | focal   | jammy        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         | true           |
-        | impish  | jammy        | lts    |                 | esm-infra | disabled        | esm-apps | enabled         | true           |
         | jammy   | kinetic      | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
 
     @slow

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -39,7 +39,5 @@ Feature: Upgrade between releases when uaclient is unattached
         | release | next_release | prompt | devel_release   | service_status |
         | xenial  | bionic       | lts    |                 | enabled        |
         | bionic  | focal        | lts    |                 | enabled        |
-        | focal   | impish       | normal |                 | n/a            |
         | focal   | jammy        | lts    | --devel-release | enabled        |
-        | impish  | jammy        | lts    |                 | enabled       |
         | jammy   | kinetic      | normal | --devel-release | n/a            |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -27,8 +27,8 @@ Feature: Command behaviour when unattached
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.xenial
     @uses.config.machine_type.lxd.container
@@ -101,8 +101,8 @@ Feature: Command behaviour when unattached
            | focal   | refresh |
            | xenial  | detach  |
            | xenial  | refresh |
-           | impish  | detach  |
-           | impish  | refresh |
+           | kinetic | detach  |
+           | kinetic | refresh |
            | jammy   | detach  |
            | jammy   | refresh |
 
@@ -117,7 +117,7 @@ Feature: Command behaviour when unattached
             esm-infra
 
             Available:
-            <infra-status>
+            <infra-available>
 
             Help:
             Extended Security Maintenance for Infrastructure provides access
@@ -130,7 +130,7 @@ Feature: Command behaviour when unattached
         When I run `pro help esm-infra --format json` with sudo
         Then I will see the following on stdout:
             """
-            {"name": "esm-infra", "available": "yes", "help": "Extended Security Maintenance for Infrastructure provides access\nto a private ppa which includes available high and critical CVE fixes\nfor Ubuntu LTS packages in the Ubuntu Main repository between the end\nof the standard Ubuntu LTS security maintenance and its end of life.\nIt is enabled by default with Ubuntu Pro. You can find out more about\nthe service at https://ubuntu.com/security/esm\n"}
+            {"name": "esm-infra", "available": "<infra-available>", "help": "Extended Security Maintenance for Infrastructure provides access\nto a private ppa which includes available high and critical CVE fixes\nfor Ubuntu LTS packages in the Ubuntu Main repository between the end\nof the standard Ubuntu LTS security maintenance and its end of life.\nIt is enabled by default with Ubuntu Pro. You can find out more about\nthe service at https://ubuntu.com/security/esm\n"}
             """
         When I verify that running `pro help invalid-service` `with sudo` exits `1`
         Then I will see the following on stderr:
@@ -139,12 +139,12 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ubuntu release
-           | release  | infra-status |
-           | bionic   | yes          |
-           | focal    | yes          |
-           | xenial   | yes          |
-           | impish   | no           |
-           | jammy    | yes           |
+           | release  | infra-available |
+           | bionic   | yes             |
+           | focal    | yes             |
+           | xenial   | yes             |
+           | kinetic  | no              |
+           | jammy    | yes             |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -214,7 +214,7 @@ Feature: Command behaviour when unattached
           | bionic  | disable  |
           | focal   | enable   |
           | focal   | disable  |
-          | impish  | enable   |
-          | impish  | disable  |
+          | kinetic | enable   |
+          | kinetic | disable  |
           | jammy   | enable   |
           | jammy   | disable  |

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -37,8 +37,8 @@ Feature: Unattached status
            | bionic  |
            | focal   |
            | xenial  |
-           | impish  |
            | jammy   |
+           | kinetic |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -151,8 +151,8 @@ Feature: Unattached status
            | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
            | bionic  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
            | focal   | yes      | no     |     | yes           | yes  | yes       | no  | yes       | usg | no              |
-           | impish  | no       | no     | cis | no            | no   | no        | no  | no        |     | no              |
            | jammy   | yes      | no     |     | no            | no   | yes       | no  | yes       | usg | yes             |
+           | kinetic | no       | no     | cis | no            | no   | no        | no  | no        |     | no              |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -220,8 +220,8 @@ Feature: Unattached status
            | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
            | bionic  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     | no              |
            | focal   | yes      | no     |     | yes           | yes  | yes       | no  | yes       | usg | no              |
-           | impish  | no       | no     | cis | no            | no   | no        | no  | no        |     | no              |
            | jammy   | yes      | no     |     | no            | no   | yes       | no  | yes       | usg | yes             |
+           | kinetic | no       | no     | cis | no            | no   | no        | no  | no        |     | no              |
 
 
     @series.all
@@ -271,5 +271,5 @@ Feature: Unattached status
            | xenial  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     |
            | bionic  | yes      | yes    | cis | yes           | yes  | yes       | yes | yes       |     |
            | focal   | yes      | no     |     | yes           | yes  | yes       | no  | yes       | usg |
-           | impish  | no       | no     | cis | no            | no   | no        | no  | no        |     |
            | jammy   | yes      | no     |     | no            | no   | yes       | no  | yes       | usg |
+           | kinetic | no       | no     | cis | no            | no   | no        | no  | no        |     |

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -34,20 +34,21 @@ version_to_codename = {
     "16.04": "xenial",
     "18.04": "bionic",
     "20.04": "focal",
-    "21.10": "impish",
     "22.04": "jammy",
+    "22.10": "kinetic",
 }
 
+# We consider the past release for LTSs to be the last LTS,
+# because we don't have any services available on non-LTS.
+# This makes it safer for us to try to process contract deltas.
+# For example, we had "jammy": "focal" even when Impish was
+# still supported.
 current_codename_to_past_codename = {
     "xenial": "trusty",
     "bionic": "xenial",
     "focal": "bionic",
-    "impish": "focal",
-    # We are considering the past release for Jammy to be Focal
-    # because we don't have any services available on Impish.
-    # Therefore, it is safer for us to try to process contract deltas
-    # using Focal
     "jammy": "focal",
+    "kinetic": "jammy",
 }
 
 

--- a/tools/create-lp-release-branches.sh
+++ b/tools/create-lp-release-branches.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
-DRY_RUN_USAGE="usage: env DEVEL_RELEASE=kinetic RELEASES=\"xenial bionic focal impish jammy\" UA_VERSION=27.3 SRU_BUG=1942929 LP_USER=username bash tools/create-lp-release-branches.sh"
-DO_IT_USAGE="usage: env DO_IT=1 DEVEL_RELEASE=kinetic RELEASES=\"xenial bionic focal impish jammy\" UA_VERSION=27.3 SRU_BUG=1942929 LP_USER=username bash tools/create-lp-release-branches.sh"
+DRY_RUN_USAGE="usage: env DEVEL_RELEASE=kinetic RELEASES=\"xenial bionic focal jammy\" UA_VERSION=27.3 SRU_BUG=1942929 LP_USER=username bash tools/create-lp-release-branches.sh"
+DO_IT_USAGE="usage: env DO_IT=1 DEVEL_RELEASE=kinetic RELEASES=\"xenial bionic focal jammy\" UA_VERSION=27.3 SRU_BUG=1942929 LP_USER=username bash tools/create-lp-release-branches.sh"
 
 if [ -z "$DEVEL_RELEASE" ]; then
   echo "please set DEVEL_RELEASE"
@@ -53,7 +53,6 @@ do
       xenial) version=${UA_VERSION}~16.04.1;;
       bionic) version=${UA_VERSION}~18.04.1;;
       focal) version=${UA_VERSION}~20.04.1;;
-      impish) version=${UA_VERSION}~21.10.1;;
       jammy) version=${UA_VERSION}~22.04.1;;
       kinetic) version=${UA_VERSION}~22.10.1;;
   esac

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -12,8 +12,8 @@ SERIES_TO_VERSION = {
     "xenial": "16.04",
     "bionic": "18.04",
     "focal": "20.04",
-    "impish": "21.10",
     "jammy": "22.04",
+    "kinetic": "22.10",
 }
 
 TOKEN_TO_ENVVAR = {
@@ -23,18 +23,19 @@ TOKEN_TO_ENVVAR = {
 }
 
 PLATFORM_SERIES_TESTS = {
-    "azuregeneric": ["xenial", "bionic", "focal"],
-    "azurepro": ["xenial", "bionic", "focal"],
+    "azuregeneric": ["xenial", "bionic", "focal", "jammy"],
+    "azurepro": ["xenial", "bionic", "focal", "jammy"],
     "azurepro-fips": ["xenial", "bionic", "focal"],
-    "awsgeneric": ["xenial", "bionic", "focal"],
-    "awspro": ["xenial", "bionic", "focal"],
+    "awsgeneric": ["xenial", "bionic", "focal", "jammy"],
+    "awspro": ["xenial", "bionic", "focal", "jammy"],
     "awspro-fips": ["xenial", "bionic", "focal"],
     "docker": ["focal"],
-    "gcpgeneric": ["xenial", "bionic", "focal", "impish", "jammy"],
-    "gcppro": ["xenial", "bionic", "focal"],
-    "lxd": ["xenial", "bionic", "focal", "impish", "jammy"],
-    "vm": ["xenial", "bionic", "focal"],
-    "upgrade": ["xenial", "bionic", "focal", "impish"],
+    "gcpgeneric": ["xenial", "bionic", "focal", "jammy", "kinetic"],
+    "gcppro": ["xenial", "bionic", "focal", "jammy"],
+    "gcppro-fips": ["bionic", "focal"],
+    "lxd": ["xenial", "bionic", "focal", "jammy", "kinetic"],
+    "vm": ["xenial", "bionic", "focal", "jammy"],
+    "upgrade": ["xenial", "bionic", "focal", "jammy"],
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,8 +67,8 @@ commands =
     behave-lxd-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-lxd-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
     behave-lxd-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-21.10: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.impish,series.all" --tags="~upgrade"
     behave-lxd-22.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-22.10: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.kinetic,series.all" --tags="~upgrade"
 
     behave-vm-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.xenial,series.all,series.lts" --tags="~upgrade"
     behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
@@ -78,7 +78,6 @@ commands =
     behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
     behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" --tags="series.focal,series.all"
-    behave-upgrade-21.10: behave -v {posargs} --tags="upgrade" --tags="series.impish,series.all"
     behave-upgrade-22.04: behave -v {posargs} --tags="upgrade" --tags="series.jammy,series.all"
 
     behave-docker-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.focal" features/docker.feature
@@ -114,8 +113,8 @@ commands =
     behave-gcpgeneric-16.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-gcpgeneric-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
     behave-gcpgeneric-20.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-21.10: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.impish,series.all" --tags="~upgrade"
     behave-gcpgeneric-22.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-gcpgeneric-22.10: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.kinetic,series.all" --tags="~upgrade"
 
     behave-gcppro-16.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
     behave-gcppro-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -274,7 +274,7 @@ class TestUAAutoAttachGCPInstance:
             ({"series": "xenial"}, True),
             ({"series": "bionic"}, True),
             ({"series": "focal"}, True),
-            ({"series": "impish"}, False),
+            ({"series": "non_lts"}, False),
             ({"series": "jammy"}, True),
         ),
     )


### PR DESCRIPTION
We won't release to Impish anymore, and we will for Kinetic for a while.
This is changing Impish to Kinetic in tests and docs.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
