### PR TITLE
chore: fix the changelog entry for 27.11.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,9 @@
 ubuntu-advantage-tools (27.11.3~22.10.1) kinetic; urgency=medium
 
   * New upstream release 27.11.3:
-    - collect-logs: do not fail if a file cannot be read (LP: #1991858)
+    - d/postinst: remove the old Ubuntu Pro message and set up the
+      configurable flag instead
+    - apport-hook: do not fail if a file cannot be read (LP: #1991858)
     - config: add a flag to remove the APT related news (LP: #1992026)
       (GH: #2288)
     - messaging: move the Ubuntu Pro beta message to the end of the APT output


### PR DESCRIPTION
postinst should be in the changelog, and the change is actually to the apport hook