### PR TITLE
chore: keep the maintainer name in the backport changelog entry

### DIFF
--- a/tools/create-lp-release-branches.sh
+++ b/tools/create-lp-release-branches.sh
@@ -56,7 +56,7 @@ do
       jammy) version=${UA_VERSION}~22.04.1;;
       kinetic) version=${UA_VERSION}~22.10.1;;
   esac
-  dch_cmd=(dch -v "${version}" -D "${release}" -b  "Backport new upstream release: (LP: #${SRU_BUG}) to $release")
+  dch_cmd=(dch -m -v "${version}" -D "${release}" -b  "Backport new upstream release: (LP: #${SRU_BUG}) to $release")
   if [ -z "$DO_IT" ]; then
     echo "${dch_cmd[@]}"
   else


### PR DESCRIPTION
For a system without the Deb niceties set, the `create-lp-release-branches.sh` script will rely on local data (username, machine name) to generate the Maintainer line (Name and <email>) for the backport entry in the changelog.

Yes I know, it's just a temporary entry...
But for consistency sake we can use the `-m` flag to `dch`, so the new entry has the same information as the previous one (which should be accurate for the release shepherd anyway)

## Test Steps
Run the script and check that the new backport entry has the same Maintainer entry as the previous one.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
 - [x] I have updated or added any script in tools accordingly