### PR TITLE
Bring changes from 27.10.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,12 @@ ubuntu-advantage-tools (28.0) UNRELEASED; urgency=medium
 
  -- Chad Smith <chad.smith@canonical.com>  Wed, 19 May 2021 16:35:25 -0600
 
+ubuntu-advantage-tools (27.10.1~22.10.1) kinetic; urgency=medium
+
+  * apt-hook: Fix missing import warning when compiling
+
+ -- Lucas Moura <lucas.moura@canonical.com>  Tue, 09 Aug 2022 14:03:14 -0300
+
 ubuntu-advantage-tools (27.10~22.10.1) kinetic; urgency=medium
 
   * d/control:

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,30 @@ ubuntu-advantage-tools (28.0) UNRELEASED; urgency=medium
 
  -- Chad Smith <chad.smith@canonical.com>  Wed, 19 May 2021 16:35:25 -0600
 
+ubuntu-advantage-tools (27.10~22.10.1) kinetic; urgency=medium
+
+  * d/control:
+    - Add ca-certificates dependency
+    - Drop golang dependencies
+  * d/rules:
+    - Only install APT hooks on LTS series
+  * New upstream release 27.10 (LP: #1980990)
+    - apt-hook: replace golang with cpp for json-hook
+    - cli
+      + properly sort services for detach/attach (GH: #1831)
+      + collect-logs include rotated log files
+      + display UA features directly on status
+    - daemon: do not try enabling daemon during auto-attach (LP: #1980865)
+    - fix:
+      + update ua portal url when asking for attach
+      + add --dry-run option
+    - gcp-pro: better error message for metadata endpoint error
+    - requests: Add default timeout for web requests
+    - timer: log when job start running
+    - security-status: include download size of package updates
+
+ -- Lucas Moura <lucas.moura@canonical.com>  Fri, 01 Jul 2022 11:51:13 -0300
+
 ubuntu-advantage-tools (27.9~22.10.1) kinetic; urgency=medium
 
   * d/rules

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,6 @@ Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
-         ca-certificates,
          python3-apt,
          python3-pkg-resources,
          ${extra:Depends}

--- a/features/docker.feature
+++ b/features/docker.feature
@@ -19,7 +19,9 @@ Feature: Build docker images with pro services
             apt-get update \
             && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
 
-            && dpkg -i /ua.deb \
+            && dpkg -i /ua.deb | true \
+
+            && apt-get install -f \
 
             && pro attach --attach-config /run/secrets/ua-attach-config \
 
@@ -75,4 +77,3 @@ Feature: Build docker images with pro services
            | focal   | xenial            | [ esm-infra ]  | curl              | esm                  |
            | focal   | bionic            | [ fips ]       | openssl           | fips                 |
            | focal   | focal             | [ esm-apps ]   | hello             | esm                  |
-

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -4,6 +4,15 @@ Feature: Ua fix command behaviour
     @uses.config.machine_type.lxd.container
     Scenario Outline: Useful SSL failure message when there aren't any ca-certs
         Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt remove ca-certificates -y` with sudo
+        When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
+        Then stderr matches regexp:
+            """
+            Failed to access URL: https://.*
+            Cannot verify certificate of server
+            Please install "ca-certificates" and try again.
+            """
+        When I run `apt install ca-certificates -y` with sudo
         When I run `mv /etc/ssl/certs /etc/ssl/wronglocation` with sudo
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then stderr matches regexp:

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1756,7 +1756,9 @@ def main_error_handler(func):
             sys.exit(1)
         except exceptions.UrlError as exc:
             if "CERTIFICATE_VERIFY_FAILED" in str(exc):
-                tmpl = messages.SSL_VERIFICATION_ERROR_OPENSSL_CONFIG
+                tmpl = messages.SSL_VERIFICATION_ERROR_CA_CERTIFICATES
+                if util.is_installed("ca-certificates"):
+                    tmpl = messages.SSL_VERIFICATION_ERROR_OPENSSL_CONFIG
                 msg = tmpl.format(url=exc.url)
                 event.error(error_msg=msg.msg, error_code=msg.name)
                 event.info(info_msg=msg.msg, file_type=sys.stderr)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -551,6 +551,14 @@ SNAPD_NOT_PROPERLY_INSTALLED = FormattedNamedMessage(
     ),
 )
 
+SSL_VERIFICATION_ERROR_CA_CERTIFICATES = FormattedNamedMessage(
+    "ssl-verification-error-ca-certificate",
+    """\
+Failed to access URL: {url}
+Cannot verify certificate of server
+Please install "ca-certificates" and try again.""",
+)
+
 SSL_VERIFICATION_ERROR_OPENSSL_CONFIG = FormattedNamedMessage(
     "ssl-verification-error-openssl-config",
     """\


### PR DESCRIPTION
This brings changes from the `27.10.1` release from the `release-27` branch. The extra commit with the latest changelog entry (which existed only in Launchpad) was uploaded directly to `release-27` and is cherry-picked here as well.