### PR TITLE
files: extract services-once-enabled from config (SC-1267)

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -92,9 +92,6 @@ class UAConfig:
         "marker-reboot-cmds": DataPath(
             "marker-reboot-cmds-required", False, False
         ),
-        "services-once-enabled": DataPath(
-            "services-once-enabled", False, True
-        ),
         "jobs-status": DataPath("jobs-status.json", False, True),
     }  # type: Dict[str, DataPath]
 

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -9,6 +9,10 @@ from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
 from uaclient.entitlements import repo
 from uaclient.entitlements.base import IncompatibleService
 from uaclient.entitlements.entitlement_status import ApplicationStatus
+from uaclient.files.state_files import (
+    ServicesOnceEnabledData,
+    services_once_enabled_file,
+)
 from uaclient.types import (  # noqa: F401
     MessagingOperations,
     MessagingOperationsDict,
@@ -441,30 +445,30 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     def static_affordances(self) -> Tuple[StaticAffordance, ...]:
         static_affordances = super().static_affordances
 
-        fips_update = FIPSUpdatesEntitlement(self.cfg)
+        fips_updates = FIPSUpdatesEntitlement(self.cfg)
         enabled_status = ApplicationStatus.ENABLED
-        is_fips_update_enabled = bool(
-            fips_update.application_status()[0] == enabled_status
+        is_fips_updates_enabled = bool(
+            fips_updates.application_status()[0] == enabled_status
         )
 
-        services_once_enabled = (
-            self.cfg.read_cache("services-once-enabled") or {}
-        )
-        fips_updates_once_enabled = services_once_enabled.get(
-            fips_update.name, False
+        services_once_enabled_obj = services_once_enabled_file.read()
+        fips_updates_once_enabled = (
+            services_once_enabled_obj.fips_updates
+            if services_once_enabled_obj
+            else False
         )
 
         return static_affordances + (
             (
                 messages.FIPS_ERROR_WHEN_FIPS_UPDATES_ENABLED.format(
-                    fips=self.title, fips_updates=fips_update.title
+                    fips=self.title, fips_updates=fips_updates.title
                 ),
-                lambda: is_fips_update_enabled,
+                lambda: is_fips_updates_enabled,
                 False,
             ),
             (
                 messages.FIPS_ERROR_WHEN_FIPS_UPDATES_ONCE_ENABLED.format(
-                    fips=self.title, fips_updates=fips_update.title
+                    fips=self.title, fips_updates=fips_updates.title
                 ),
                 lambda: fips_updates_once_enabled,
                 False,
@@ -577,14 +581,10 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
             self.cfg.notice_file.try_remove(
                 "", messages.FIPS_DISABLE_REBOOT_REQUIRED
             )
-            services_once_enabled = (
-                self.cfg.read_cache("services-once-enabled") or {}
-            )
-            services_once_enabled.update({self.name: True})
-            self.cfg.write_cache(
-                key="services-once-enabled", content=services_once_enabled
-            )
 
+            services_once_enabled_file.write(
+                ServicesOnceEnabledData(fips_updates=True)
+            )
             return True
 
         return False

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -99,7 +99,6 @@ def entitlement_factory(tmpdir, FakeConfig):
         assume_yes: Optional[bool] = None,
         suites: List[str] = None,
         additional_packages: List[str] = None,
-        services_once_enabled: Dict[str, bool] = None,
         cfg: Optional[config.UAConfig] = None,
         cfg_extension: Optional[Dict[str, Any]] = None
     ):
@@ -119,9 +118,6 @@ def entitlement_factory(tmpdir, FakeConfig):
                     additional_packages=additional_packages,
                 ),
             )
-
-        if services_once_enabled:
-            cfg.write_cache("services-once-enabled", services_once_enabled)
 
         args = {
             "allow_beta": allow_beta,

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -10,6 +10,7 @@ from functools import partial
 import mock
 import pytest
 
+import uaclient.entitlements.fips as fips
 from uaclient import apt, defaults, exceptions, messages, system, util
 from uaclient.clouds.identity import NoCloudTypeReason
 from uaclient.entitlements.entitlement_status import (
@@ -263,7 +264,10 @@ class TestFIPSEntitlementEnable:
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch(M_PATH + "get_cloud_type", return_value=("", None))
     def test_enable_configures_apt_sources_and_auth_files(
-        self, _m_get_cloud_type, m_setup_apt_proxy, entitlement
+        self,
+        _m_get_cloud_type,
+        m_setup_apt_proxy,
+        entitlement,
     ):
         """When entitled, configure apt repo auth token, pinning and url."""
         patched_packages = ["a", "b"]
@@ -300,6 +304,9 @@ class TestFIPSEntitlementEnable:
                 mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
             )
             stack.enter_context(mock.patch(M_REPOPATH + "os.path.exists"))
+            stack.enter_context(
+                mock.patch.object(fips, "services_once_enabled_file")
+            )
             # Note that this patch uses a PropertyMock and happens on the
             # entitlement's type because packages is a property
             m_packages = mock.PropertyMock(return_value=patched_packages)
@@ -449,7 +456,8 @@ class TestFIPSEntitlementEnable:
         entitlement,
     ):
         m_repo_enable.return_value = repo_enable_return_value
-        assert repo_enable_return_value is entitlement._perform_enable()
+        with mock.patch.object(fips, "services_once_enabled_file"):
+            assert repo_enable_return_value is entitlement._perform_enable()
         assert (
             expected_remove_notice_calls == m_remove_notice.call_args_list[:2]
         )
@@ -660,20 +668,25 @@ class TestFIPSEntitlementEnable:
         entitlement_factory,
     ):
         m_handle_message_op.return_value = True
-        fips_entitlement = entitlement_factory(
-            FIPSEntitlement, services_once_enabled={"fips-updates": True}
-        )
+        fake_dof = mock.MagicMock()
+        fake_ua_file = mock.MagicMock()
+        fake_ua_file.to_json.return_value = {"fips_updates": True}
+        fake_dof.read.return_value = fake_ua_file
+        fips_entitlement = entitlement_factory(FIPSEntitlement)
 
         with mock.patch.object(
             fips_entitlement, "_allow_fips_on_cloud_instance"
         ) as m_allow_fips_on_cloud:
             m_allow_fips_on_cloud.return_value = True
-            result, reason = fips_entitlement.enable()
-            assert not result
-            expected_msg = (
-                "Cannot enable FIPS because FIPS Updates was once enabled."
-            )
-            assert expected_msg.strip() == reason.message.msg.strip()
+            with mock.patch.object(
+                fips, "services_once_enabled_file", fake_dof
+            ):
+                result, reason = fips_entitlement.enable()
+                assert not result
+                expected_msg = (
+                    "Cannot enable FIPS because FIPS Updates was once enabled."
+                )
+                assert expected_msg.strip() == reason.message.msg.strip()
 
     @mock.patch("uaclient.system.get_platform_info")
     @mock.patch("uaclient.entitlements.fips.get_cloud_type")
@@ -1316,32 +1329,26 @@ class TestFIPSUpdatesEntitlementEnable:
         entitlement_factory,
     ):
         m_perform_enable.return_value = enable_ret
-        m_write_cache = mock.MagicMock()
-        m_read_cache = mock.MagicMock()
-        m_read_cache.return_value = {}
+        fake_file = mock.MagicMock()
+        fake_file.read.return_value = None
 
-        cfg = mock.MagicMock()
-        cfg.read_cache = m_read_cache
-        cfg.write_cache = m_write_cache
-        cfg.notice_file.try_remove = m_remove_notice
-
-        fips_updates_ent = entitlement_factory(FIPSUpdatesEntitlement, cfg=cfg)
-        assert fips_updates_ent._perform_enable() == enable_ret
+        with mock.patch.object(
+            fips, "services_once_enabled_file", fake_file
+        ) as m_services_once_enabled:
+            cfg = mock.MagicMock()
+            cfg.notice_file.try_remove = m_remove_notice
+            fips_updates_ent = entitlement_factory(
+                FIPSUpdatesEntitlement, cfg=cfg
+            )
+            assert fips_updates_ent._perform_enable() == enable_ret
 
         if enable_ret:
-            assert 1 == m_read_cache.call_count
-            assert 1 == m_write_cache.call_count
-            assert [
-                mock.call(
-                    key="services-once-enabled", content={"fips-updates": True}
-                )
-            ] == m_write_cache.call_args_list
+            assert 1 == m_services_once_enabled.write.call_count
             assert [
                 mock.call("", messages.FIPS_DISABLE_REBOOT_REQUIRED)
             ] == m_remove_notice.call_args_list
         else:
-            assert not m_read_cache.call_count
-            assert not m_write_cache.call_count
+            assert not m_services_once_enabled.write.call_count
 
 
 class TestFIPSUpdatesEntitlementCanEnable:

--- a/uaclient/files/__init__.py
+++ b/uaclient/files/__init__.py
@@ -1,0 +1,10 @@
+from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
+from uaclient.files.files import MachineTokenFile, NoticeFile, UAFile
+
+__all__ = [
+    "DataObjectFile",
+    "DataObjectFileFormat",
+    "MachineTokenFile",
+    "NoticeFile",
+    "UAFile",
+]

--- a/uaclient/files/data_types.py
+++ b/uaclient/files/data_types.py
@@ -1,0 +1,69 @@
+import json
+from enum import Enum
+from typing import Callable, Dict, Generic, Optional, Type, TypeVar
+
+import yaml
+
+from uaclient import exceptions
+from uaclient.data_types import DataObject
+from uaclient.files.files import UAFile
+
+
+class DataObjectFileFormat(Enum):
+    JSON = "json"
+    YAML = "yaml"
+
+
+DOFType = TypeVar("DOFType", bound=DataObject)
+
+
+class DataObjectFile(Generic[DOFType]):
+    def __init__(
+        self,
+        data_object_cls: Type[DOFType],
+        ua_file: UAFile,
+        file_format: DataObjectFileFormat = DataObjectFileFormat.JSON,
+        preprocess_data: Optional[Callable[[Dict], Dict]] = None,
+    ):
+        self.data_object_cls = data_object_cls
+        self.ua_file = ua_file
+        self.file_format = file_format
+        self.preprocess_data = preprocess_data
+
+    def read(self) -> Optional[DOFType]:
+        raw_data = self.ua_file.read()
+        if raw_data is None:
+            return None
+
+        parsed_data = None
+        if self.file_format == DataObjectFileFormat.JSON:
+            try:
+                parsed_data = json.loads(raw_data)
+            except json.JSONDecodeError:
+                raise exceptions.InvalidFileFormatError(
+                    self.ua_file.path, "json"
+                )
+        elif self.file_format == DataObjectFileFormat.YAML:
+            try:
+                parsed_data = yaml.safe_load(raw_data)
+            except yaml.parser.ParserError:
+                raise exceptions.InvalidFileFormatError(
+                    self.ua_file.path, "yaml"
+                )
+
+        if parsed_data is None:
+            return None
+
+        if self.preprocess_data:
+            parsed_data = self.preprocess_data(parsed_data)
+
+        return self.data_object_cls.from_dict(parsed_data)
+
+    def write(self, content: DOFType):
+        if self.file_format == DataObjectFileFormat.JSON:
+            str_content = content.to_json()
+        elif self.file_format == DataObjectFileFormat.YAML:
+            data = content.to_dict()
+            str_content = yaml.dump(data, default_flow_style=False)
+
+        self.ua_file.write(str_content)

--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -1,0 +1,364 @@
+import json
+import logging
+import os
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from uaclient import defaults, event_logger, exceptions, messages, system, util
+from uaclient.contract_data_types import PublicMachineTokenData
+
+event = event_logger.get_event_logger()
+LOG = logging.getLogger(__name__)
+
+
+class UAFile:
+    def __init__(
+        self,
+        name: str,
+        directory: str = defaults.DEFAULT_DATA_DIR,
+        private: bool = True,
+    ):
+        self._directory = directory
+        self._file_name = name
+        self._is_private = private
+        self._path = os.path.join(self._directory, self._file_name)
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @property
+    def is_private(self) -> bool:
+        return self._is_private
+
+    @property
+    def is_present(self):
+        return os.path.exists(self.path)
+
+    def write(self, content: str):
+        file_mode = (
+            defaults.ROOT_READABLE_MODE
+            if self.is_private
+            else defaults.WORLD_READABLE_MODE
+        )
+        if not os.path.exists(self._directory):
+            os.makedirs(self._directory)
+            if os.path.basename(self._directory) == defaults.PRIVATE_SUBDIR:
+                os.chmod(self._directory, 0o700)
+        system.write_file(self.path, content, file_mode)
+
+    def read(self) -> Optional[str]:
+        content = None
+        try:
+            content = system.load_file(self.path)
+        except FileNotFoundError:
+            LOG.debug("File does not exist: {}".format(self.path))
+        return content
+
+    def delete(self):
+        system.remove_file(self.path)
+
+
+class MachineTokenFile:
+    def __init__(
+        self,
+        directory: str = defaults.DEFAULT_DATA_DIR,
+        root_mode: bool = True,
+        machine_token_overlay_path: Optional[str] = None,
+    ):
+        file_name = defaults.MACHINE_TOKEN_FILE
+        self.is_root = root_mode
+        self.private_file = UAFile(
+            file_name, directory + defaults.PRIVATE_SUBDIR
+        )
+        self.public_file = UAFile(file_name, directory, False)
+        self.machine_token_overlay_path = machine_token_overlay_path
+        self._machine_token = None
+        self._entitlements = None
+        self._contract_expiry_datetime = None
+
+    def write(self, content: dict):
+        """Update the machine_token file for both pub/private files"""
+        if self.is_root:
+            content_str = json.dumps(
+                content, cls=util.DatetimeAwareJSONEncoder
+            )
+            self.private_file.write(content_str)
+            content = json.loads(content_str)  # taking care of datetime type
+            content = PublicMachineTokenData.from_dict(content).to_dict(False)
+            content_str = json.dumps(
+                content, cls=util.DatetimeAwareJSONEncoder
+            )
+            self.public_file.write(content_str)
+
+            self._machine_token = None
+            self._entitlements = None
+        else:
+            raise exceptions.NonRootUserError()
+
+    def delete(self):
+        """Delete both pub and private files"""
+        if self.is_root:
+            self.public_file.delete()
+            self.private_file.delete()
+
+            self._machine_token = None
+            self._entitlements = None
+        else:
+            raise exceptions.NonRootUserError()
+
+    def read(self) -> Optional[dict]:
+        if self.is_root:
+            file_handler = self.private_file
+        else:
+            file_handler = self.public_file
+        content = file_handler.read()
+        if not content:
+            return None
+        try:
+            content = json.loads(content, cls=util.DatetimeAwareJSONDecoder)
+        except Exception:
+            pass
+        return content  # type: ignore
+
+    @property
+    def is_present(self):
+        if self.is_root:
+            return self.public_file.is_present and self.private_file.is_present
+        else:
+            return self.public_file.is_present
+
+    @property
+    def machine_token(self):
+        """Return the machine-token if cached in the machine token response."""
+        if not self._machine_token:
+            content = self.read()
+            if content and self.machine_token_overlay_path:
+                machine_token_overlay = self.parse_machine_token_overlay(
+                    self.machine_token_overlay_path
+                )
+
+                if machine_token_overlay:
+                    util.depth_first_merge_overlay_dict(
+                        base_dict=content,
+                        overlay_dict=machine_token_overlay,
+                    )
+            self._machine_token = content
+        return self._machine_token
+
+    def parse_machine_token_overlay(self, machine_token_overlay_path):
+        if not os.path.exists(machine_token_overlay_path):
+            raise exceptions.UserFacingError(
+                messages.INVALID_PATH_FOR_MACHINE_TOKEN_OVERLAY.format(
+                    file_path=machine_token_overlay_path
+                )
+            )
+
+        try:
+            machine_token_overlay_content = system.load_file(
+                machine_token_overlay_path
+            )
+
+            return json.loads(
+                machine_token_overlay_content,
+                cls=util.DatetimeAwareJSONDecoder,
+            )
+        except ValueError as e:
+            raise exceptions.UserFacingError(
+                messages.ERROR_JSON_DECODING_IN_FILE.format(
+                    error=str(e), file_path=machine_token_overlay_path
+                )
+            )
+
+    @property
+    def account(self) -> Optional[dict]:
+        if bool(self.machine_token):
+            return self.machine_token["machineTokenInfo"]["accountInfo"]
+        return None
+
+    @property
+    def entitlements(self):
+        """Return configured entitlements keyed by entitlement named"""
+        if self._entitlements:
+            return self._entitlements
+        if not self.machine_token:
+            return {}
+        self._entitlements = self.get_entitlements_from_token(
+            self.machine_token
+        )
+        return self._entitlements
+
+    @staticmethod
+    def get_entitlements_from_token(machine_token: Dict):
+        """Return a dictionary of entitlements keyed by entitlement name.
+
+        Return an empty dict if no entitlements are present.
+        """
+        from uaclient.contract import apply_contract_overrides
+
+        if not machine_token:
+            return {}
+
+        entitlements = {}
+        contractInfo = machine_token.get("machineTokenInfo", {}).get(
+            "contractInfo"
+        )
+        if not contractInfo:
+            return {}
+
+        tokens_by_name = dict(
+            (e.get("type"), e.get("token"))
+            for e in machine_token.get("resourceTokens", [])
+        )
+        ent_by_name = dict(
+            (e.get("type"), e)
+            for e in contractInfo.get("resourceEntitlements", [])
+        )
+        for entitlement_name, ent_value in ent_by_name.items():
+            entitlement_cfg = {"entitlement": ent_value}
+            if entitlement_name in tokens_by_name:
+                entitlement_cfg["resourceToken"] = tokens_by_name[
+                    entitlement_name
+                ]
+            apply_contract_overrides(entitlement_cfg)
+            entitlements[entitlement_name] = entitlement_cfg
+        return entitlements
+
+    @property
+    def contract_expiry_datetime(self) -> datetime:
+        """Return a datetime of the attached contract expiration."""
+        if not self._contract_expiry_datetime:
+            self._contract_expiry_datetime = self.machine_token[
+                "machineTokenInfo"
+            ]["contractInfo"]["effectiveTo"]
+
+        return self._contract_expiry_datetime  # type: ignore
+
+    @property
+    def is_attached(self):
+        """Report whether this machine configuration is attached to UA."""
+        return bool(self.machine_token)  # machine_token is removed on detach
+
+    @property
+    def contract_remaining_days(self) -> int:
+        """Report num days until contract expiration based on effectiveTo
+
+        :return: A positive int representing the number of days the attached
+            contract remains in effect. Return a negative int for the number
+            of days beyond contract's effectiveTo date.
+        """
+        delta = self.contract_expiry_datetime.date() - datetime.utcnow().date()
+        return delta.days
+
+    @property
+    def activity_token(self) -> "Optional[str]":
+        if self.machine_token:
+            return self.machine_token.get("activityInfo", {}).get(
+                "activityToken"
+            )
+        return None
+
+    @property
+    def activity_id(self) -> "Optional[str]":
+        if self.machine_token:
+            return self.machine_token.get("activityInfo", {}).get("activityID")
+        return None
+
+    @property
+    def activity_ping_interval(self) -> "Optional[int]":
+        if self.machine_token:
+            return self.machine_token.get("activityInfo", {}).get(
+                "activityPingInterval"
+            )
+        return None
+
+    @property
+    def contract_id(self):
+        if self.machine_token:
+            return (
+                self.machine_token.get("machineTokenInfo", {})
+                .get("contractInfo", {})
+                .get("id")
+            )
+        return None
+
+
+class NoticeFile:
+    def __init__(
+        self,
+        directory: str = defaults.DEFAULT_DATA_DIR,
+        root_mode: bool = True,
+    ):
+        file_name = "notices.json"
+        self.file = UAFile(file_name, directory, False)
+        self.is_root = root_mode
+
+    def add(self, label: str, description: str):
+        """
+        Adds a notice to the notices.json file.
+        Raises a NonRootUserError if the user is not root.
+        """
+        if self.is_root:
+            notices = self.read() or []
+            notice = [label, description]
+            if notice not in notices:
+                notices.append(notice)
+                self.write(notices)
+        else:
+            raise exceptions.NonRootUserError
+
+    def try_add(self, label: str, description: str):
+        """
+        Adds a notice to the notices.json file.
+        Logs a warning when adding as non-root
+        """
+        try:
+            self.add(label, description)
+        except exceptions.NonRootUserError:
+            event.warning("Trying to add notice as non-root user")
+
+    def remove(self, label_regex: str, descr_regex: str):
+        """
+        Removes a notice to the notices.json file.
+        Raises a NonRootUserError if the user is not root.
+        """
+        if self.is_root:
+            notices = []
+            cached_notices = self.read() or []
+            if cached_notices:
+                for notice_label, notice_descr in cached_notices:
+                    if re.match(label_regex, notice_label):
+                        if re.match(descr_regex, notice_descr):
+                            continue
+                    notices.append((notice_label, notice_descr))
+            if notices:
+                self.write(notices)
+            elif os.path.exists(self.file.path):
+                self.file.delete()
+        else:
+            raise exceptions.NonRootUserError
+
+    def try_remove(self, label_regex: str, descr_regex: str):
+        """
+        Removes a notice to the notices.json file.
+        Logs  a warning when removing as non-root
+        """
+        try:
+            self.remove(label_regex, descr_regex)
+        except exceptions.NonRootUserError:
+            event.warning("Trying to remove notice as non-root user")
+
+    def read(self):
+        content = self.file.read()
+        if not content:
+            return None
+        try:
+            return json.loads(content, cls=util.DatetimeAwareJSONDecoder)
+        except ValueError:
+            return content
+
+    def write(self, content: Any):
+        if not isinstance(content, str):
+            content = json.dumps(content, cls=util.DatetimeAwareJSONEncoder)
+        self.file.write(content)

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict
+
+from uaclient.data_types import BoolDataValue, DataObject, Field
+from uaclient.files.data_types import DataObjectFile
+from uaclient.files.files import UAFile
+
+SERVICES_ONCE_ENABLED = "services-once-enabled"
+
+
+class ServicesOnceEnabledData(DataObject):
+    fields = [
+        Field("fips_updates", BoolDataValue, False),
+    ]
+
+    def __init__(self, fips_updates: bool):
+        self.fips_updates = fips_updates
+
+
+def _services_once_enable_preprocess_data(
+    data: Dict[str, Any]
+) -> Dict[str, Any]:
+    # Since we are using now returning DataObject instances from read, we
+    # cannot have variables with "-" in them. We need to explictly convert
+    # them before creating the object
+    updated_data = {}
+    for key in data.keys():
+        if "-" in key:
+            updated_data[key.replace("-", "_")] = True
+        else:
+            updated_data[key] = True
+
+    return updated_data
+
+
+services_once_enabled_file = DataObjectFile(
+    data_object_cls=ServicesOnceEnabledData,
+    ua_file=UAFile(
+        name=SERVICES_ONCE_ENABLED,
+        private=False,
+    ),
+    preprocess_data=_services_once_enable_preprocess_data,
+)

--- a/uaclient/files/tests/test_data_types.py
+++ b/uaclient/files/tests/test_data_types.py
@@ -1,0 +1,123 @@
+import mock
+import pytest
+
+from uaclient import exceptions
+from uaclient.data_types import (
+    DataObject,
+    Field,
+    IncorrectFieldTypeError,
+    IntDataValue,
+    StringDataValue,
+)
+from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
+
+
+class MockUAFile:
+    def __init__(self):
+        self.write = mock.MagicMock()
+        self.read = mock.MagicMock()
+        self.delete = mock.MagicMock()
+        self.path = mock.MagicMock()
+
+
+class NestedTestData(DataObject):
+    fields = [
+        Field("integer", IntDataValue),
+    ]
+
+    def __init__(self, integer: int):
+        self.integer = integer
+
+
+class TestData(DataObject):
+    fields = [
+        Field("string", StringDataValue),
+        Field("nested", NestedTestData),
+    ]
+
+    def __init__(self, string: str, nested: NestedTestData):
+        self.string = string
+        self.nested = nested
+
+
+class TestDataObjectFile:
+    def test_write_valid_json(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+        )
+        dof.write(TestData(string="test", nested=NestedTestData(integer=1)))
+        assert mock_file.write.call_args_list == [
+            mock.call("""{"nested": {"integer": 1}, "string": "test"}""")
+        ]
+
+    def test_write_valid_yaml(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+            DataObjectFileFormat.YAML,
+        )
+        dof.write(TestData(string="test", nested=NestedTestData(integer=1)))
+        assert mock_file.write.call_args_list == [
+            mock.call("""nested:\n  integer: 1\nstring: test\n""")
+        ]
+
+    def test_read_valid_json(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+        )
+        mock_file.read.return_value = (
+            """{"string": "test", "nested": {"integer": 1}}"""
+        )
+        do = dof.read()
+        assert do.string == "test"
+        assert do.nested.integer == 1
+
+    def test_read_valid_yaml(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+            DataObjectFileFormat.YAML,
+        )
+        mock_file.read.return_value = (
+            """nested:\n  integer: 1\nstring: test\n"""
+        )
+        do = dof.read()
+        assert do.string == "test"
+        assert do.nested.integer == 1
+
+    def test_read_invalid_data(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+        )
+        mock_file.read.return_value = """{"nested": {"integer": 1}}"""
+        with pytest.raises(IncorrectFieldTypeError):
+            dof.read()
+
+    def test_read_invalid_json(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+        )
+        mock_file.read.return_value = """{"nested": {"""
+        with pytest.raises(exceptions.InvalidFileFormatError):
+            dof.read()
+
+    def test_read_invalid_yaml(self):
+        mock_file = MockUAFile()
+        dof = DataObjectFile(
+            TestData,
+            mock_file,
+            DataObjectFileFormat.YAML,
+        )
+        mock_file.read.return_value = """nested": {"""
+        with pytest.raises(exceptions.InvalidFileFormatError):
+            dof.read()

--- a/uaclient/files/tests/test_files.py
+++ b/uaclient/files/tests/test_files.py
@@ -1,0 +1,49 @@
+import os
+
+from uaclient import system
+from uaclient.files import MachineTokenFile, UAFile
+
+
+class TestUAFile:
+    def test_read_write(self, tmpdir):
+        file_name = "temp_file"
+        file = UAFile(file_name, tmpdir.strpath, False)
+        content = "dummy file words"
+        file.write(content)
+        path = os.path.join(tmpdir.strpath, file_name)
+        res = system.load_file(path)
+        assert res == file.read()
+        assert res == content
+
+
+class TestMachineTokenFile:
+    def test_deleting(self, tmpdir):
+        token_file = MachineTokenFile(
+            directory=tmpdir.strpath,
+        )
+        token = {"machineTokenInfo": {"machineId": "random-id"}}
+        token_file.write(token)
+        assert token_file.machine_token == token
+        token_file.delete()
+        assert token_file.machine_token is None
+
+    def test_public_file_filtering(self, tmpdir):
+        # root access of machine token file
+        token_file = MachineTokenFile(
+            directory=tmpdir.strpath,
+        )
+        token = {
+            "machineTokenInfo": {"machineId": "random-id"},
+            "machineToken": "token",
+        }
+        token_file.write(token)
+        root_token = token_file.machine_token
+        assert token == root_token
+        # non root access of machine token file
+        token_file = MachineTokenFile(
+            directory=tmpdir.strpath, root_mode=False
+        )
+        nonroot_token = token_file.machine_token
+        assert root_token != nonroot_token
+        machine_token = nonroot_token.get("machineToken", None)
+        assert machine_token is None

--- a/uaclient/files/tests/test_state_files.py
+++ b/uaclient/files/tests/test_state_files.py
@@ -1,0 +1,17 @@
+import pytest
+
+from uaclient.files.state_files import _services_once_enable_preprocess_data
+
+
+class TestServicesOnceEnabledPreprocessData:
+    @pytest.mark.parametrize(
+        "content",
+        (
+            ({"fips-updates": True}),
+            ({"fips_updates": True}),
+        ),
+    )
+    def test_add_service(self, content):
+        assert _services_once_enable_preprocess_data(content) == {
+            "fips_updates": True
+        }

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1039,3 +1039,5 @@ ENTITLEMENT_NOT_FOUND = FormattedNamedMessage(
 TRY_UBUNTU_PRO_BETA = """\
 Try Ubuntu Pro beta with a free personal subscription on up to 5 machines.
 Learn more at https://ubuntu.com/pro"""
+
+INVALID_STATE_FILE = "Invalid state file: {}"


### PR DESCRIPTION
## Proposed Commit Message
files: extract services-once-enabled from config

Extract the services-once-enabled state file from the UAConfig class and handle it on a dedicated module.

This PR also proposed a refactoring on the structure of how we manage files on UA.

## Test Steps
Run the integration scenario`Attached enable of FIPS-updates in an ubuntu lxd vm` on the `enable_fips_vm`  feature

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
