### PR TITLE
enable: fix apt auth line replacement

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1065,3 +1065,34 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         Stderr: E: Unable to locate package some-package-aws
         """
+
+    @series.xenial
+    @uses.config.contract_token
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: APT auth file is edited correctly on enable
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+        Then I will see the following on stdout:
+        """
+        2 /etc/apt/auth.conf.d/90ubuntu-advantage
+        """
+        # simulate a scenario where the line should get replaced
+        When I run `cp /etc/apt/auth.conf.d/90ubuntu-advantage /etc/apt/auth.conf.d/90ubuntu-advantage.backup` with sudo
+        When I run `pro disable esm-infra` with sudo
+        When I run `cp /etc/apt/auth.conf.d/90ubuntu-advantage.backup /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+        When I run `pro enable esm-infra` with sudo
+        When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+        Then I will see the following on stdout:
+        """
+        2 /etc/apt/auth.conf.d/90ubuntu-advantage
+        """
+        When I run `pro enable cis` with sudo
+        When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+        Then I will see the following on stdout:
+        """
+        3 /etc/apt/auth.conf.d/90ubuntu-advantage
+        """
+        Examples: ubuntu release
+           | release |
+           | xenial  |


### PR DESCRIPTION
The regex was failing to grab the entire url and would only match
"esm.ubuntu.com" for each line. Because every service is a more specific
path of esm.ubuntu.com and there was no check to prevent multiple
additions of a new line, then a new line would be inserted before every
existing line each time.

This changes to a simpler split-based approach to get each line's url
and compare. We also add an integration test to insure the behavior is
not inflating the size of the file.

LP: #1985863

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the new integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
