### PR TITLE
lib/auto_attach: Fix cloud-init ua config presence

### DIFF
--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -43,7 +43,10 @@ def check_cloudinit_userdata_for_ua_info():
     if init is None:
         return False
 
-    if init.cfg and "ubuntu_advantage" in init.cfg.keys():
+    if init.cfg and (
+        "ubuntu_advantage" in init.cfg.keys()
+        or "ubuntu-advantage" in init.cfg.keys()
+    ):
         return True
 
     return False


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
lib/auto_attach: Fix cloud-init ua config presence

In order to let cloud-init drive the auto attach
UA checks the presence of UA config in cloud-init
user-data.

Check for the presence of `ubuntu-advantage` in
user-data. This is the deprecated way to define
the config of cc_ubuntu_advantage.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
