### PR TITLE
Fix esm across release upgrade

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -217,7 +217,7 @@ EOF
         cat > "${apt_pref_file}" <<EOF
 # Written by ubuntu-advantage-tools
 Package: *
-Pin: release o=${apt_origin}, n=${release}
+Pin: release o=${apt_origin}
 Pin-Priority: never
 EOF
     fi

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -397,16 +397,13 @@ def restore_commented_apt_list_file(filename: str) -> None:
 
 def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):
     """Add an apt preferences file and pin for a PPA."""
-    series = system.get_platform_info()["series"]
     _protocol, repo_path = repo_url.split("://")
     if repo_path.endswith("/"):  # strip trailing slash
         repo_path = repo_path[:-1]
     content = (
         "Package: *\n"
-        "Pin: release o={origin}, n={series}\n"
-        "Pin-Priority: {priority}\n".format(
-            origin=origin, priority=priority, series=series
-        )
+        "Pin: release o={origin}\n"
+        "Pin-Priority: {priority}\n".format(origin=origin, priority=priority)
     )
     system.write_file(apt_preference_file, content)
 

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -95,10 +95,10 @@ class ESMInfraEntitlement(ESMBaseEntitlement):
 
     @property
     def repo_pin_priority(self) -> Optional[str]:
-        """Once a release goes into EOL it is entitled to ESM Infra."""
-        if system.is_active_esm(system.get_platform_info()["series"]):
+        """All LTS are entitled to ESM Infra."""
+        if system.is_lts(system.get_platform_info()["series"]):
             return "never"
-        return None  # No pinning on non-ESM releases
+        return None  # No pinning on non-LTS releases
 
     @property
     def disable_apt_auth_only(self) -> bool:

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -19,36 +19,37 @@ def entitlement(request, entitlement_factory):
 
 class TestESMRepoPinPriority:
     @pytest.mark.parametrize(
-        "series, is_active_esm, repo_pin_priority",
+        "series, is_lts, repo_pin_priority",
         (
             ("xenial", True, "never"),
-            ("bionic", False, None),
-            ("focal", False, None),
+            ("bionic", True, "never"),
+            ("impish", False, None),
         ),
     )
-    @mock.patch("uaclient.system.is_active_esm")
+    @mock.patch("uaclient.system.is_lts")
     @mock.patch("uaclient.entitlements.esm.system.get_platform_info")
-    def test_esm_infra_repo_pin_priority_never_on_active_esm(
+    def test_esm_infra_repo_pin_priority_never_on_lts(
         self,
         m_get_platform_info,
-        m_is_active_esm,
+        m_is_lts,
         series,
-        is_active_esm,
+        is_lts,
         repo_pin_priority,
     ):
-        """Repository pinning priority for ESMInfra is 'never' when active ESM
+        """Repository pinning priority for ESMInfra is 'never' when LTS
 
         A pin priority of 'never' means we advertize those service packages
         without allowing them to be installed until someone attaches
         the machine to Ubuntu Advantage. This is only done for ESM Infra
-        when the release is EOL and supports ESM. We won't want/need to
-        advertize ESM Infra packages on releases that are not EOL.
+        when the release is LTS. We won't want/need to
+        advertize ESM Infra packages on releases that are not EOL, but
+        this is dealt with in the enable/disable flows, and in postinst.
         """
-        m_is_active_esm.return_value = is_active_esm
+        m_is_lts.return_value = is_lts
         m_get_platform_info.return_value = {"series": series}
         inst = ESMInfraEntitlement({})
         assert repo_pin_priority == inst.repo_pin_priority
-        assert [mock.call(series)] == m_is_active_esm.call_args_list
+        assert [mock.call(series)] == m_is_lts.call_args_list
 
     @pytest.mark.parametrize(
         "series, is_beta, repo_pin_priority",

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -69,7 +69,7 @@ class TestAddPPAPinning:
         expected_pref = dedent(
             """\
             Package: *
-            Pin: release o=MYORIG, n=xenial
+            Pin: release o=MYORIG
             Pin-Priority: 1003\n"""
         )
         assert expected_pref == system.load_file(pref_file)


### PR DESCRIPTION
From the associated LP bug:
```
With u-a-t 27.11, currently on -proposed, upgrading from Xenial to Bionic fails when unattached.

The reason is: Bionic has some updates available in esm-apps, and the repositories are present due to the postinst script seeing that the service is not beta anymore.

However, the preferences file only pins esm for Xenial, and do-release-upgrade:
1. Sees the packages in the Bionic ESM repository
2. Ignores the pinning to 'never'
3. Fails to get those packages - all of them are 401ed
4. Fail to calculate the diffs and exits 1.

Although found and reproducible when upgrading from Xenial to Bionic, this bug may affect any upgrade across releases where the system is unattached, and has any given package installed which is present in the ESM repository of the next release.
```

This changeset removes the release information from the preferences file, pinning the repositories to "never" based only on having ESM as an origin.

The immediate side effect is another bug, where the preferences file is not removed when enabling esm-infra on any LTS which is not EOSS yet. As esm-infra can be enabled in any release (even if it has only the dummy package) this does not make sense. This changeset tackles that by returning the "never" pin value for any LTS, making sure the file is removed when the service is enabled (although it is only created again in EOSS releases, which makes sense for advertisement purposes).

LP: #1990907


## Test Steps
Run `features/ubuntu_upgrade_unattached.feature` for Xenial using version `27.11`, and see it fails.
Run the same including the contents of this changeset, and see it succeeds.


## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have slightly updated or added any documentation accordingly
