### PR TITLE
status: reduce calls to read machine token file when unattached SC1063

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -90,12 +90,15 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     @property
     def presentation_name(self) -> str:
         """The user-facing name shown for this entitlement"""
-        return (
-            self.cfg.machine_token_file.entitlements.get(self.name, {})
-            .get("entitlement", {})
-            .get("affordances", {})
-            .get("presentedAs", self.name)
-        )
+        if self.cfg.machine_token_file.is_present:
+            return (
+                self.cfg.machine_token_file.entitlements.get(self.name, {})
+                .get("entitlement", {})
+                .get("affordances", {})
+                .get("presentedAs", self.name)
+            )
+        else:
+            return self.name
 
     @property
     def help_info(self) -> str:

--- a/uaclient/files.py
+++ b/uaclient/files.py
@@ -43,6 +43,10 @@ class UAFile:
     def is_private(self) -> bool:
         return self._is_private
 
+    @property
+    def is_present(self):
+        return os.path.exists(self.path)
+
     def write(self, content: str):
         file_mode = (
             defaults.ROOT_READABLE_MODE
@@ -183,6 +187,13 @@ class MachineTokenFile:
         except Exception:
             pass
         return content  # type: ignore
+
+    @property
+    def is_present(self):
+        if self.is_root:
+            return self.public_file.is_present and self.private_file.is_present
+        else:
+            return self.public_file.is_present
 
     @property
     def machine_token(self):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->


status: reduce calls to read machine token file when unattached

We had almost 231 machine token access when running `pro status` as root. This PR reduces this to about 5.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
