### PR TITLE
systemd: add machine token condition for auto-attach

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -272,7 +272,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         And stdout matches regexp:
         """
-        This machine is already attached to '.*'
+        Active: inactive \(dead\).*
+        \s*Condition: start condition failed.*
+        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
         When I run `pro auto-attach` with sudo
         Then stderr matches regexp:
@@ -395,7 +397,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         And stdout matches regexp:
         """
-        This machine is already attached to '.*'
+        Active: inactive \(dead\).*
+        \s*Condition: start condition failed.*
+        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
         When I run `pro auto-attach` with sudo
         Then stderr matches regexp:
@@ -517,7 +521,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         And stdout matches regexp:
         """
-        This machine is already attached to '.*'
+        Active: inactive \(dead\).*
+        \s*Condition: start condition failed.*
+        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
         When I run `pro auto-attach` with sudo
         Then stderr matches regexp:

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -48,7 +48,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         And stdout matches regexp:
         """
-        This machine is already attached to '.*'
+        Active: inactive \(dead\).*
+        \s*Condition: start condition failed.*
+        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
         When I run `pro auto-attach` with sudo
         Then stderr matches regexp:
@@ -261,7 +263,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         And stdout matches regexp:
         """
-        This machine is already attached to '.*'
+        Active: inactive \(dead\).*
+        \s*Condition: start condition failed.*
+        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
         When I run `pro auto-attach` with sudo
         Then stderr matches regexp:
@@ -527,7 +531,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         And stdout matches regexp:
         """
-        This machine is already attached to '.*'
+        Active: inactive \(dead\).*
+        \s*Condition: start condition failed.*
+        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
         When I run `pro auto-attach` with sudo
         Then stderr matches regexp:

--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -3,6 +3,9 @@ Description=Ubuntu Advantage auto attach
 Before=cloud-config.service
 After=cloud-config.target
 
+# Only run if not already attached
+ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json
+
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/auto_attach.py


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

systemd: add machine token condition for auto-attach

This is a simple improvement. Just an extra check for the auto-attach.service - make sure that the machine is not attached.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
