### PR TITLE
security-status: remove module level logic

### DIFF
--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -221,8 +221,8 @@ class TestSecurityStatus:
             "example", installed_version, other_versions
         )
         with mock.patch(
-            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE",
-            ORIGIN_TO_SERVICE_MOCK,
+            M_PATH + "get_origin_information_to_service_map",
+            return_value=ORIGIN_TO_SERVICE_MOCK,
         ):
             assert expected_output == get_origin_for_package(package_mock)
 
@@ -248,8 +248,8 @@ class TestSecurityStatus:
     )
     def test_service_name(self, origins_input, expected_output):
         with mock.patch(
-            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE",
-            ORIGIN_TO_SERVICE_MOCK,
+            M_PATH + "get_origin_information_to_service_map",
+            return_value=ORIGIN_TO_SERVICE_MOCK,
         ):
             assert expected_output == get_service_name(origins_input)
 
@@ -299,8 +299,8 @@ class TestSecurityStatus:
             ),
         ]
         with mock.patch(
-            M_PATH + "ORIGIN_INFORMATION_TO_SERVICE",
-            ORIGIN_TO_SERVICE_MOCK,
+            M_PATH + "get_origin_information_to_service_map",
+            return_value=ORIGIN_TO_SERVICE_MOCK,
         ):
             filtered_versions = filter_security_updates(package_list)
             assert expected_return == filtered_versions


### PR DESCRIPTION
With the current bug being fixed in #2217 ua fails to run on a kernel that doesn't match the broken regex.
It fails so early that it isn't even able to log anything or print why it failed. It fails that early because of this use of `get_platform_info` that happens at module import time.

The fix is to just only make this function call when it is needed and cache the result, rather than compute it at module import time

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
