### PR TITLE
reboot-required: add api endpoint for reboot info (SC-1266)

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -721,40 +721,54 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         livepatch +yes +enabled
         """
-        When I run `pro api u.pro.security.status.reboot.v1` with sudo
+        When I run `pro api u.pro.security.status.reboot_required.v1` with sudo
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "no"}, "meta": {"environment_vars": \[\]}, "type": "RebootStatus"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "no"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I create the file `/var/run/reboot-required` with the following:
+        When I run `pro system reboot-required` as non-root
+        Then I will see the following on stdout:
         """
+        no
         """
-        And I run `pro api u.pro.security.status.reboot.v1` with sudo
+        When I run `apt-get install libc6 -y` with sudo
+        And I run `pro api u.pro.security.status.reboot_required.v1` as non-root
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes"}, "meta": {"environment_vars": \[\]}, "type": "RebootStatus"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I create the file `/var/run/reboot-required.pkgs` with the following:
+        When I run `pro system reboot-required` as non-root
+        Then I will see the following on stdout:
         """
-        linux-base
-        linux-image-5.4.0-1074
-        test
-        test123
+        yes
         """
-        And I run `pro api u.pro.security.status.reboot.v1` with sudo
+        When I reboot the machine
+        And I run `pro system reboot-required` as non-root
+        Then I will see the following on stdout:
+        """
+        no
+        """
+        When I run `apt-get install linux-image-generic -y` with sudo
+        And I run `pro api u.pro.security.status.reboot_required.v1` as non-root
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes"}, "meta": {"environment_vars": \[\]}, "type": "RebootStatus"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes-kernel-livepatches-applied"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I create the file `/var/run/reboot-required.pkgs` with the following:
+        When I run `pro system reboot-required` as non-root
+        Then I will see the following on stdout:
         """
-        linux-base
-        linux-image-5.4.0-1074
+        yes-kernel-livepatches-applied
         """
-        And I run `pro api u.pro.security.status.reboot.v1` with sudo
+        When I run `apt-get install dbus -y` with sudo
+        And I run `pro api u.pro.security.status.reboot_required.v1` with sudo
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes-kernel-livepatches-applied"}, "meta": {"environment_vars": \[\]}, "type": "RebootStatus"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        """
+        When I run `pro system reboot-required` as non-root
+        Then I will see the following on stdout:
+        """
+        yes
         """
 
         Examples: ubuntu release

--- a/features/schemas/ua_security_status.json
+++ b/features/schemas/ua_security_status.json
@@ -63,6 +63,9 @@
         },
         "num_standard_security_updates": {
           "type": "integer"
+        },
+        "reboot_required": {
+          "type": "string"
         }
       }
     },

--- a/uaclient/api/api.py
+++ b/uaclient/api/api.py
@@ -23,7 +23,7 @@ VALID_ENDPOINTS = [
     "u.pro.attach.auto.should_auto_attach.v1",
     "u.pro.attach.auto.full_auto_attach.v1",
     "u.security.package_manifest.v1",
-    "u.pro.security.status.reboot.v1",
+    "u.pro.security.status.reboot_required.v1",
 ]
 
 

--- a/uaclient/api/api.py
+++ b/uaclient/api/api.py
@@ -23,6 +23,7 @@ VALID_ENDPOINTS = [
     "u.pro.attach.auto.should_auto_attach.v1",
     "u.pro.attach.auto.full_auto_attach.v1",
     "u.security.package_manifest.v1",
+    "u.pro.security.status.reboot.v1",
 ]
 
 

--- a/uaclient/api/tests/test_api_u_pro_security_status_reboot_required_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_status_reboot_required_v1.py
@@ -1,10 +1,12 @@
 import mock
 import pytest
 
-from uaclient.api.u.pro.security.status.reboot.v1 import reboot_status
+from uaclient.api.u.pro.security.status.reboot_required.v1 import (
+    _reboot_required,
+)
 from uaclient.security_status import RebootStatus
 
-PATH = "uaclient.api.u.pro.security.status.reboot.v1."
+PATH = "uaclient.api.u.pro.security.status.reboot_required.v1."
 
 
 class TestRebootStatus:
@@ -21,5 +23,5 @@ class TestRebootStatus:
         m_get_reboot_status.return_value = reboot_state
         assert (
             reboot_state.value
-            == reboot_status(mock.MagicMock()).reboot_required
+            == _reboot_required(mock.MagicMock()).reboot_required
         )

--- a/uaclient/api/tests/test_api_u_pro_security_status_reboot_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_status_reboot_v1.py
@@ -1,0 +1,25 @@
+import mock
+import pytest
+
+from uaclient.api.u.pro.security.status.reboot.v1 import reboot_status
+from uaclient.security_status import RebootStatus
+
+PATH = "uaclient.api.u.pro.security.status.reboot.v1."
+
+
+class TestRebootStatus:
+    @pytest.mark.parametrize(
+        "reboot_state",
+        (
+            (RebootStatus.REBOOT_REQUIRED),
+            (RebootStatus.REBOOT_NOT_REQUIRED),
+            (RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED),
+        ),
+    )
+    @mock.patch(PATH + "get_reboot_status")
+    def test_reboot_status_api(self, m_get_reboot_status, reboot_state):
+        m_get_reboot_status.return_value = reboot_state
+        assert (
+            reboot_state.value
+            == reboot_status(mock.MagicMock()).reboot_required
+        )

--- a/uaclient/api/u/pro/security/status/reboot/v1.py
+++ b/uaclient/api/u/pro/security/status/reboot/v1.py
@@ -1,0 +1,30 @@
+from uaclient.api.api import APIEndpoint
+from uaclient.api.data_types import AdditionalInfo
+from uaclient.config import UAConfig
+from uaclient.data_types import DataObject, Field, StringDataValue
+from uaclient.security_status import get_reboot_status
+
+
+class RebootStatusResult(DataObject, AdditionalInfo):
+    fields = [
+        Field("reboot_required", StringDataValue),
+    ]
+
+    def __init__(
+        self,
+        reboot_required: str,
+    ):
+        self.reboot_required = reboot_required
+
+
+def reboot_status(cfg: UAConfig) -> RebootStatusResult:
+    status = get_reboot_status()
+    return RebootStatusResult(reboot_required=status.value)
+
+
+endpoint = APIEndpoint(
+    version="v1",
+    name="RebootStatus",
+    fn=reboot_status,
+    options_cls=None,
+)

--- a/uaclient/api/u/pro/security/status/reboot_required/v1.py
+++ b/uaclient/api/u/pro/security/status/reboot_required/v1.py
@@ -5,7 +5,7 @@ from uaclient.data_types import DataObject, Field, StringDataValue
 from uaclient.security_status import get_reboot_status
 
 
-class RebootStatusResult(DataObject, AdditionalInfo):
+class RebootRequiredResult(DataObject, AdditionalInfo):
     fields = [
         Field("reboot_required", StringDataValue),
     ]
@@ -17,14 +17,18 @@ class RebootStatusResult(DataObject, AdditionalInfo):
         self.reboot_required = reboot_required
 
 
-def reboot_status(cfg: UAConfig) -> RebootStatusResult:
+def reboot_required() -> RebootRequiredResult:
+    return _reboot_required(UAConfig())
+
+
+def _reboot_required(cfg: UAConfig) -> RebootRequiredResult:
     status = get_reboot_status()
-    return RebootStatusResult(reboot_required=status.value)
+    return RebootRequiredResult(reboot_required=status.value)
 
 
 endpoint = APIEndpoint(
     version="v1",
-    name="RebootStatus",
-    fn=reboot_status,
+    name="RebootRequired",
+    fn=_reboot_required,
     options_cls=None,
 )

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -33,6 +33,9 @@ from uaclient import (
 from uaclient import status as ua_status
 from uaclient import util, version
 from uaclient.api.api import call_api
+from uaclient.api.u.pro.security.status.reboot_required.v1 import (
+    _reboot_required,
+)
 from uaclient.apt import AptProxyScope, setup_apt_proxy
 from uaclient.data_types import AttachActionsConfigFile, IncorrectTypeError
 from uaclient.defaults import DEFAULT_LOG_FORMAT, PRINT_WRAP_WIDTH
@@ -738,6 +741,52 @@ def disable_parser(parser, cfg: config.UAConfig):
     return parser
 
 
+def system_parser(parser):
+    """Build or extend an arg parser for system subcommand."""
+    parser.usage = USAGE_TMPL.format(name=NAME, command="system <command>")
+    parser.description = (
+        "Output system related information related to Pro services"
+    )
+    parser.prog = "system"
+    parser._optionals.title = "Flags"
+    subparsers = parser.add_subparsers(
+        title="Available Commands", dest="command", metavar=""
+    )
+    parser_reboot_required = subparsers.add_parser(
+        "reboot-required", help="does the system need to be rebooted"
+    )
+    parser_reboot_required.set_defaults(action=action_system_reboot_required)
+    reboot_required_parser(parser_reboot_required)
+
+    return parser
+
+
+def reboot_required_parser(parser):
+    # This formatter_class ensures that our formatting below isn't lost
+    parser.usage = USAGE_TMPL.format(
+        name=NAME, command="system reboot-required"
+    )
+    parser.pro = "reboot-required"
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    parser.description = textwrap.dedent(
+        """\
+        Report the current reboot-required status for the machine.
+
+        This command will output one of the three following states
+        for the machine regarding reboot:
+
+        * no: The machine doesn't require a reboot
+        * yes: The machine requires a reboot
+        * yes-kernel-livepatches-applied: There are only kernel related
+          packages that require a reboot, but Livepatch has already provided
+          patches for the current running kernel. The machine still needs a
+          reboot, but you can assess if the reboot can be performed in the
+          nearest maintenance window.
+        """
+    )
+    return parser
+
+
 def status_parser(parser):
     """Build or extend an arg parser for status subcommand."""
     usage = USAGE_TMPL.format(name=NAME, command="status")
@@ -817,6 +866,19 @@ def status_parser(parser):
     return parser
 
 
+def _print_help_for_subcommand(
+    cfg: config.UAConfig, cmd_name: str, subcmd_name: str
+):
+    parser = get_parser(cfg=cfg)
+    subparser = parser._get_positional_actions()[0].choices[cmd_name]
+    valid_choices = subparser._get_positional_actions()[0].choices.keys()
+    if subcmd_name not in valid_choices:
+        parser._get_positional_actions()[0].choices[cmd_name].print_help()
+        raise exceptions.UserFacingError(
+            "\n<command> must be one of: {}".format(", ".join(valid_choices))
+        )
+
+
 def _perform_disable(entitlement, cfg, *, assume_yes, update_status=True):
     """Perform the disable action on a named entitlement.
 
@@ -854,14 +916,10 @@ def action_config(args, *, cfg, **kwargs):
 
     :return: 0 on success, 1 otherwise
     """
-    parser = get_parser(cfg=cfg)
-    subparser = parser._get_positional_actions()[0].choices["config"]
-    valid_choices = subparser._get_positional_actions()[0].choices.keys()
-    if args.command not in valid_choices:
-        parser._get_positional_actions()[0].choices["config"].print_help()
-        raise exceptions.UserFacingError(
-            "\n<command> must be one of: {}".format(", ".join(valid_choices))
-        )
+    _print_help_for_subcommand(
+        cfg, cmd_name="config", subcmd_name=args.command
+    )
+    return 0
 
 
 def action_config_show(args, *, cfg, **kwargs):
@@ -1536,6 +1594,12 @@ def get_parser(cfg: config.UAConfig):
     )
     parser_version.set_defaults(action=print_version)
 
+    parser_system = subparsers.add_parser(
+        "system", help="show system information related to Pro services"
+    )
+    parser_system.set_defaults(action=action_system)
+    system_parser(parser_system)
+
     return parser
 
 
@@ -1579,6 +1643,23 @@ def action_status(args, *, cfg):
     event.info(util.handle_unicode_characters(output))
     event.process_events()
     return ret
+
+
+def action_system(args, *, cfg, **kwargs):
+    """Perform the system action.
+
+    :return: 0 on success, 1 otherwise
+    """
+    _print_help_for_subcommand(
+        cfg, cmd_name="system", subcmd_name=args.command
+    )
+    return 0
+
+
+def action_system_reboot_required(args, *, cfg: config.UAConfig):
+    result = _reboot_required(cfg)
+    event.info(result.reboot_required)
+    return 0
 
 
 def print_version(_args=None, cfg=None):

--- a/uaclient/tests/test_cli_reboot_required.py
+++ b/uaclient/tests/test_cli_reboot_required.py
@@ -1,0 +1,37 @@
+import mock
+import pytest
+
+from uaclient.cli import main
+
+HELP_OUTPUT = """\
+usage: pro system reboot-required [flags]
+
+Report the current reboot-required status for the machine.
+
+This command will output one of the three following states
+for the machine regarding reboot:
+
+* no: The machine doesn't require a reboot
+* yes: The machine requires a reboot
+* yes-kernel-livepatches-applied: There are only kernel related
+  packages that require a reboot, but Livepatch has already provided
+  patches for the current running kernel. The machine still needs a
+  reboot, but you can assess if the reboot can be performed in the
+  nearest maintenance window.
+"""
+
+
+class TestActionRebootRequired:
+    def test_enable_help(self, capsys, FakeConfig):
+        with pytest.raises(SystemExit):
+            with mock.patch(
+                "sys.argv",
+                ["/usr/bin/ua", "system", "reboot-required", "--help"],
+            ):
+                with mock.patch(
+                    "uaclient.config.UAConfig",
+                    return_value=FakeConfig(),
+                ):
+                    main()
+        out, _err = capsys.readouterr()
+        assert HELP_OUTPUT in out


### PR DESCRIPTION
## Proposed Commit Message
reboot-required: add api endpoint for reboot info

Add endpoint to verify the reboot state of a machine taking into
consideration livepatch as well. We have also added this information
on the output of running security-status

## Test Steps
Run the new integration and unittests

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
