### PR TITLE
api: best effort full_auto_attach instead of fail fast

### DIFF
--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -88,7 +88,7 @@ result = initiate()
 ```
 
 #### Expected return object:
-`uaclient.api.u.pro.atatch.magic.initiate.v1.MagicAttachInitiateResult`
+`uaclient.api.u.pro.attach.magic.initiate.v1.MagicAttachInitiateResult`
 
 |Field Name|Type|Description|
 |-|-|-|
@@ -138,7 +138,7 @@ result = wait(options)
 ```
 
 #### Expected return object:
-`uaclient.api.u.pro.atatch.magic.wait.v1.MagicAttachWaitResult`
+`uaclient.api.u.pro.attach.magic.wait.v1.MagicAttachWaitResult`
 
 |Field Name|Type|Description|
 |-|-|-|
@@ -193,7 +193,7 @@ result = revoke(options)
 ```
 
 #### Expected return object:
-`uaclient.api.u.pro.atatch.magic.wait.v1.MagicAttachRevokeResult`
+`uaclient.api.u.pro.attach.magic.wait.v1.MagicAttachRevokeResult`
 
 No data present in the result.
 
@@ -234,7 +234,7 @@ result = should_auto_attach()
 ```
 
 #### Expected return object:
-`uaclient.api.u.pro.atatch.auto.should_auto_attach.v1.ShouldAutoAttachResult`
+`uaclient.api.u.pro.attach.auto.should_auto_attach.v1.ShouldAutoAttachResult`
 
 |Field Name|Type|Description|
 |-|-|-|
@@ -276,22 +276,18 @@ result = full_auto_attach(options)
 ```
 
 #### Expected return object:
-`uaclient.api.u.pro.atatch.auto.full_auto_attach.v1.FullAutoAttachResult`
+`uaclient.api.u.pro.attach.auto.full_auto_attach.v1.FullAutoAttachResult`
 
 No data present in the result.
 
 ### Raised Exceptions
 
 - `AlreadyAttachedError`: raised if running on a machine which is already attached to a Pro subscription
-- `BetaServiceError`: raised when a beta service is found in the `enable` list, instead of in the
-  `enable_beta` list
+- `AutoAttachDisabledError`: raised if `disable_auto_attach: true` in uaclient.conf
 - `ConnectivityError`: raised if it is not possible to connect to the Contracts Server
 - `ContractAPIError`: raised if there is an unexpected error in the Contracts Server interaction
-- `EntitlementNotEnabledError`: raised if the client fails to enable any of the entitlements
+- `EntitlementsNotEnabledError`: raised if the client fails to enable any of the entitlements
   (whether present in any of the lists or listed in the contract)
-- `EntitlementNotFoundError`: raised when an invalid entitlement is present in any of the lists
-- `IncompatibleEntitlementsDetected`: raised if any two entitlements present in any of the lists are mutually
-  incompatible
 - `LockHeldError`: raised if another Client process is holding the lock on the machine
 - `NonAutoAttachImageError`: raised if the cloud where the system is running does not support auto-attach
 - `UserFacingError`: raised if:

--- a/uaclient/api/exceptions.py
+++ b/uaclient/api/exceptions.py
@@ -1,6 +1,8 @@
+from typing import List, Tuple
+
+from uaclient import messages
 from uaclient.exceptions import (
     AlreadyAttachedError,
-    BetaServiceError,
     ConnectivityError,
     ContractAPIError,
     EntitlementNotFoundError,
@@ -13,7 +15,6 @@ from uaclient.exceptions import (
 
 __all__ = [
     "AlreadyAttachedError",
-    "BetaServiceError",
     "ConnectivityError",
     "ContractAPIError",
     "EntitlementNotFoundError",
@@ -25,11 +26,24 @@ __all__ = [
 ]
 
 
-class EntitlementNotEnabledError(UserFacingError):
-    """An exception raised when enabling of an entitlement fails"""
+class EntitlementsNotEnabledError(UserFacingError):
+    def __init__(
+        self, failed_services: List[Tuple[str, messages.NamedMessage]]
+    ):
+        info_dicts = [
+            {"name": f[0], "code": f[1].name, "title": f[1].msg}
+            for f in failed_services
+        ]
+        super().__init__(
+            messages.ENTITLEMENTS_NOT_ENABLED_ERROR.msg,
+            messages.ENTITLEMENTS_NOT_ENABLED_ERROR.name,
+            additional_info={"services": info_dicts},
+        )
 
-    pass
 
-
-class IncompatibleEntitlementsDetected(UserFacingError):
-    pass
+class AutoAttachDisabledError(UserFacingError):
+    def __init__(self):
+        super().__init__(
+            messages.AUTO_ATTACH_DISABLED_ERROR.msg,
+            messages.AUTO_ATTACH_DISABLED_ERROR.name,
+        )

--- a/uaclient/api/tests/test_u_pro_attach_auto_full_auto_attach_v1.py
+++ b/uaclient/api/tests/test_u_pro_attach_auto_full_auto_attach_v1.py
@@ -1,115 +1,163 @@
 import mock
 import pytest
 
+from uaclient import messages
 from uaclient.api import exceptions
 from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
     FullAutoAttachOptions,
+    FullAutoAttachResult,
+    _enable_services_by_name,
     _full_auto_attach,
-    _is_incompatible_services_present,
+    _full_auto_attach_in_lock,
 )
 from uaclient.entitlements.entitlement_status import (
     CanEnableFailure,
     CanEnableFailureReason,
 )
-from uaclient.messages import NamedMessage
+from uaclient.testing.helpers import does_not_raise
 
-M_API = "uaclient.api.u.pro."
+M_PATH = "uaclient.api.u.pro.attach.auto.full_auto_attach.v1."
+
+
+class TestEnableServicesByName:
+    @pytest.mark.parametrize(
+        [
+            "services",
+            "allow_beta",
+            "enable_side_effect",
+            "expected_enable_call_args",
+            "expected_ret",
+        ],
+        [
+            # success one service, allow beta
+            (
+                ["esm-infra"],
+                True,
+                [(True, None)],
+                [
+                    mock.call(
+                        mock.ANY, "esm-infra", assume_yes=True, allow_beta=True
+                    )
+                ],
+                [],
+            ),
+            # success multi service, no allow beta
+            (
+                ["esm-apps", "esm-infra", "livepatch"],
+                False,
+                [(True, None), (True, None), (True, None)],
+                [
+                    mock.call(
+                        mock.ANY, "esm-apps", assume_yes=True, allow_beta=False
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "esm-infra",
+                        assume_yes=True,
+                        allow_beta=False,
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "livepatch",
+                        assume_yes=True,
+                        allow_beta=False,
+                    ),
+                ],
+                [],
+            ),
+            # fail via user facing error
+            (
+                ["esm-apps", "esm-infra", "livepatch"],
+                False,
+                [
+                    (True, None),
+                    exceptions.UserFacingError("msg"),
+                    exceptions.UserFacingError("msg", "code"),
+                ],
+                [
+                    mock.call(
+                        mock.ANY, "esm-apps", assume_yes=True, allow_beta=False
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "esm-infra",
+                        assume_yes=True,
+                        allow_beta=False,
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "livepatch",
+                        assume_yes=True,
+                        allow_beta=False,
+                    ),
+                ],
+                [
+                    ("esm-infra", messages.NamedMessage("unknown", "msg")),
+                    ("livepatch", messages.NamedMessage("code", "msg")),
+                ],
+            ),
+            # fail via return
+            (
+                ["esm-apps", "esm-infra", "livepatch"],
+                False,
+                [
+                    (True, None),
+                    (False, None),
+                    (
+                        False,
+                        CanEnableFailure(
+                            CanEnableFailureReason.ALREADY_ENABLED,
+                            messages.NamedMessage("test", "test"),
+                        ),
+                    ),
+                ],
+                [
+                    mock.call(
+                        mock.ANY, "esm-apps", assume_yes=True, allow_beta=False
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "esm-infra",
+                        assume_yes=True,
+                        allow_beta=False,
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "livepatch",
+                        assume_yes=True,
+                        allow_beta=False,
+                    ),
+                ],
+                [
+                    (
+                        "esm-infra",
+                        messages.NamedMessage("unknown", "failed to enable"),
+                    ),
+                    ("livepatch", messages.NamedMessage("test", "test")),
+                ],
+            ),
+        ],
+    )
+    @mock.patch(M_PATH + "actions.enable_entitlement_by_name")
+    def test_enable_services_by_name(
+        self,
+        m_enable_entitlement_by_name,
+        services,
+        allow_beta,
+        enable_side_effect,
+        expected_enable_call_args,
+        expected_ret,
+    ):
+        m_enable_entitlement_by_name.side_effect = enable_side_effect
+        ret = _enable_services_by_name(mock.MagicMock(), services, allow_beta)
+        assert (
+            m_enable_entitlement_by_name.call_args_list
+            == expected_enable_call_args
+        )
+        assert ret == expected_ret
 
 
 class TestFullAutoAttachV1:
-    @mock.patch(
-        "uaclient.actions.enable_entitlement_by_name",
-        return_value=(True, None),
-    )
-    def test_error_when_beta_in_enable_list(
-        self,
-        enable_ent_by_name,
-        FakeConfig,
-    ):
-        cfg = FakeConfig(root_mode=True)
-        options = FullAutoAttachOptions(
-            enable=["esm-infra", "realtime-kernel"]
-        )
-        with pytest.raises(exceptions.BetaServiceError):
-            _full_auto_attach(options, cfg)
-
-        assert 0 == enable_ent_by_name.call_count
-
-    @mock.patch(
-        "uaclient.actions.enable_entitlement_by_name",
-        return_value=(True, None),
-    )
-    @mock.patch("uaclient.actions.get_cloud_instance")
-    @mock.patch("uaclient.actions.auto_attach")
-    def test_error_invalid_ent_names(
-        self,
-        _auto_attach,
-        _get_cloud_instance,
-        enable_ent_by_name,
-        FakeConfig,
-    ):
-        cfg = FakeConfig(root_mode=True)
-        options = FullAutoAttachOptions(
-            enable=["esm-infra", "cis"],
-            enable_beta=["esm-apps", "realtime-kernel", "test", "wrong"],
-        )
-        with pytest.raises(exceptions.EntitlementNotFoundError):
-            _full_auto_attach(options, cfg)
-
-        assert 0 == enable_ent_by_name.call_count
-
-    @mock.patch(
-        "uaclient.actions.enable_entitlement_by_name",
-        return_value=(
-            False,
-            CanEnableFailure(
-                CanEnableFailureReason.ALREADY_ENABLED,
-                NamedMessage("test", "test"),
-            ),
-        ),
-    )
-    @mock.patch("uaclient.actions.get_cloud_instance")
-    @mock.patch("uaclient.actions.auto_attach")
-    def test_error_ent_not_enabled(
-        self,
-        _auto_attach,
-        _get_cloud_instance,
-        enable_ent_by_name,
-        FakeConfig,
-    ):
-        cfg = FakeConfig(root_mode=True)
-        options = FullAutoAttachOptions(
-            enable=["esm-infra", "cis"],
-            enable_beta=["esm-apps", "realtime-kernel"],
-        )
-        with pytest.raises(exceptions.EntitlementNotEnabledError):
-            _full_auto_attach(options, cfg)
-
-        assert 1 == enable_ent_by_name.call_count
-
-    @mock.patch(
-        "uaclient.actions.enable_entitlement_by_name",
-        return_value=(False, None),
-    )
-    @mock.patch("uaclient.actions.get_cloud_instance")
-    @mock.patch("uaclient.actions.auto_attach")
-    def test_error_full_auto_attach_fail(
-        self,
-        _auto_attach,
-        _get_cloud_instance,
-        enable_ent_by_name,
-        FakeConfig,
-    ):
-        cfg = FakeConfig(root_mode=True)
-        options = FullAutoAttachOptions(
-            enable=["esm-infra", "fips"],
-            enable_beta=["esm-apps", "ros"],
-        )
-        with pytest.raises(exceptions.EntitlementNotEnabledError):
-            _full_auto_attach(options, cfg)
-
-        assert 1 == enable_ent_by_name.call_count
-
     @mock.patch(
         "uaclient.lock.SpinLock.__enter__",
         side_effect=[
@@ -120,52 +168,153 @@ class TestFullAutoAttachV1:
         with pytest.raises(exceptions.LockHeldError):
             _full_auto_attach(FullAutoAttachOptions, FakeConfig())
 
-    def test_error_incompatible_services(
+    @pytest.mark.parametrize(
+        [
+            "options",
+            "is_attached",
+            "is_disabled",
+            "expected_auto_attach_call_args",
+            "enable_services_by_name_side_effect",
+            "expected_enable_services_by_name_call_args",
+            "raise_expectation",
+            "expected_error_message",
+            "expected_ret",
+        ],
+        [
+            # already attached
+            (
+                FullAutoAttachOptions(),
+                True,
+                False,
+                [],
+                [],
+                [],
+                pytest.raises(exceptions.AlreadyAttachedError),
+                messages.ALREADY_ATTACHED.format(
+                    account_name="test_account"
+                ).msg,
+                None,
+            ),
+            # disable_auto_attach: true
+            (
+                FullAutoAttachOptions(),
+                False,
+                True,
+                [],
+                [],
+                [],
+                pytest.raises(exceptions.AutoAttachDisabledError),
+                messages.AUTO_ATTACH_DISABLED_ERROR.msg,
+                None,
+            ),
+            # success no options
+            (
+                FullAutoAttachOptions(),
+                False,
+                False,
+                [mock.call(mock.ANY, mock.ANY, allow_enable=True)],
+                [],
+                [],
+                does_not_raise(),
+                None,
+                FullAutoAttachResult(),
+            ),
+            # success enable
+            (
+                FullAutoAttachOptions(enable=["cis"]),
+                False,
+                False,
+                [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
+                [[]],
+                [mock.call(mock.ANY, ["cis"], allow_beta=False)],
+                does_not_raise(),
+                None,
+                FullAutoAttachResult(),
+            ),
+            # success enable_beta
+            (
+                FullAutoAttachOptions(enable_beta=["cis"]),
+                False,
+                False,
+                [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
+                [[]],
+                [mock.call(mock.ANY, ["cis"], allow_beta=True)],
+                does_not_raise(),
+                None,
+                FullAutoAttachResult(),
+            ),
+            # success enable and enable_beta
+            (
+                FullAutoAttachOptions(enable=["fips"], enable_beta=["cis"]),
+                False,
+                False,
+                [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
+                [[], []],
+                [
+                    mock.call(mock.ANY, ["fips"], allow_beta=False),
+                    mock.call(mock.ANY, ["cis"], allow_beta=True),
+                ],
+                does_not_raise(),
+                None,
+                FullAutoAttachResult(),
+            ),
+            # fail to enable
+            (
+                FullAutoAttachOptions(enable=["fips"], enable_beta=["cis"]),
+                False,
+                False,
+                [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
+                [
+                    [("fips", messages.NamedMessage("one", "two"))],
+                    [("cis", messages.NamedMessage("three", "four"))],
+                ],
+                [
+                    mock.call(mock.ANY, ["fips"], allow_beta=False),
+                    mock.call(mock.ANY, ["cis"], allow_beta=True),
+                ],
+                pytest.raises(exceptions.EntitlementsNotEnabledError),
+                messages.ENTITLEMENTS_NOT_ENABLED_ERROR.msg,
+                None,
+            ),
+        ],
+    )
+    @mock.patch(M_PATH + "_enable_services_by_name")
+    @mock.patch(M_PATH + "actions.auto_attach")
+    @mock.patch(M_PATH + "actions.get_cloud_instance")
+    @mock.patch(M_PATH + "util.is_config_value_true")
+    def test_full_auto_attach_v1(
         self,
+        m_is_config_value_true,
+        m_get_cloud_instance,
+        m_auto_attach,
+        m_enable_services_by_name,
+        options,
+        is_attached,
+        is_disabled,
+        expected_auto_attach_call_args,
+        enable_services_by_name_side_effect,
+        expected_enable_services_by_name_call_args,
+        raise_expectation,
+        expected_error_message,
+        expected_ret,
         FakeConfig,
     ):
-        cfg = FakeConfig(root_mode=True)
-        options = FullAutoAttachOptions(
-            enable=["esm-infra", "fips"],
-            enable_beta=["esm-apps", "livepatch"],
+        if is_attached:
+            cfg = FakeConfig.for_attached_machine()
+        else:
+            cfg = FakeConfig()
+        m_is_config_value_true.return_value = is_disabled
+        m_enable_services_by_name.side_effect = (
+            enable_services_by_name_side_effect
         )
-        with pytest.raises(exceptions.IncompatibleEntitlementsDetected) as e:
-            _full_auto_attach(options, cfg)
-
-        expected_info = {
-            "service": "fips",
-            "incompatible_services": "livepatch,fips-updates,realtime-kernel",
-        }
-
-        assert expected_info == e.value.additional_info
-
-    @pytest.mark.parametrize(
-        "ent_list,service,incompatible_services,detected",
-        (
-            (
-                ["fips", "esm-infra", "fips-updates", "esm-apps"],
-                "fips",
-                ["livepatch", "fips-updates", "realtime-kernel"],
-                True,
-            ),
-            (
-                ["fips-updates", "esm-infra", "realtime-kernel", "esm-apps"],
-                "fips-updates",
-                ["fips", "realtime-kernel"],
-                True,
-            ),
-            (
-                ["livepatch", "esm-infra", "esm-apps"],
-                "",
-                [],
-                False,
-            ),
-        ),
-    )
-    def test_incompatible_services(
-        self, ent_list, service, incompatible_services, detected, FakeConfig
-    ):
-        res = _is_incompatible_services_present(FakeConfig(), ent_list)
-        assert detected == res[0]
-        assert service == res[1]
-        assert incompatible_services == res[2]
+        with raise_expectation as e:
+            ret = _full_auto_attach_in_lock(options, cfg)
+        assert m_auto_attach.call_args_list == expected_auto_attach_call_args
+        assert (
+            m_enable_services_by_name.call_args_list
+            == expected_enable_services_by_name_call_args
+        )
+        if expected_error_message is not None:
+            assert e.value.msg == expected_error_message
+        if expected_ret is not None:
+            assert ret == expected_ret

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -1,11 +1,12 @@
 from typing import List, Optional, Tuple
 
-from uaclient import actions, entitlements, event_logger, lock
+from uaclient import actions, event_logger, lock, messages, util
 from uaclient.api import exceptions
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.config import UAConfig
 from uaclient.data_types import DataObject, Field, StringDataValue, data_list
+from uaclient.entitlements import entitlements_enable_order
 from uaclient.entitlements.entitlement_status import CanEnableFailure
 
 event = event_logger.get_event_logger()
@@ -30,34 +31,37 @@ class FullAutoAttachResult(DataObject, AdditionalInfo):
     pass
 
 
-def _is_any_beta(cfg: UAConfig, ents: List[str]) -> Tuple[bool, str]:
-    for name in ents:
-        try:
-            ent_cls = entitlements.entitlement_factory(cfg, name)
-            if ent_cls.is_beta:
-                return True, name
-        except exceptions.EntitlementNotFoundError:
+def _enable_services_by_name(
+    cfg: UAConfig, services: List[str], allow_beta: bool
+) -> List[Tuple[str, messages.NamedMessage]]:
+    failed_services = []
+    for name in entitlements_enable_order(cfg):
+        if name not in services:
             continue
-    return False, ""
-
-
-def _is_incompatible_services_present(
-    cfg, ent_list: List[str]
-) -> Tuple[bool, str, List[str]]:
-    ent_cls = []
-    for e in ent_list:
-        ent_cls.append(entitlements.entitlement_factory(cfg, e))
-
-    for ent in ent_cls:
-        ent_inst = ent(cfg)
-        if ent_inst.incompatible_services:
-            incompat = [
-                service.entitlement
-                for service in ent_inst.incompatible_services
-            ]
-            if any(e in incompat for e in ent_cls):
-                return True, ent_inst.name, [e(cfg).name for e in incompat]
-    return False, "", []
+        try:
+            ent_ret, reason = actions.enable_entitlement_by_name(
+                cfg, name, assume_yes=True, allow_beta=allow_beta
+            )
+        except exceptions.UserFacingError as e:
+            failed_services.append(
+                (name, messages.NamedMessage(e.msg_code or "unknown", e.msg))
+            )
+            continue
+        if not ent_ret:
+            if (
+                reason is not None
+                and isinstance(reason, CanEnableFailure)
+                and reason.message is not None
+            ):
+                failed_services.append((name, reason.message))
+            else:
+                failed_services.append(
+                    (
+                        name,
+                        messages.NamedMessage("unknown", "failed to enable"),
+                    )
+                )
+    return failed_services
 
 
 def full_auto_attach(options: FullAutoAttachOptions) -> FullAutoAttachResult:
@@ -89,71 +93,29 @@ def _full_auto_attach_in_lock(
             cfg.machine_token_file.account.get("name", "")
         )
 
-    services = set()
-    if options.enable:
-        is_beta_found, service = _is_any_beta(cfg, options.enable)
-        if is_beta_found:
-            raise exceptions.BetaServiceError(
-                msg="beta service found in the enable list",
-                msg_code="beta-service-found",
-                additional_info={"beta_service": service},
-            )
-        services.update(options.enable)
-    if options.enable_beta:
-        services.update(options.enable_beta)
-
-    service_list = list(services)
-
-    found, not_found = entitlements.get_valid_entitlement_names(
-        service_list, cfg
-    )
-    if not_found:
-        raise exceptions.EntitlementNotFoundError(", ".join(not_found))
-
-    incompat_detected, ent, incompat_ents = _is_incompatible_services_present(
-        cfg, sorted(found)
-    )  # sort for easy testing exceptions raised
-    if incompat_detected:
-        err_msg = "{ent} is incompatible with any of these services {incompat}"
-        raise exceptions.IncompatibleEntitlementsDetected(
-            msg=err_msg.format(ent=ent, incompat=incompat_ents),
-            msg_code="incompatible-services-detected",
-            additional_info={
-                "service": ent,
-                "incompatible_services": ",".join(incompat_ents),
-            },
-        )
+    if util.is_config_value_true(
+        config=cfg.cfg, path_to_value="features.disable_auto_attach"
+    ):
+        raise exceptions.AutoAttachDisabledError()
 
     instance = actions.get_cloud_instance(cfg)
     enable_default_services = (
         options.enable is None and options.enable_beta is None
     )
-    actions.auto_attach(cfg, instance, enable_default_services)
+    actions.auto_attach(cfg, instance, allow_enable=enable_default_services)
 
-    if enable_default_services:
-        return FullAutoAttachResult()
-
-    for name in found:
-        ent_ret, reason = actions.enable_entitlement_by_name(
-            cfg, name, assume_yes=True, allow_beta=True
+    failed = []
+    if options.enable is not None:
+        failed += _enable_services_by_name(
+            cfg, options.enable, allow_beta=False
         )
-        if not ent_ret:
-            if (
-                reason is not None
-                and isinstance(reason, CanEnableFailure)
-                and reason.message is not None
-            ):
-                raise exceptions.EntitlementNotEnabledError(
-                    msg=reason.message.msg,
-                    msg_code=reason.message.name,
-                    additional_info={"service": name},
-                )
-            else:
-                raise exceptions.EntitlementNotEnabledError(
-                    msg="Failed to enable service: {}".format(name),
-                    msg_code="entitlement-not-enabled",
-                    additional_info={"service": name},
-                )
+    if options.enable_beta is not None:
+        failed += _enable_services_by_name(
+            cfg, options.enable_beta, allow_beta=True
+        )
+
+    if len(failed) > 0:
+        raise exceptions.EntitlementsNotEnabledError(failed)
 
     return FullAutoAttachResult()
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from urllib import error
 
 from uaclient import messages
@@ -21,7 +21,7 @@ class UserFacingError(Exception):
         self,
         msg: str,
         msg_code: Optional[str] = None,
-        additional_info: Optional[Dict[str, str]] = None,
+        additional_info: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.msg = msg
         self.msg_code = msg_code
@@ -129,19 +129,6 @@ class ProxyInvalidUrl(UserFacingError):
             msg=messages.NOT_SETTING_PROXY_INVALID_URL.format(proxy=proxy).msg,
             msg_code=messages.NOT_SETTING_PROXY_INVALID_URL.name,
         )
-
-
-class BetaServiceError(UserFacingError):
-    """
-    An exception to be raised trying to interact with beta service
-    without the right parameters.
-
-    :param msg:
-        Takes a single parameter, which is the beta service error message that
-        should be emitted before exiting non-zero.
-    """
-
-    pass
 
 
 class NonAutoAttachImageError(UserFacingError):

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -12,6 +12,20 @@ class NamedMessage:
         # useful if the message represents an error.
         self.additional_info = None  # type: Optional[Dict[str, str]]
 
+    def __eq__(self, other):
+        return (
+            self.msg == other.msg
+            and self.name == other.name
+            and self.additional_info == other.additional_info
+        )
+
+    def __repr__(self):
+        return "NamedMessage({}, {}, {})".format(
+            self.name.__repr__(),
+            self.msg.__repr__(),
+            self.additional_info.__repr__(),
+        )
+
 
 class FormattedNamedMessage(NamedMessage):
     def __init__(self, name: str, msg: str):
@@ -1041,3 +1055,13 @@ Try Ubuntu Pro beta with a free personal subscription on up to 5 machines.
 Learn more at https://ubuntu.com/pro"""
 
 INVALID_STATE_FILE = "Invalid state file: {}"
+
+ENTITLEMENTS_NOT_ENABLED_ERROR = NamedMessage(
+    "entitlements-not-enabled",
+    "failed to enable some services",
+)
+
+AUTO_ATTACH_DISABLED_ERROR = NamedMessage(
+    "auto-attach-disabled",
+    "features.disable_auto_attach set in config",
+)

--- a/uaclient/testing/helpers.py
+++ b/uaclient/testing/helpers.py
@@ -1,0 +1,23 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def does_not_raise():
+    """Context manager to parametrize tests raising and not raising exceptions
+    Note: In python-3.7+, this can be substituted by contextlib.nullcontext
+    More info:
+    https://docs.pytest.org/en/6.2.x/example/parametrize.html?highlight=does_not_raise#parametrizing-conditional-raising
+    Example:
+    --------
+    >>> @pytest.mark.parametrize(
+    >>>     "example_input,expectation",
+    >>>     [
+    >>>         (1, does_not_raise()),
+    >>>         (0, pytest.raises(ZeroDivisionError)),
+    >>>     ],
+    >>> )
+    >>> def test_division(example_input, expectation):
+    >>>     with expectation:
+    >>>         assert (0 / example_input) is not None
+    """
+    yield


### PR DESCRIPTION
full_auto_attach.v1 will no longer raise exceptions about invalid
arguments before attempting to attach. Instead it will attempt to auto
attach and enable all services. If any services fail, they will all be
reported in a single error.

This also adds a check for the disable_auto_attach configuration and
raises an error if that is true before the attempt to attach.

This is technically a breaking change, but because we caught this early
and we know of the only current consumer of this function we can make it
safely without bumping the version.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
everything should still pass

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly
