### PR TITLE
test: Extend auto-attach no-op scenario (SC-1270) 

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -121,6 +121,7 @@ class Cloud:
         user_data: Optional[str] = None,
         ephemeral: bool = False,
         inbound_ports: Optional[List[str]] = None,
+        cloud_init_ppa: Optional[str] = None,
     ) -> pycloudlib.instance.BaseInstance:
         """Create and wait for cloud provider instance to be ready.
 
@@ -138,6 +139,8 @@ class Cloud:
             If instance should be ephemeral
         :param inbound_ports:
             List of ports to open for network ingress to the instance
+        :param cloud_init_ppa:
+            Cloud-init's ppa to upgrade with
 
         :returns:
             An cloud provider instance
@@ -163,7 +166,18 @@ class Cloud:
             except Exception as e:
                 logging.info("--- Retrying instance.wait on {}".format(str(e)))
 
-        self._check_cloudinit_status(inst)
+        if cloud_init_ppa:
+            logging.info("--- Installing cloud-init PPA: %s", cloud_init_ppa)
+            assert inst.execute(
+                "sudo add-apt-repository {} -y".format(cloud_init_ppa)
+            ).ok
+            assert inst.execute("sudo apt-get update -q").ok
+            assert inst.execute("sudo apt-get install -qy cloud-init").ok
+            assert inst.execute("sudo cloud-init clean --logs").ok
+        else:
+            # Check only if cloud-init wasn't upgraded as given user-data could
+            # be only compatible with the newer version.
+            self._check_cloudinit_status(inst)
         return inst
 
     def get_instance_id(

--- a/features/environment.py
+++ b/features/environment.py
@@ -618,6 +618,7 @@ def create_instance_with_uat_installed(
     series: str,
     name: str,
     custom_user_data: Optional[str] = None,
+    cloud_init_ppa: Optional[str] = None,
 ) -> pycloudlib.instance.BaseInstance:
     """Create a given series lxd image with ubuntu-advantage-tools installed
 
@@ -634,6 +635,8 @@ def create_instance_with_uat_installed(
        A string representing the instance name
     :param custom_user_data:
        A string representing custom userdata to be added to the instance
+    :param cloud_init_ppa:
+        Cloud-init's ppa to upgrade with
 
     :return: A pycloudlib Instance
     """
@@ -655,7 +658,10 @@ def create_instance_with_uat_installed(
         "--- Launching VM to create a base image with ubuntu-advantage"
     )
     inst = context.config.cloud_manager.launch(
-        instance_name=name, series=series, user_data=user_data
+        instance_name=name,
+        series=series,
+        user_data=user_data,
+        cloud_init_ppa=cloud_init_ppa,
     )
     instance_id = context.config.cloud_manager.get_instance_id(inst)
 

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -613,18 +613,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
     @uses.config.machine_type.gcp.pro
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.azure.pro
-    Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
-        Given a `<release>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
-        # This user_data should not do anything, just guarantee that the ua-auto-attach service
-        # # does nothing
-        """
-        ubuntu_advantage:
-        """
-        When I run `cloud-init query userdata` with sudo
-        Then stdout matches regexp:
-        """
-        ubuntu_advantage:
-        """
+    Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata and cloud-init auto attaches
+        # In the first boot we install uat and daily cloud-init and prepare/check preconditions
+        # In the second boot we execute the test
+
+        Given a `<release>` machine with ubuntu-advantage-tools installed and cloud-init upgraded to the latest daily version
         # On GCP, this service will auto-attach the machine automatically after we override
         # the uaclient.conf file. To guarantee that we are not auto-attaching on reboot
         # through the ua-auto-attach.service, we are masking it
@@ -636,14 +629,26 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         log_level: debug
         log_file: /var/log/ubuntu-advantage.log
         """
-        And I reboot the machine
         And I run `pro status --wait` with sudo
         And I run `pro security-status --format json` with sudo
         Then stdout matches regexp:
         """
         "attached": false
         """
-        When I run `cat /var/log/ubuntu-advantage.log` with sudo
+
+        # Prepare for second boot
+        When I run `cloud-init clean --logs` with sudo
+        And I take a snapshot of the machine
+        And I launch a `clone` machine from the snapshot adding this cloud-init user_data:
+        """
+        #cloud-config
+        ubuntu_advantage:
+          features:
+            disable_auto_attach: False
+          enable:
+          - livepatch
+        """
+        When I run `cat /var/log/ubuntu-advantage.log` `with sudo` on the `clone` machine
         Then stdout matches regexp:
         """
         cloud-init userdata has ubuntu-advantage key.
@@ -651,6 +656,18 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And stdout matches regexp:
         """
         Skipping auto-attach and deferring to cloud-init to setup and configure auto-attach
+        """
+        When I run `cloud-init status` `with sudo` on the `clone` machine
+        Then stdout matches regexp:
+        """
+        status: done
+        """
+
+        When I run `pro status --wait` `with sudo` on the `clone` machine
+        And I run `pro security-status --format json` `with sudo` on the `clone` machine
+        Then stdout matches regexp:
+        """
+        "attached": true
         """
 
         Examples: ubuntu release


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
test: Extend auto-attach no-op scenario

The test has been divided into two stages / boots. The first
one to prepare the instance environment and the second one
to execute the test.

In the first boot:

- Install cloud-init from ppa:cloud-init-dev/daily to ensure
  we are getting latest feature behavior.
- Remove explicit user-data, as features/enviroment.py already
  prepares user-data to stop auto-attach, and instead, assert
  that the instance is not auto attached at the end of the first
  boot.
- Create snapshot and boot with a valid user-data to auto attach
  with cloud-init.

Second boot:

- Assert UA nooped
- Assert cloud-init status shows success
- Assert the instance is auto attached
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Execute the modified test scenario.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
