### PR TITLE
auto-attach: use api in cli entry-point (SC-1274)

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -304,10 +304,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
             """
             This command must be run as root \(try using sudo\).
             """
-        When I verify that running `pro auto-attach` `with sudo` exits `0`
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
             """
-            Skipping auto-attach: Instance is already attached.
+            This machine is already attached to 'UA Client Test'
+            To use a different subscription first run: sudo pro detach.
             """
 
         Examples: ubuntu release
@@ -394,10 +395,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         other: False
         """
         When I run `pro detach --assume-yes` with sudo
-        When I run `pro auto-attach` with sudo
-        Then stdout matches regexp:
+        Then I verify that running `pro auto-attach` `with sudo` exits `1`
+        Then stderr matches regexp:
         """
-        Skipping auto-attach. Config disable_auto_attach is set.
+        features.disable_auto_attach set in config
         """
 
         Examples: ubuntu release

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -15,10 +15,11 @@ Feature: Attached cloud does not detach when auto-attaching after manually attac
         Successfully refreshed your subscription.
         Successfully updated Ubuntu Pro related APT and MOTD messages.
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to 'UA Client Test'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `pro status` with sudo
         Then stdout matches regexp:

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -276,10 +276,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         \s*Condition: start condition failed.*
         .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to '.*'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
@@ -525,10 +526,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         \s*Condition: start condition failed.*
         .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to '.*'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -402,10 +402,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         \s*Condition: start condition failed.*
         .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to '.*'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -52,10 +52,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         \s*Condition: start condition failed.*
         .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to '.*'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
@@ -536,10 +537,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         \s*Condition: start condition failed.*
         .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to '.*'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -267,10 +267,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         \s*Condition: start condition failed.*
         .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
         """
-        When I run `pro auto-attach` with sudo
+        When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        Skipping auto-attach: Instance is already attached.
+        This machine is already attached to '.*'
+        To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`

--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -13,9 +13,10 @@ their side.
 import logging
 import sys
 
-from uaclient import actions, messages, system
+from uaclient import messages, system
 from uaclient.api.exceptions import (
     AlreadyAttachedError,
+    AutoAttachDisabledError,
     EntitlementsNotEnabledError,
 )
 from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
@@ -61,9 +62,6 @@ def check_cloudinit_userdata_for_ua_info():
 
 
 def main(cfg: UAConfig):
-    if actions.should_disable_auto_attach(cfg):
-        return
-
     if check_cloudinit_userdata_for_ua_info():
         logging.info("cloud-init userdata has ubuntu-advantage key.")
         logging.info(
@@ -79,6 +77,11 @@ def main(cfg: UAConfig):
         full_auto_attach(FullAutoAttachOptions())
     except AlreadyAttachedError as e:
         logging.info(e.msg)
+    except AutoAttachDisabledError:
+        logging.debug(
+            "Skipping auto-attach. Config disable_auto_attach is set."
+        )
+        return
     except EntitlementsNotEnabledError as e:
         logging.warning(e.msg)
     except Exception as e:

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -231,18 +231,6 @@ def collect_logs(cfg: config.UAConfig, output_dir: str):
             )
 
 
-def should_disable_auto_attach(cfg: config.UAConfig) -> bool:
-    disable_auto_attach = util.is_config_value_true(
-        config=cfg.cfg, path_to_value="features.disable_auto_attach"
-    )
-    if disable_auto_attach:
-        msg = "Skipping auto-attach. Config disable_auto_attach is set."
-        logging.debug(msg)
-        print(msg)
-
-    return disable_auto_attach
-
-
 def get_cloud_instance(
     cfg: config.UAConfig,
 ) -> AutoAttachCloudInstance:

--- a/uaclient/api/tests/test_u_pro_attach_auto_full_auto_attach_v1.py
+++ b/uaclient/api/tests/test_u_pro_attach_auto_full_auto_attach_v1.py
@@ -223,10 +223,7 @@ class TestFullAutoAttachV1:
 
     @pytest.mark.parametrize(
         "mode",
-        [
-            pytest.param(e.value, id=e.name)
-            for e in event_logger.EventLoggerMode
-        ],
+        list(map(lambda e: e.value, event_logger.EventLoggerMode)),
     )
     @pytest.mark.parametrize(
         [
@@ -241,7 +238,8 @@ class TestFullAutoAttachV1:
             "expected_ret",
         ],
         [
-            pytest.param(
+            # already attached
+            (
                 FullAutoAttachOptions(),
                 True,
                 False,
@@ -253,9 +251,9 @@ class TestFullAutoAttachV1:
                     account_name="test_account"
                 ).msg,
                 None,
-                id="already_attached",
             ),
-            pytest.param(
+            # disable_auto_attach: true
+            (
                 FullAutoAttachOptions(),
                 False,
                 True,
@@ -265,9 +263,9 @@ class TestFullAutoAttachV1:
                 pytest.raises(exceptions.AutoAttachDisabledError),
                 messages.AUTO_ATTACH_DISABLED_ERROR.msg,
                 None,
-                id="disable_auto_attach_true",
             ),
-            pytest.param(
+            # success no options
+            (
                 FullAutoAttachOptions(),
                 False,
                 False,
@@ -277,9 +275,9 @@ class TestFullAutoAttachV1:
                 does_not_raise(),
                 None,
                 FullAutoAttachResult(),
-                id="success_no_options",
             ),
-            pytest.param(
+            # success enable
+            (
                 FullAutoAttachOptions(enable=["cis"]),
                 False,
                 False,
@@ -289,9 +287,9 @@ class TestFullAutoAttachV1:
                 does_not_raise(),
                 None,
                 FullAutoAttachResult(),
-                id="success_enable",
             ),
-            pytest.param(
+            # success enable_beta
+            (
                 FullAutoAttachOptions(enable_beta=["cis"]),
                 False,
                 False,
@@ -301,9 +299,9 @@ class TestFullAutoAttachV1:
                 does_not_raise(),
                 None,
                 FullAutoAttachResult(),
-                id="success_enable_beta",
             ),
-            pytest.param(
+            # success enable and enable_beta
+            (
                 FullAutoAttachOptions(enable=["fips"], enable_beta=["cis"]),
                 False,
                 False,
@@ -316,9 +314,9 @@ class TestFullAutoAttachV1:
                 does_not_raise(),
                 None,
                 FullAutoAttachResult(),
-                id="success_enable_and_enable_beta",
             ),
-            pytest.param(
+            # fail to enable
+            (
                 FullAutoAttachOptions(enable=["fips"], enable_beta=["cis"]),
                 False,
                 False,
@@ -334,7 +332,6 @@ class TestFullAutoAttachV1:
                 pytest.raises(exceptions.EntitlementsNotEnabledError),
                 messages.ENTITLEMENTS_NOT_ENABLED_ERROR.msg,
                 None,
-                id="fail_to_enable",
             ),
         ],
     )

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -67,14 +67,17 @@ def full_auto_attach(options: FullAutoAttachOptions) -> FullAutoAttachResult:
 
 
 def _full_auto_attach(
-    options: FullAutoAttachOptions, cfg: UAConfig
+    options: FullAutoAttachOptions,
+    cfg: UAConfig,
+    *,
+    mode: event_logger.EventLoggerMode = event_logger.EventLoggerMode.JSON
 ) -> FullAutoAttachResult:
     try:
         with lock.SpinLock(
             cfg=cfg,
             lock_holder="pro.api.u.pro.attach.auto.full_auto_attach.v1",
         ):
-            ret = _full_auto_attach_in_lock(options, cfg)
+            ret = _full_auto_attach_in_lock(options, cfg, mode=mode)
     except Exception as e:
         lock.clear_lock_file_if_present()
         raise e
@@ -82,9 +85,11 @@ def _full_auto_attach(
 
 
 def _full_auto_attach_in_lock(
-    options: FullAutoAttachOptions, cfg: UAConfig
+    options: FullAutoAttachOptions,
+    cfg: UAConfig,
+    mode: event_logger.EventLoggerMode,
 ) -> FullAutoAttachResult:
-    event.set_event_mode(event_logger.EventLoggerMode.JSON)
+    event.set_event_mode(mode)
 
     if cfg.is_attached:
         raise exceptions.AlreadyAttachedError(

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1390,8 +1390,6 @@ def action_auto_attach(args, *, cfg: config.UAConfig) -> int:
         return 1
     except api_exceptions.AutoAttachDisabledError:
         return 0
-    except exceptions.AlreadyAttachedError as e:
-        raise exceptions.AlreadyAttachedOnPROError() from e
     else:
         _post_cli_attach(cfg)
         return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -33,7 +33,6 @@ from uaclient import (
 )
 from uaclient import status as ua_status
 from uaclient import util, version
-from uaclient.api import exceptions as api_exceptions
 from uaclient.api.api import call_api
 from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
     FullAutoAttachOptions,
@@ -1388,8 +1387,6 @@ def action_auto_attach(args, *, cfg: config.UAConfig) -> int:
     except exceptions.UrlError:
         event.info(messages.ATTACH_FAILURE.msg)
         return 1
-    except api_exceptions.AutoAttachDisabledError:
-        return 0
     else:
         _post_cli_attach(cfg)
         return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1392,9 +1392,6 @@ def action_auto_attach(args, *, cfg: config.UAConfig) -> int:
         return 0
     except exceptions.AlreadyAttachedError as e:
         raise exceptions.AlreadyAttachedOnPROError() from e
-    except exceptions.UserFacingError as e:
-        event.info(e.msg)
-        return 1
     else:
         _post_cli_attach(cfg)
         return 0

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -137,16 +137,6 @@ class NonAutoAttachImageError(UserFacingError):
     exit_code = 0
 
 
-class AlreadyAttachedOnPROError(UserFacingError):
-    """Raised when a PRO machine retries attaching with the same instance-id"""
-
-    exit_code = 0
-
-    def __init__(self):
-        msg = messages.ALREADY_ATTACHED_ON_PRO
-        super().__init__(msg=msg.msg, msg_code=msg.name)
-
-
 class AlreadyAttachedError(UserFacingError):
     """An exception to be raised when a command needs an unattached system."""
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -595,12 +595,6 @@ ALREADY_ATTACHED = FormattedNamedMessage(
     ),
 )
 
-ALREADY_ATTACHED_ON_PRO = NamedMessage(
-    "already-attached-on-pro",
-    """\
-Skipping auto-attach: Instance is already attached.""",
-)
-
 CONNECTIVITY_ERROR = NamedMessage(
     "connectivity-error",
     """\

--- a/uaclient/testing/helpers.py
+++ b/uaclient/testing/helpers.py
@@ -1,4 +1,7 @@
-from contextlib import AbstractContextManager
+try:  # Drop try-except after xenial EOL
+    from contextlib import AbstractContextManager
+except ImportError:
+    AbstractContextManager = object
 
 
 class does_not_raise(AbstractContextManager):
@@ -22,6 +25,9 @@ class does_not_raise(AbstractContextManager):
     >>>     with expectation:
     >>>         assert (0 / example_input) is not None
     """
+
+    def __enter__(self):
+        return self
 
     def __exit__(self, *args, **kwargs):
         pass

--- a/uaclient/testing/helpers.py
+++ b/uaclient/testing/helpers.py
@@ -1,12 +1,14 @@
-from contextlib import contextmanager
+from contextlib import AbstractContextManager
 
 
-@contextmanager
-def does_not_raise():
-    """Context manager to parametrize tests raising and not raising exceptions
+class does_not_raise(AbstractContextManager):
+    """Reentrant noop context manager.
+    Useful to parametrize tests raising and not raising exceptions.
+
     Note: In python-3.7+, this can be substituted by contextlib.nullcontext
     More info:
     https://docs.pytest.org/en/6.2.x/example/parametrize.html?highlight=does_not_raise#parametrizing-conditional-raising
+
     Example:
     --------
     >>> @pytest.mark.parametrize(
@@ -20,4 +22,6 @@ def does_not_raise():
     >>>     with expectation:
     >>>         assert (0 / example_input) is not None
     """
-    yield
+
+    def __exit__(self, *args, **kwargs):
+        pass

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -1,9 +1,11 @@
 import textwrap
+from typing import Optional
 
 import mock
 import pytest
 
 from uaclient import event_logger, exceptions
+from uaclient.api import exceptions as api_exceptions
 from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
     FullAutoAttachOptions,
 )
@@ -57,6 +59,28 @@ class TestActionAutoAttach:
         out, _err = capsys.readouterr()
         assert HELP_OUTPUT == out
 
+    @mock.patch(M_PATH + "_post_cli_attach")
+    @mock.patch(M_PATH + "_full_auto_attach")
+    def test_happy_path(
+        self,
+        m_full_auto_attach,
+        m_post_cli_attach,
+        _m_getuid,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+
+        assert 0 == action_auto_attach(mock.MagicMock(), cfg=cfg)
+
+        assert [
+            mock.call(
+                FullAutoAttachOptions(enable=None, enable_beta=None),
+                cfg=cfg,
+                mode=event_logger.EventLoggerMode.CLI,
+            )
+        ] == m_full_auto_attach.call_args_list
+        assert [mock.call(cfg)] == m_post_cli_attach.call_args_list
+
     def test_error_if_attached(
         self,
         _m_getuid,
@@ -67,46 +91,15 @@ class TestActionAutoAttach:
             action_auto_attach(mock.MagicMock(), cfg=cfg)
 
     @pytest.mark.parametrize(
-        "features_override", ((None), ({"disable_auto_attach": True}))
-    )
-    @mock.patch(M_PATH + "_post_cli_attach")
-    @mock.patch(M_PATH + "_full_auto_attach")
-    def test_disable_auto_attach_config(
-        self,
-        m_full_auto_attach,
-        m_post_cli_attach,
-        _m_getuid,
-        features_override,
-        FakeConfig,
-    ):
-        cfg = FakeConfig()
-        if features_override:
-            cfg.override_features(features_override)
-
-        ret = action_auto_attach(mock.MagicMock(), cfg=cfg)
-
-        assert 0 == ret
-        if features_override:
-            assert [] == m_full_auto_attach.call_args_list
-            assert [] == m_post_cli_attach.call_args_list
-        else:
-            assert [
-                mock.call(
-                    FullAutoAttachOptions(enable=None, enable_beta=None),
-                    cfg=cfg,
-                    mode=event_logger.EventLoggerMode.CLI,
-                )
-            ] == m_full_auto_attach.call_args_list
-            assert [mock.call(mock.ANY)] == m_post_cli_attach.call_args_list
-
-    @pytest.mark.parametrize(
-        "faa_side_effect, event_info",
+        "faa_side_effect, event_info, exit_code",
         [
             (
-                exceptions.UrlError(cause="cause"),
+                exceptions.UrlError(cause="does-not-matter"),
                 "Failed to attach machine. See https://ubuntu.com/pro",
+                1,
             ),
-            (exceptions.UserFacingError("msg"), "msg"),
+            (api_exceptions.AutoAttachDisabledError, None, 0),
+            (exceptions.UserFacingError("msg"), "msg", 1),
         ],
     )
     @mock.patch(M_PATH + "event")
@@ -119,15 +112,20 @@ class TestActionAutoAttach:
         m_event,
         _m_getuid,
         faa_side_effect,
-        event_info,
+        event_info: Optional[str],
+        exit_code,
         FakeConfig,
         capsys,
     ):
         m_full_auto_attach.side_effect = faa_side_effect
         cfg = FakeConfig()
 
-        assert 1 == action_auto_attach(mock.MagicMock(), cfg=cfg)
-        assert [mock.call(event_info)] == m_event.info.call_args_list
+        assert exit_code == action_auto_attach(mock.MagicMock(), cfg=cfg)
+
+        if event_info is not None:
+            assert [mock.call(event_info)] == m_event.info.call_args_list
+        else:
+            assert [] == m_event.info.call_args_list
         assert [] == m_post_cli_attach.call_args_list
 
 

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -15,7 +15,6 @@ from uaclient.cli import (
     get_parser,
     main,
 )
-from uaclient.exceptions import AlreadyAttachedOnPROError, NonRootUserError
 
 M_PATH = "uaclient.cli."
 M_ID_PATH = "uaclient.clouds.identity."
@@ -38,7 +37,7 @@ def test_non_root_users_are_rejected(getuid, FakeConfig):
     getuid.return_value = 1
 
     cfg = FakeConfig()
-    with pytest.raises(NonRootUserError):
+    with pytest.raises(exceptions.NonRootUserError):
         action_auto_attach(mock.MagicMock(), cfg=cfg)
 
 
@@ -87,7 +86,7 @@ class TestActionAutoAttach:
         FakeConfig,
     ):
         cfg = FakeConfig.for_attached_machine()
-        with pytest.raises(AlreadyAttachedOnPROError):
+        with pytest.raises(exceptions.AlreadyAttachedOnPROError):
             action_auto_attach(mock.MagicMock(), cfg=cfg)
 
     @pytest.mark.parametrize(
@@ -99,7 +98,6 @@ class TestActionAutoAttach:
                 1,
             ),
             (api_exceptions.AutoAttachDisabledError, None, 0),
-            (exceptions.UserFacingError("msg"), "msg", 1),
         ],
     )
     @mock.patch(M_PATH + "event")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
auto-attach: Refactor cli entry-point to use the api

In order to simplify the code base, make use of
full_auto_attach api endpoint in cli `pro auto-attach` command.

Behavior change:

Previously, in the case where the user tried to auto attach using
the cli `pro auto-attach` on instances that were already attached
or have disable_auto_attach configured as true in the
uaclient.conf file, the cli exited with a 0 exit_code.

Now, the cli returns non 0 exit codes in both cases. The cli returned
0s because we would call the cli command on the
ua-auto-attach.service systemd unit. If we detected that the user 
was already attached or hand explicit config disabling that service,
we didn't want to show that this service failed.

After previous and this refactoring, both entry-points make use of the
new external api to auto-attach (full_auto_attach) and handle the error
cases differently.

We didn't advertise the use of `pro auto-attach` for programmatic
consumption.

Therefore we believe it is safe to change the exit codes in these
scenarios.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
