### PR TITLE
create public machine-token for attached machines

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -54,6 +54,9 @@ SYSTEMD_HELPER_ENABLED_WANTS_LINK="/var/lib/systemd/deb-systemd-helper-enabled/m
 REBOOT_CMD_MARKER_FILE="/var/lib/ubuntu-advantage/marker-reboot-cmds-required"
 OLD_LICENSE_CHECK_MARKER_FILE="/var/lib/ubuntu-advantage/marker-license-check"
 
+MACHINE_TOKEN_FILE="/var/lib/ubuntu-advantage/private/machine-token.json"
+PUBLIC_MACHINE_TOKEN_FILE="/var/lib/ubuntu-advantage/machine-token.json"
+
 
 # Rename apt config files for ua services removing ubuntu release names
 redact_ubuntu_release_from_ua_apt_filenames() {
@@ -368,6 +371,19 @@ remove_old_systemd_units() {
     fi
 }
 
+create_public_machine_token_file() {
+    # When we perform the write operation through
+    # MachineTokenFile we already write the public
+    # version of the machine-token file with all the
+    # sensitive data removed.
+    /usr/bin/python3 -c "
+from uaclient.files import MachineTokenFile
+machine_token_file = MachineTokenFile()
+content = machine_token_file.read()
+machine_token_file.write(content=content)
+"
+}
+
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -439,6 +455,13 @@ case "$1" in
       disable_new_timer_if_old_timer_already_disabled $PREVIOUS_PKG_VER
       remove_old_systemd_units $PREVIOUS_PKG_VER
       /usr/lib/ubuntu-advantage/cloud-id-shim.sh || true
+
+      # On old version of ubuntu-advantange-tools, we don't have a public
+      # machine_token.json file on attached machines. Since the non-root
+      # status now needs that file, we need to create it during the upgrade
+      if [ -f $MACHINE_TOKEN_FILE ] && [ ! -f $PUBLIC_MACHINE_TOKEN_FILE ]; then
+          create_public_machine_token_file
+      fi
       ;;
 esac
 

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -916,3 +916,29 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | jammy   |
+
+    @series.lts
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Run timer script to valid machine activity endpoint
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `rm /var/lib/ubuntu-advantage/machine-token.json` with sudo
+        And I run `ua status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE +AVAILABLE +DESCRIPTION
+        """
+        When I run `dpkg-reconfigure ubuntu-advantage-tools` with sudo
+        Then I verify that files exist matching `/var/lib/ubuntu-advantage/machine-token.json`
+        When I run `ua status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE +ENTITLED +STATUS +DESCRIPTION
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | jammy   |


### PR DESCRIPTION
## Proposed Commit Message
create public machine-token for attached machines

On already attached machines, we won't have the public machine-token file. We need that file for non-root status calls. Because of that, we are creating that file during postinst to guarantee the correct behavior of non-root status

## Test Steps
Run the new integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
