### PR TITLE
security-status: add CVEs fixed by Livepatch to the JSON output (SC-1233)

### DIFF
--- a/docs/source/explanations/how_to_interpret_the_security_status_command.md
+++ b/docs/source/explanations/how_to_interpret_the_security_status_command.md
@@ -36,6 +36,10 @@ packages:
   status: upgrade_available
   version: 1:1.2.8.dfsg-2ubuntu4.3+esm1
   download_size: 123456
+livepatch:
+  fixed_cves:
+    - Name: cve-2013-1798
+      Patched: true
 ```
 
 Let's understand what each key mean on the output of the `ua security-status` command:
@@ -101,3 +105,6 @@ Let's understand what each key mean on the output of the `ua security-status` co
       the service which provides the upgrade.
   * **`version`**: The update version.
   * **`download_size`**: The number of bytes that would be downloaded in order to install the update.
+
+* **`livepatch`**: Livepatch related information. Currently, the only information
+presented is **`fixed_cves`** - a list of CVEs that were fixed by Livepatches applied to the kernel.

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -1015,3 +1015,22 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | release | package   | service   |
            | xenial  | apport    | esm-infra |
            | bionic  | libkrb5-3 | esm-apps  |
+
+    @series.xenial
+    @uses.config.machine_type.lxd.vm
+    Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine
+        Given a `xenial` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `pro security-status --format json` as non-root
+        Then stdout is a json matching the `ua_security_status` schema
+        Then stdout matches regexp:
+        """
+        {"name": "cve-2013-1798", "patched": true}
+        """
+        When I run `pro security-status --format yaml` as non-root
+        Then stdout is a yaml matching the `ua_security_status` schema
+        And stdout matches regexp:
+        """
+          - name: cve-2013-1798
+            patched: true
+        """

--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -97,6 +97,25 @@
           }
         }
       }
+    },
+    "livepatch": {
+      "type": "object",
+      "properties": {
+        "fixed_cves": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "patched": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -524,7 +524,13 @@ def refresh_parser(parser):
 def action_security_status(args, *, cfg, **kwargs):
     # For now, --format is mandatory so no need to check for it here.
     if args.format == "json":
-        print(json.dumps(security_status.security_status(cfg)))
+        print(
+            json.dumps(
+                security_status.security_status(cfg),
+                sort_keys=True,
+                cls=util.DatetimeAwareJSONEncoder,
+            ),
+        )
     else:
         print(
             yaml.safe_dump(

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -10,6 +10,7 @@ from uaclient.cli import (
     main,
     security_status_parser,
 )
+from uaclient.util import DatetimeAwareJSONEncoder
 
 M_PATH = "uaclient.cli."
 
@@ -76,7 +77,11 @@ class TestActionSecurityStatus:
 
         if output_format == "json":
             assert m_dumps.call_args_list == [
-                mock.call(m_security_status.return_value)
+                mock.call(
+                    m_security_status.return_value,
+                    sort_keys=True,
+                    cls=DatetimeAwareJSONEncoder,
+                ),
             ]
             assert m_safe_dump.call_count == 0
         else:


### PR DESCRIPTION
Add a list with the CVEs fixed by livepatch to the output of `security-status`.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
