### PR TITLE
auto-attach: better error for invalid Pro image (SC-1211)

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -659,3 +659,21 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | bionic  |
            | focal   |
            | jammy   |
+
+    @series.lts
+    @uses.config.machine_type.aws.generic
+    Scenario Outline: Unregistered Pro machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I verify that running `pro auto-attach` `with sudo` exits `1`
+        Then stderr matches regexp:
+        """
+        Error on Pro Image:
+        missing instance information
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | jammy   |

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -90,12 +90,20 @@ class UAContractClient(serviceclient.UAServiceClient):
 
         @return: Dict of the JSON response containing the contract-token.
         """
-        response, _headers = self.request_url(
-            API_V1_AUTO_ATTACH_CLOUD_TOKEN.format(
-                cloud_type=instance.cloud_type
-            ),
-            data=instance.identity_doc,
-        )
+        try:
+            response, _headers = self.request_url(
+                API_V1_AUTO_ATTACH_CLOUD_TOKEN.format(
+                    cloud_type=instance.cloud_type
+                ),
+                data=instance.identity_doc,
+            )
+        except exceptions.ContractAPIError as e:
+            msg = e.api_error.get("message", "")
+            if msg:
+                logging.debug(msg)
+                raise exceptions.InvalidProImage(error_msg=msg)
+            raise e
+
         self.cfg.write_cache("contract-token", response)
         return response
 
@@ -502,12 +510,8 @@ def _create_attach_forbidden_message(
     e: exceptions.ContractAPIError,
 ) -> messages.NamedMessage:
     msg = messages.ATTACH_EXPIRED_TOKEN
-    if (
-        hasattr(e, "api_errors")
-        and len(e.api_errors) > 0
-        and "info" in e.api_errors[0]
-    ):
-        info = e.api_errors[0]["info"]
+    if hasattr(e, "api_error") and "info" in e.api_error:
+        info = e.api_error["info"]
         contract_id = info["contractId"]
         reason = info["reason"]
         reason_msg = None

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -293,6 +293,12 @@ class SecurityAPIMetadataError(UserFacingError):
         )
 
 
+class InvalidProImage(UserFacingError):
+    def __init__(self, error_msg: str):
+        msg = messages.INVALID_PRO_IMAGE.format(msg=error_msg)
+        super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
 class GCPProAccountError(UserFacingError):
     """An exception raised when GCP Pro service account is not enabled"""
 
@@ -373,40 +379,35 @@ class ProcessExecutionError(IOError):
 class ContractAPIError(UrlError):
     def __init__(self, e, error_response):
         super().__init__(e, e.code, e.headers, e.url)
-        if "error_list" in error_response:
-            self.api_errors = error_response["error_list"]
-        else:
-            self.api_errors = [error_response]
-        for api_error in self.api_errors:
-            api_error["code"] = api_error.get("title", api_error.get("code"))
+
+        if error_response is None:
+            error_response = {}
+
+        self.api_error = error_response
 
     def __contains__(self, error_code):
-        for api_error in self.api_errors:
-            if error_code == api_error.get("code"):
-                return True
-            if api_error.get("message", "").startswith(error_code):
-                return True
+        if error_code == self.api_error.get("code"):
+            return True
+        if self.api_error.get("message", "").startswith(error_code):
+            return True
+
         return False
 
     def __get__(self, error_code, default=None):
-        for api_error in self.api_errors:
-            if api_error["code"] == error_code:
-                return api_error["detail"]
+        if self.api_error.get("code") == error_code:
+            return self.api_error.get("message")
         return default
 
     def __str__(self):
         prefix = super().__str__()
-        details = []
-        for err in self.api_errors:
-            if not err.get("extra"):
-                details.append(err.get("detail", err.get("message", "")))
-            else:
-                for extra in err["extra"].values():
-                    if isinstance(extra, list):
-                        details.extend(extra)
-                    else:
-                        details.append(extra)
-        return prefix + ": [" + self.url + "]" + ", ".join(details)
+        return (
+            prefix
+            + ": ["
+            + self.url
+            + "]"
+            + ", "
+            + self.api_error.get("message", "")
+        )
 
 
 class SecurityAPIError(UrlError):

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -940,3 +940,7 @@ WARN_NEW_VERSION_AVAILABLE = FormattedNamedMessage(
 Please upgrade to the latest version to get the new features \
 and bug fixes.",
 )
+
+INVALID_PRO_IMAGE = FormattedNamedMessage(
+    name="invalid-pro-image", msg="Error on Pro Image:\n{msg}"
+)

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -154,9 +154,17 @@ class UAServiceClient(metaclass=abc.ABCMeta):
             return response["response"], response.get("headers", {})
         # Must be an error
         e = error.URLError(response["response"])
-        raise exceptions.UrlError(
+        url_exception = exceptions.UrlError(
             e,
             code=response["code"],
             headers=response.get("headers", {}),
             url=url,
         )
+
+        if response.get("type") == "contract":
+            raise exceptions.ContractAPIError(
+                url_exception,
+                error_response=response["response"],
+            )
+        else:
+            raise url_exception

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import socket
 
 import mock
@@ -30,6 +31,7 @@ from uaclient.messages import (
     ATTACH_FORBIDDEN_NEVER,
     ATTACH_FORBIDDEN_NOT_YET,
     ATTACH_INVALID_TOKEN,
+    INVALID_PRO_IMAGE,
     UNEXPECTED_ERROR,
 )
 from uaclient.status import UserFacingStatus
@@ -1257,3 +1259,38 @@ class TestApplyContractOverrides:
 
         apply_contract_overrides(orig_access)
         assert orig_access == expected
+
+
+@mock.patch("uaclient.serviceclient.UAServiceClient.request_url")
+class TestRequestAutoAttach:
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    def test_request_for_invalid_pro_image(
+        self, m_request_url, caplog_text, FakeConfig
+    ):
+        cfg = FakeConfig()
+        contract = UAContractClient(cfg)
+
+        error_response = {
+            "code": "contract not found",
+            "message": (
+                'missing product mapping for subscription "test", '
+                'plan "pro-image", product "pro-product", '
+                'publisher "canonical", sku "pro-sku"'
+            ),
+        }
+        m_request_url.side_effect = exceptions.ContractAPIError(
+            exceptions.UrlError("test", 400),
+            error_response=error_response,
+        )
+
+        with pytest.raises(exceptions.InvalidProImage) as exc_error:
+            contract.request_auto_attach_contract_token(
+                instance=mock.MagicMock()
+            )
+
+        expected_message = INVALID_PRO_IMAGE.format(
+            msg=error_response["message"]
+        )
+        assert expected_message.msg == exc_error.value.msg
+        assert error_response["message"] in caplog_text()
+        assert exc_error.value.msg_code == "invalid-pro-image"


### PR DESCRIPTION
## Proposed Commit Message
auto-attach: better error for invalid Pro image

We are now creating a specific exception for the situation
where the Pro image is is not registered on the contract side.
Additonally, we are also adding a specific logging for this
situation as well.

Fixes: #2180

## Test Steps
Verify if the existing tests are passing

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
