### PR TITLE
fix: use is_installed from s̶y̶s̶t̶e̶m̶ apt in cli.py

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -491,8 +491,9 @@ def is_installed(pkg: str) -> bool:
 
 
 def get_installed_packages() -> List[str]:
-    out, _ = system.subp(["dpkg-query", "-W", "--showformat=${Package}\\n"])
-    return out.splitlines()
+    out, _ = system.subp(["apt", "list", "--installed"])
+    package_list = out.splitlines()[1:]
+    return [entry.split("/")[0] for entry in package_list]
 
 
 def setup_apt_proxy(

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -18,6 +18,7 @@ import yaml
 
 from uaclient import (
     actions,
+    apt,
     config,
     contract,
     daemon,
@@ -1757,7 +1758,7 @@ def main_error_handler(func):
         except exceptions.UrlError as exc:
             if "CERTIFICATE_VERIFY_FAILED" in str(exc):
                 tmpl = messages.SSL_VERIFICATION_ERROR_CA_CERTIFICATES
-                if util.is_installed("ca-certificates"):
+                if apt.is_installed("ca-certificates"):
                     tmpl = messages.SSL_VERIFICATION_ERROR_OPENSSL_CONFIG
                 msg = tmpl.format(url=exc.url)
                 event.error(error_msg=msg.msg, error_code=msg.name)

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -166,7 +166,7 @@ class LivepatchEntitlement(UAEntitlement):
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
             )
-        elif "snapd" not in apt.get_installed_packages():
+        elif not snap.is_installed():
             raise exceptions.SnapdNotProperlyInstalledError(
                 snap_cmd=snap.SNAP_CMD, service=self.title
             )


### PR DESCRIPTION
Don't import it from util anymore
And list only installed packages in `get_installed_packages`

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
