### PR TITLE
tests: remove snapshot_strategy from the test script

### DIFF
--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -70,9 +70,6 @@ def build_commands(
                     envvar = TOKEN_TO_ENVVAR[t]
                     env[envvar] = credentials["token"].get(envvar)
 
-                # Until we don't get sbuild to run just once per run,
-                env["UACLIENT_BEHAVE_SNAPSHOT_STRATEGY"] = "1"
-
                 # Tox command itself
                 command = "tox -e behave-{}-{}".format(
                     p, series_version


### PR DESCRIPTION
No need to use it in local tests, as sbuild is being executed just once for sure.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
