### PR TITLE
tests: install uat with commands instead of user-data

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -104,7 +104,7 @@ jobs:
           UACLIENT_BEHAVE_DEBS_PATH: '${{ runner.temp }}'
           UACLIENT_BEHAVE_ARTIFACT_DIR: '${{ runner.temp }}/artifacts/behave-${{ matrix.platform }}-${{ matrix.release }}'
           UACLIENT_BEHAVE_SNAPSHOT_STRATEGY: '1'
-          UACLIENT_BEHAVE_INSTALL_FROM: 'local'
+          UACLIENT_BEHAVE_INSTALL_FROM: 'prebuilt'
           UACLIENT_BEHAVE_CONTRACT_TOKEN: '${{ secrets.UACLIENT_BEHAVE_CONTRACT_TOKEN }}'
           UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING: '${{ secrets.UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING }}'
           UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED: '${{ secrets.UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED }}'

--- a/dev-docs/howtoguides/testing.md
+++ b/dev-docs/howtoguides/testing.md
@@ -126,14 +126,6 @@ image build step).
 performed in `features/environment.py`, so don't expect to find
 documentation about it outside of this codebase.)
 
-For development purposes there is `reuse_container` option.
-If you would like to run behave tests in an existing container
-you need to add `-D reuse_container=container_name`:
-
-```sh
-tox -e behave -D reuse_container=container_name
-```
-
 ## Optimizing total run time of integration tests with snapshots
 When `UACLIENT_BEHAVE_SNAPSHOT_STRATEGY=1` we create a snapshot of an instance
 with ubuntu-advantage-tools installed and restore from that snapshot for all tests.

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -6,8 +6,8 @@ Feature: Performing attach using ua-airgapped
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
         # set up the apt mirror configuration
-        When I launch a `jammy` `mirror` machine
-        And I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `mirror` machine
+        Given a `jammy` machine named `mirror`
+        When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `mirror` machine
         And I run `apt-get update` `with sudo` on the `mirror` machine
         And I run `apt-get install apt-mirror get-resource-tokens ua-airgapped -yq` `with sudo` on the `mirror` machine
         And I download the service credentials on the `mirror` machine
@@ -21,8 +21,8 @@ Feature: Performing attach using ua-airgapped
         And I create the contract config overrides file for `esm-infra,esm-apps` on the `mirror` machine
         And I generate the contracts-airgapped configuration on the `mirror` machine
         # set up the contracts-airgapped configuration
-        When I launch a `jammy` `contracts` machine
-        And I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `contracts` machine
+        Given a `jammy` machine named `contracts`
+        When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `contracts` machine
         And I run `apt-get update` `with sudo` on the `contracts` machine
         And I run `apt-get install contracts-airgapped -yq` `with sudo` on the `contracts` machine
         And I run `apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4067E40313CB4B13` `with sudo` on the `contracts` machine

--- a/features/cloud_pro_clone.feature
+++ b/features/cloud_pro_clone.feature
@@ -34,7 +34,7 @@ Feature: Creating golden images based on Cloud Ubuntu Pro instances
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         Then I verify that `activityInfo.activityToken` value has been updated on the contract
         Then I verify that `activityInfo.activityID` value has not been updated on the contract
-        When I launch a `clone` machine from the snapshot
+        When I launch a `<release>` machine named `clone` from the snapshot of `system-under-test`
         # The clone will run auto-attach on boot
         When I run `pro status --wait` `with sudo` on the `clone` machine
         When I run `pro status --format yaml` `with sudo` on the `clone` machine

--- a/features/environment.py
+++ b/features/environment.py
@@ -6,57 +6,14 @@ import random
 import re
 import string
 import sys
-import textwrap
 from typing import Dict, List, Optional, Tuple, Union  # noqa: F401
 
-import pycloudlib  # type: ignore
+import pycloudlib  # type: ignore  # noqa: F401
 from behave.model import Feature, Scenario
 from behave.runner import Context
 
 import features.cloud as cloud
-from features.util import InstallationSource, build_debs, lxc_get_property
-
-ALL_SUPPORTED_SERIES = ["bionic", "focal", "xenial"]
-
-UA_PPA_TEMPLATE = "http://ppa.launchpad.net/ua-client/{}/ubuntu"
-DEFAULT_UA_PPA_KEYID = "6E34E7116C0BC933"
-
-USERDATA_BLOCK_AUTO_ATTACH_IMG = """\
-#cloud-config
-"""
-
-# we can't use write_files because it will clash with the
-# lxd vendor-data write_files that is necessary to set up
-# the lxd_agent on some releases
-USERDATA_RUNCMD_PIN_PPA = """\
-runcmd:
-  - "printf \\"Package: *\\nPin: release o=LP-PPA-ua-client-{}\\nPin-Priority: 1001\\n\\" > /etc/apt/preferences.d/uaclient"
-"""  # noqa: E501
-
-USERDATA_RUNCMD_ENABLE_PROPOSED = """
-runcmd:
-  - printf \"deb http://archive.ubuntu.com/ubuntu/ {series}-proposed main\" > /etc/apt/sources.list.d/uaclient-proposed.list
-  - printf \"deb http://archive.ubuntu.com/ubuntu/ {series}-proposed universe\" > /etc/apt/sources.list.d/uaclient-proposed-universe.list
-  - "printf \\"Package: *\\nPin: release a={series}-proposed\\nPin-Priority: 400\\n\\" > /etc/apt/preferences.d/lower-proposed"
-  - "printf \\"Package: ubuntu-advantage-tools\\nPin: release a={series}-proposed\\nPin-Priority: 1001\\n\\" > /etc/apt/preferences.d/uaclient-proposed"
-  - "printf \\"Package: ubuntu-advantage-pro\\nPin: release a={series}-proposed\\nPin-Priority: 1001\\n\\" > /etc/apt/preferences.d/uaclientpro-proposed"
-"""  # noqa: E501
-
-USERDATA_APT_SOURCE_PPA = """\
-apt:
-  sources:
-    ua-tools-ppa:
-        source: deb {ppa_url} $RELEASE main
-        keyid: {ppa_keyid}
-"""
-
-PROCESS_LOG_TMPL = """\
-returncode: {}
-stdout:
-{stdout}
-stderr:
-{stderr}
-"""
+from features.util import SUT, InstallationSource, lxc_get_property
 
 PROCESS_LOG_TMPL = """\
 returncode: {returncode}
@@ -126,11 +83,10 @@ class UAClientBehaveConfig:
         "private_key_file",
         "private_key_name",
         "reuse_image",
-        "debs_path",
         "artifact_dir",
         "install_from",
         "custom_ppa",
-        "custom_ppa_keyid",
+        "debs_path",
         "userdata_file",
         "check_version",
         "sbuild_chroot",
@@ -162,11 +118,10 @@ class UAClientBehaveConfig:
         contract_token: Optional[str] = None,
         contract_token_staging: Optional[str] = None,
         contract_token_staging_expired: Optional[str] = None,
-        debs_path: Optional[str] = None,
         artifact_dir: Optional[str] = None,
         install_from: InstallationSource = InstallationSource.DAILY,
         custom_ppa: Optional[str] = None,
-        custom_ppa_keyid: Optional[str] = None,
+        debs_path: Optional[str] = None,
         userdata_file: Optional[str] = None,
         check_version: Optional[str] = None,
         sbuild_chroot: Optional[str] = None,
@@ -186,11 +141,10 @@ class UAClientBehaveConfig:
         self.private_key_name = private_key_name
         self.reuse_image = reuse_image
         self.cmdline_tags = cmdline_tags
-        self.debs_path = debs_path
         self.artifact_dir = artifact_dir
         self.install_from = install_from
         self.custom_ppa = custom_ppa
-        self.custom_ppa_keyid = custom_ppa_keyid
+        self.debs_path = debs_path
         self.userdata_file = userdata_file
         self.check_version = check_version
         self.sbuild_chroot = sbuild_chroot
@@ -202,6 +156,19 @@ class UAClientBehaveConfig:
             ]
         )
         # Next, perform any required validation
+        if install_from == InstallationSource.CUSTOM and not custom_ppa:
+            logging.error(
+                "UACLIENT_BEHAVE_INSTALL_FROM is set to 'custom', "
+                "but missing UACLIENT_BEHAVE_CUSTOM_PPA"
+            )
+            sys.exit(1)
+        if install_from == InstallationSource.PREBUILT and not debs_path:
+            logging.error(
+                "UACLIENT_BEHAVE_INSTALL_FROM is set to 'prebuilt', "
+                "but missing UACLIENT_BEHAVE_DEBS_PATH"
+            )
+            sys.exit(1)
+
         if self.reuse_image is not None:
             if self.image_clean:
                 print(" Reuse_image specified, it will not be deleted.")
@@ -357,9 +324,10 @@ def before_all(context: Context) -> None:
             print("   - {} = {}".format(key, value))
     context.series_image_name = {}
     context.series_reuse_image = ""
-    context.reuse_container = {}
     context.config = UAClientBehaveConfig.from_environ(context.config)
     context.config.cloud_manager.manage_ssh_key()
+    context.snapshots = {}
+    context.machines = {}
 
     if context.config.reuse_image:
         series = lxc_get_property(
@@ -378,26 +346,6 @@ def before_all(context: Context) -> None:
         else:
             print(" Could not check image series. It will not be used. ")
             context.config.reuse_image = None
-
-    if userdata.get("reuse_container"):
-        inst = context.config.cloud_api.get_instance(
-            userdata.get("reuse_container")
-        )
-        codename = inst.execute(
-            ["grep", "UBUNTU_CODENAME", "/etc/os-release"]
-        ).strip()
-        [_, series] = codename.split("=")
-
-        context.reuse_container = {series: userdata.get("reuse_container")}
-        print(
-            textwrap.dedent(
-                """
-            You are providing a {series} container. Make sure you are running
-            this series tests. For instance: --tags=series.{series}""".format(
-                    series=series
-                )
-            )
-        )
 
 
 def _should_skip_tags(context: Context, tags: List) -> str:
@@ -536,7 +484,7 @@ def after_step(context, step):
                     )
                 )
 
-        if hasattr(context, "instances"):
+        if hasattr(context, "machines") and SUT in context.machines:
             if not os.path.exists(artifacts_dir):
                 os.makedirs(artifacts_dir)
             for log_file in FAILURE_FILES:
@@ -547,7 +495,7 @@ def after_step(context, step):
                     "-- pull instance:{} {}".format(log_file, artifact_file)
                 )
                 try:
-                    result = context.instances["uaclient"].execute(
+                    result = context.machines[SUT].instance.execute(
                         ["cat", log_file], use_sudo=True
                     )
                     content = result.stdout if result.ok else ""
@@ -556,7 +504,7 @@ def after_step(context, step):
                 with open(artifact_file, "w") as stream:
                     stream.write(content)
             for artifact_file, cmd in FAILURE_CMDS.items():
-                result = context.instances["uaclient"].execute(
+                result = context.machines[SUT].instance.execute(
                     cmd, use_sudo=True
                 )
                 artifact_file = os.path.join(artifacts_dir, artifact_file)
@@ -585,277 +533,14 @@ def after_all(context):
                 "Failed to delete instance ssh keys:\n{}".format(str(e))
             )
 
-
-def capture_container_as_image(
-    container_id: str, image_name: str, cloud_api: pycloudlib.cloud.BaseCloud
-) -> str:
-    """Capture a container as an image.
-
-    :param container_id:
-        The id of the container to be captured.  Note that this container
-        will be stopped.
-    :param image_name:
-        The name under which the image should be published.
-    :param cloud_api: Optional pycloud BaseCloud api for applicable
-        machine_types.
-    """
-    logging.info(
-        "--- Creating  base image snapshot from vm {}".format(container_id)
-    )
-    inst = cloud_api.get_instance(container_id)
-    return cloud_api.snapshot(instance=inst)
-
-
-def build_debs_from_sbuild(context: Context, series: str) -> List[str]:
-    """Create a chroot and build the package using sbuild
-
-
-    Will stop the development instance after deb build succeeds.
-
-    :return: A list of paths to applicable deb files published.
-    """
-    deb_paths = []
-
-    if context.config.debs_path:
-        logging.info(
-            "--- Checking if debs can be reused in {}".format(
-                context.config.debs_path
+    if "builder" in context.snapshots:
+        try:
+            context.config.cloud_manager.api.delete_image(
+                context.snapshots["builder"]
             )
-        )
-        debs_path = context.config.debs_path
-        if os.path.isdir(debs_path):
-            deb_paths = [
-                os.path.join(debs_path, deb_file)
-                for deb_file in os.listdir(debs_path)
-                if series in deb_file
-            ]
-
-    if len(deb_paths):
-        logging.info("--- Reusing debs: {}".format(", ".join(deb_paths)))
-    else:
-        logging.info(
-            "--- Could not find any debs to reuse. Building it locally"
-        )
-        deb_paths = build_debs(
-            series=series,
-            chroot=context.config.sbuild_chroot,
-        )
-
-    if "pro" in context.config.machine_type:
-        return deb_paths
-    return deb_paths
-
-
-def create_instance_with_uat_installed(
-    context: Context,
-    series: str,
-    name: str,
-    custom_user_data: Optional[str] = None,
-) -> pycloudlib.instance.BaseInstance:
-    """Create a given series lxd image with ubuntu-advantage-tools installed
-
-    This will launch a container, install ubuntu-advantage-tools, and publish
-    the image. The image's name is stored in context.series_image_name for
-    use within step code.
-
-    :param context:
-        A `behave.runner.Context`;  this will have `series.image_name` set on
-        it.
-    :param series:
-       A string representing the series name to create
-    :param name:
-       A string representing the instance name
-    :param custom_user_data:
-       A string representing custom userdata to be added to the instance
-
-    :return: A pycloudlib Instance
-    """
-
-    if series in context.reuse_container:
-        logging.info(
-            "\n Reusing the existing container: ",
-            context.reuse_container[series],
-        )
-        return
-
-    user_data = _get_user_data_for_instance(context.config, series)
-
-    if custom_user_data:
-        prefix = "" if user_data else "#cloud-config"
-        user_data += "{}\n{}".format(prefix, custom_user_data)
-
-    logging.info(
-        "--- Launching VM to create a base image with ubuntu-advantage"
-    )
-    inst = context.config.cloud_manager.launch(
-        instance_name=name, series=series, user_data=user_data
-    )
-    instance_id = context.config.cloud_manager.get_instance_id(inst)
-
-    deb_paths = None
-    if context.config.install_from is InstallationSource.LOCAL:
-        deb_paths = build_debs_from_sbuild(context, series)
-
-    _install_uat_in_container(
-        instance_id,
-        series=series,
-        config=context.config,
-        machine_type=context.config.machine_type,
-        deb_paths=deb_paths,
-    )
-
-    return inst
-
-
-def _get_user_data_for_instance(
-    config: UAClientBehaveConfig, series: str
-) -> str:
-    if config.install_from in (
-        InstallationSource.ARCHIVE,
-        InstallationSource.LOCAL,
-    ):
-        return ""
-
-    user_data = "#cloud-config\n"
-
-    if "pro" in config.machine_type:
-        user_data = USERDATA_BLOCK_AUTO_ATTACH_IMG
-
-    if config.userdata_file and os.path.exists(config.userdata_file):
-        with open(config.userdata_file, "r") as stream:
-            user_data = stream.read()
-
-    if config.install_from is InstallationSource.PROPOSED:
-        user_data += USERDATA_RUNCMD_ENABLE_PROPOSED.format(series=series)
-        return user_data
-
-    if config.install_from is InstallationSource.DAILY:
-        user_data += USERDATA_RUNCMD_PIN_PPA.format("daily")
-        ppa = UA_PPA_TEMPLATE.format("daily")
-        ppa_keyid = DEFAULT_UA_PPA_KEYID
-    elif config.install_from is InstallationSource.STAGING:
-        user_data += USERDATA_RUNCMD_PIN_PPA.format("staging")
-        ppa = UA_PPA_TEMPLATE.format("staging")
-        ppa_keyid = DEFAULT_UA_PPA_KEYID
-    elif config.install_from is InstallationSource.STABLE:
-        user_data += USERDATA_RUNCMD_PIN_PPA.format("stable")
-        ppa = UA_PPA_TEMPLATE.format("stable")
-        ppa_keyid = DEFAULT_UA_PPA_KEYID
-    elif config.install_from is InstallationSource.CUSTOM:
-        if not config.custom_ppa or not config.custom_ppa_keyid:
+        except RuntimeError as e:
             logging.error(
-                "UACLIENT_BEHAVE_INSTALL_FROM is set to 'custom', "
-                + "but missing UACLIENT_BEHAVE_CUSTOM_PPA or "
-                + "UACLIENT_BEHAVE_CUSTOM_PPA_KEYID"
-            )
-            sys.exit(1)
-        ppa = config.custom_ppa
-        if ppa.startswith("ppa:"):
-            ppa = ppa.replace("ppa:", "http://ppa.launchpad.net/") + "/ubuntu"
-        ppa_keyid = config.custom_ppa_keyid or ""
-
-    user_data += USERDATA_APT_SOURCE_PPA.format(
-        ppa_url=ppa, ppa_keyid=ppa_keyid
-    )
-
-    logging.info("-- user data:\n" + user_data)
-    return user_data
-
-
-def _install_uat_in_container(
-    container_id: str,
-    series: str,
-    config: UAClientBehaveConfig,
-    machine_type: str,
-    deb_paths: Optional[List[str]] = None,
-) -> None:
-    """Install ubuntu-advantage-tools into the specified container
-
-    :param container_id:
-        The id of the container into which ubuntu-advantage-tools should be
-        installed.
-    :param series: The name of the series that is being used
-    :param config: UAClientBehaveConfig
-    :param deb_paths: Optional paths to local deb files we need to install
-    """
-    cmds = ["systemctl is-system-running --wait"]  # type:  List[str]
-
-    if deb_paths is None:
-        deb_paths = []
-
-    if deb_paths:
-        cmds.append("sudo apt-get update -qqy")
-
-        deb_files = []
-        inst = config.cloud_api.get_instance(container_id)
-
-        for deb_file in deb_paths:
-            if "pro" in deb_file and "pro" not in config.machine_type:
-                continue
-
-            deb_name = os.path.basename(deb_file)
-            deb_files.append("/tmp/" + deb_name)
-            inst.push_file(deb_file, "/tmp/" + deb_name)
-
-        cmds.append(
-            " ".join(
-                [
-                    "sudo",
-                    "DEBIAN_FRONTEND=noninteractive",
-                    "apt-get",
-                    "install",
-                    "-y",
-                    "--allow-downgrades",
-                    '-o Dpkg::Options::="--force-confdef"',
-                    '-o Dpkg::Options::="--force-confold"',
-                ]
-                + deb_files
-            )
-        )
-    else:
-        ua_pkg = ["ubuntu-advantage-tools"]
-        if "pro" in machine_type:
-            ua_pkg.append("ubuntu-advantage-pro")
-
-        cmds.append("sudo apt-get update")
-        cmds.append(
-            " ".join(
-                [
-                    "sudo",
-                    "DEBIAN_FRONTEND=noninteractive",
-                    "apt-get",
-                    "install",
-                    "-y",
-                    "--allow-downgrades",
-                    '-o Dpkg::Options::="--force-confdef"',
-                    '-o Dpkg::Options::="--force-confold"',
-                ]
-                + ua_pkg
-            )
-        )
-
-    if "pro" in config.machine_type:
-        features = "features:\n  disable_auto_attach: true\n"
-        conf_path = "/etc/ubuntu-advantage/uaclient.conf"
-        cmd = "printf '{}' > /var/tmp/uaclient.conf".format(features)
-        cmds.append('sh -c "{}"'.format(cmd))
-        cmds.append(
-            'sudo -- sh -c "cat /var/tmp/uaclient.conf >> {}"'.format(
-                conf_path
-            )
-        )
-        cmds.append("sudo pro status --wait")
-        cmds.append("sudo pro detach --assume-yes")
-
-    cmds.append("pro version")
-    instance = config.cloud_api.get_instance(container_id)
-    for cmd in cmds:  # type: ignore
-        result = instance.execute(cmd)
-        if result.failed:
-            logging.info(
-                "--- Failed {}: out {} err {}".format(
-                    cmd, result.stdout, result.stderr
+                "Failed to delete image: {}\n{}".format(
+                    context.snapshots["builder"], str(e)
                 )
             )
-        elif "version" in cmd:
-            logging.info("--- " + result)

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -33,6 +33,7 @@ Feature: Ua fix command behaviour
     @uses.config.machine_type.lxd.container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt-get update` with sudo
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
@@ -97,6 +98,7 @@ Feature: Ua fix command behaviour
     @uses.config.machine_type.lxd.container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt-get update` with sudo
         When I run `apt install -y libawl-php` with sudo
         And I reboot the machine
         And I verify that running `pro fix USN-4539-1` `as non-root` exits `1`
@@ -293,6 +295,7 @@ Feature: Ua fix command behaviour
     @uses.config.machine_type.lxd.container
     Scenario: Fix command on an unattached machine
         Given a `bionic` machine with ubuntu-advantage-tools installed
+        When I run `apt-get update` with sudo
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
         """

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -6,8 +6,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when proxy is configured for uaclient
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -165,8 +165,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attach command when proxy is configured
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -258,8 +258,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when authenticated proxy is configured for uaclient
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt update` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -355,8 +355,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attach command when authenticated proxy is configured
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt update` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -406,8 +406,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when proxy is configured manually via conf file for uaclient
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -555,8 +555,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when authenticated proxy is configured manually for uaclient
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt update` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -635,8 +635,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when proxy is configured globally
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -799,8 +799,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command when authenticated proxy is configured globally
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt update` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -899,8 +899,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: Get warning when configuring global or uaclient proxy
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -1050,8 +1050,8 @@ Feature: Proxy configuration
     @uses.config.machine_type.lxd.container
     Scenario Outline: apt_http(s)_proxy still works
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
         """
         dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -1190,8 +1190,8 @@ Feature: Proxy configuration
     Scenario: Enable realtime kernel through proxy on a machine with no internet
         Given a `jammy` machine with ubuntu-advantage-tools installed
         When I disable any internet connection on the machine
-        And I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all

--- a/features/steps/contract.py
+++ b/features/steps/contract.py
@@ -3,10 +3,8 @@ import datetime
 from behave import then, when
 from hamcrest import assert_that, equal_to, not_
 
-from features.steps.shell import (
-    when_i_run_command,
-    when_i_run_command_on_machine,
-)
+from features.steps.shell import when_i_run_command
+from features.util import SUT
 from uaclient.defaults import (
     DEFAULT_CONFIG_FILE,
     DEFAULT_PRIVATE_MACHINE_TOKEN_PATH,
@@ -82,21 +80,17 @@ def _get_saved_attr(context, key):
     return saved_value
 
 
-@then(
-    "I verify that `{key}` value has been updated on the contract on the `{machine}` machine"  # noqa: E501
-)
-def i_verify_that_key_value_has_been_updated_on_machine(context, key, machine):
-    i_verify_that_key_value_has_been_updated(context, key, machine)
-
-
 @then("I verify that `{key}` value has been updated on the contract")
-def i_verify_that_key_value_has_been_updated(context, key, machine="uaclient"):
+@then(
+    "I verify that `{key}` value has been updated on the contract on the `{machine_name}` machine"  # noqa: E501
+)
+def i_verify_that_key_value_has_been_updated(context, key, machine_name=SUT):
     saved_value = _get_saved_attr(context, key)
-    when_i_run_command_on_machine(
+    when_i_run_command(
         context,
         "jq -r '.{}' {}".format(key, DEFAULT_PRIVATE_MACHINE_TOKEN_PATH),
         "with sudo",
-        instance_name=machine,
+        machine_name=machine_name,
     )
     assert_that(context.process.stdout.strip(), not_(equal_to(saved_value)))
 

--- a/features/steps/network.py
+++ b/features/steps/network.py
@@ -1,74 +1,71 @@
 from behave import when
 
 from features.steps.shell import when_i_run_command
+from features.util import SUT
 
 
 @when("I disable any internet connection on the machine")
-def disable_internet_connection(context, instance_name="uaclient"):
+@when("I disable any internet connection on the `{machine_name}` machine")
+def disable_internet_connection(context, machine_name=SUT):
     when_i_run_command(
         context,
         "ufw default deny incoming",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw default deny outgoing",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw allow from 10.0.0.0/8",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw allow from 172.16.0.0/12",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw allow from 192.168.0.0/16",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw allow out to 10.0.0.0/8",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw allow out to 172.16.0.0/12",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
         context,
         "ufw allow out to 192.168.0.0/16",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
     )
     when_i_run_command(
-        context, "ufw allow ssh", "with sudo", instance_name=instance_name
+        context, "ufw allow ssh", "with sudo", machine_name=machine_name
     )
     # We expect DNS to be working, but don't really want to set a server up...
     when_i_run_command(
-        context, "ufw allow out 53", "with sudo", instance_name=instance_name
+        context, "ufw allow out 53", "with sudo", machine_name=machine_name
     )
     when_i_run_command(
         context,
         "ufw enable",
         "with sudo",
-        instance_name=instance_name,
+        machine_name=machine_name,
         stdin="y\n",
     )
-
-
-@when("I disable any internet connection on the `{machine}` machine")
-def disable_internet_connection_on_machine(context, machine):
-    disable_internet_connection(context, instance_name=machine)

--- a/features/steps/output.py
+++ b/features/steps/output.py
@@ -44,8 +44,10 @@ def then_stream_does_not_match_regexp(context, stream):
 def then_stream_matches_regexp(context, stream):
     content = getattr(context.process, stream).strip()
     text = context.text
-    if "<ci-proxy-ip>" in text and "proxy" in context.instances:
-        text = text.replace("<ci-proxy-ip>", context.instances["proxy"].ip)
+    if "<ci-proxy-ip>" in text and "proxy" in context.machines:
+        text = text.replace(
+            "<ci-proxy-ip>", context.machines["proxy"].instance.ip
+        )
     assert_that(content, matches_regexp(text))
 
 

--- a/features/steps/packages.py
+++ b/features/steps/packages.py
@@ -4,6 +4,29 @@ from behave import then, when
 from hamcrest import assert_that, contains_string, matches_regexp
 
 from features.steps.shell import when_i_run_command
+from features.util import SUT
+
+
+@when("I apt install `{package_name}`")
+def when_i_apt_install(context, package_name, machine_name=SUT):
+    when_i_run_command(
+        context,
+        " ".join(
+            [
+                "sudo",
+                "DEBIAN_FRONTEND=noninteractive",
+                "apt-get",
+                "install",
+                "-y",
+                "--allow-downgrades",
+                '-o Dpkg::Options::="--force-confdef"',
+                '-o Dpkg::Options::="--force-confold"',
+                package_name,
+            ]
+        ),
+        "with sudo",
+        machine_name=machine_name,
+    )
 
 
 @then("apt-cache policy for the following url has permission `{perm_id}`")
@@ -83,6 +106,7 @@ def when_i_install_packages(context):
     # The `gh` deb package is just installed locally,
     # and is then listed as unknown
     # https://github.com/cli/cli/releases
+    when_i_run_command(context, "apt-get update", "with sudo")
     when_i_run_command(
         context,
         (

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -1,37 +1,165 @@
 import logging
+import os
 import re
 
 from behave import when
 
-from features.environment import UA_PPA_TEMPLATE, build_debs_from_sbuild
-from features.steps.machines import launch_machine
-from features.steps.shell import (
-    when_i_run_command,
-    when_i_run_command_on_machine,
-    when_i_run_shell_command,
-)
-from features.util import InstallationSource
+from features.steps.files import when_i_create_file_with_content
+from features.steps.packages import when_i_apt_install
+from features.steps.shell import when_i_run_command, when_i_run_shell_command
+from features.util import SUT, InstallationSource, build_debs
+
+
+@when("I install ubuntu-advantage-tools")
+def when_i_install_uat(context, machine_name=SUT):
+    instance = context.machines[machine_name].instance
+    series = context.machines[machine_name].series
+    is_pro = "pro" in context.config.machine_type
+    if context.config.install_from is InstallationSource.ARCHIVE:
+        instance.execute("sudo apt update")
+        when_i_apt_install(
+            context, "ubuntu-advantage-tools", machine_name=machine_name
+        )
+        if is_pro:
+            when_i_apt_install(
+                context, "ubuntu-advantage-pro", machine_name=machine_name
+            )
+    elif context.config.install_from is InstallationSource.PREBUILT:
+        debs_path = context.config.debs_path
+        deb_paths = [
+            os.path.join(debs_path, deb_file)
+            for deb_file in os.listdir(debs_path)
+            if series in deb_file
+        ]
+        logging.info("using debs: {}".format(deb_paths))
+        for deb_path in deb_paths:
+            if "pro" not in deb_path or is_pro:
+                instance.push_file(deb_path, "/tmp/behave_ua.deb")
+                when_i_apt_install(
+                    context, "/tmp/behave_ua.deb", machine_name=machine_name
+                )
+                instance.execute("sudo rm /tmp/behave_ua.deb")
+    elif context.config.install_from is InstallationSource.LOCAL:
+        ua_deb_path, pro_deb_path = build_debs(series)
+        instance.push_file(ua_deb_path, "/tmp/behave_ua.deb")
+        when_i_apt_install(
+            context, "/tmp/behave_ua.deb", machine_name=machine_name
+        )
+        instance.execute("sudo rm /tmp/behave_ua.deb")
+        if is_pro:
+            instance.push_file(pro_deb_path, "/tmp/behave_ua.deb")
+            when_i_apt_install(
+                context, "/tmp/behave_ua.deb", machine_name=machine_name
+            )
+            instance.execute("sudo rm /tmp/behave_ua.deb")
+    elif context.config.install_from is InstallationSource.DAILY:
+        instance.execute("sudo add-apt-repository ppa:ua-client/daily")
+        instance.execute("sudo apt update")
+        when_i_apt_install(
+            context, "ubuntu-advantage-tools", machine_name=machine_name
+        )
+        if is_pro:
+            when_i_apt_install(
+                context, "ubuntu-advantage-pro", machine_name=machine_name
+            )
+    elif context.config.install_from is InstallationSource.STAGING:
+        instance.execute("sudo add-apt-repository ppa:ua-client/staging")
+        instance.execute("sudo apt update")
+        when_i_apt_install(
+            context, "ubuntu-advantage-tools", machine_name=machine_name
+        )
+        if is_pro:
+            when_i_apt_install(
+                context, "ubuntu-advantage-pro", machine_name=machine_name
+            )
+    elif context.config.install_from is InstallationSource.STABLE:
+        instance.execute("sudo add-apt-repository ppa:ua-client/stable")
+        instance.execute("sudo apt update")
+        when_i_apt_install(
+            context, "ubuntu-advantage-tools", machine_name=machine_name
+        )
+        if is_pro:
+            when_i_apt_install(
+                context, "ubuntu-advantage-pro", machine_name=machine_name
+            )
+    elif context.config.install_from is InstallationSource.PROPOSED:
+        context.text = "deb http://archive.ubuntu.com/ubuntu/ {series}-proposed main\n".format(  # noqa: E501
+            series=series
+        )
+        when_i_create_file_with_content(
+            context,
+            "/etc/apt/sources.list.d/uaclient-proposed.list",
+            machine_name=machine_name,
+        )
+
+        context.text = "Package: *\nPin: release a={series}-proposed\nPin-Priority: 400\n".format(  # noqa: E501
+            series=series
+        )
+        when_i_create_file_with_content(
+            context,
+            "/etc/apt/preferences.d/lower-proposed",
+            machine_name=machine_name,
+        )
+
+        context.text = "Package: ubuntu-advantage-tools\nPin: release a={series}-proposed\nPin-Priority: 1001\n".format(  # noqa: E501
+            series=series
+        )
+        when_i_create_file_with_content(
+            context,
+            "/etc/apt/preferences.d/uatools-proposed",
+            machine_name=machine_name,
+        )
+
+        context.text = "Package: ubuntu-advantage-pro\nPin: release a={series}-proposed\nPin-Priority: 1001\n".format(  # noqa: E501
+            series=series
+        )
+        when_i_create_file_with_content(
+            context,
+            "/etc/apt/preferences.d/uapro-proposed",
+            machine_name=machine_name,
+        )
+
+        instance.execute("sudo apt update")
+        when_i_apt_install(
+            context, "ubuntu-advantage-tools", machine_name=machine_name
+        )
+        if is_pro:
+            when_i_apt_install(
+                context, "ubuntu-advantage-pro", machine_name=machine_name
+            )
+    elif context.config.install_from is InstallationSource.CUSTOM:
+        instance.execute(
+            "sudo add-apt-repository {}".format(context.config.custom_ppa)
+        )
+        instance.execute("sudo apt update")
+        when_i_apt_install(
+            context, "ubuntu-advantage-tools", machine_name=machine_name
+        )
+        if is_pro:
+            when_i_apt_install(
+                context, "ubuntu-advantage-pro", machine_name=machine_name
+            )
 
 
 @when("I have the `{series}` debs under test in `{dest}`")
 def when_i_have_the_debs_under_test(context, series, dest):
     if context.config.install_from is InstallationSource.LOCAL:
-        deb_paths = build_debs_from_sbuild(context, series)
+        deb_paths = build_debs(context, series)
 
         for deb_path in deb_paths:
             tools_or_pro = "tools" if "tools" in deb_path else "pro"
             dest_path = "{}/ubuntu-advantage-{}.deb".format(dest, tools_or_pro)
-            context.instances["uaclient"].push_file(deb_path, dest_path)
+            context.machines[SUT].instance.push_file(deb_path, dest_path)
     else:
         if context.config.install_from is InstallationSource.PROPOSED:
             ppa_opts = ""
         else:
             if context.config.install_from is InstallationSource.DAILY:
-                ppa = UA_PPA_TEMPLATE.format("daily")
+                ppa = "ppa:ua-client/daily"
             elif context.config.install_from is InstallationSource.STAGING:
-                ppa = UA_PPA_TEMPLATE.format("staging")
+                ppa = "ppa:ua-client/staging"
             elif context.config.install_from is InstallationSource.STABLE:
-                ppa = UA_PPA_TEMPLATE.format("stable")
+                ppa = "ppa:ua-client/stable"
             elif context.config.install_from is InstallationSource.CUSTOM:
                 ppa = context.config.custom_ppa
                 if not ppa.startswith("ppa"):
@@ -72,60 +200,62 @@ def when_i_create_local_ppas(context, release, next_release):
     if context.config.install_from is not InstallationSource.LOCAL:
         return
 
+    from features.steps.machines import given_a_machine
+
     # We need Kinetic or greater to support zstd when creating the PPAs
-    launch_machine(context, "kinetic", "ppa")
-    when_i_run_command_on_machine(
-        context, "apt-get update", "with sudo", "ppa"
+    given_a_machine(context, "kinetic", "ppa")
+    when_i_run_command(
+        context, "apt-get update", "with sudo", machine_name="ppa"
     )
-    when_i_run_command_on_machine(
-        context, "apt-get install -y aptly", "with sudo", "ppa"
+    when_i_run_command(
+        context, "apt-get install -y aptly", "with sudo", machine_name="ppa"
     )
     create_local_ppa(context, release)
     create_local_ppa(context, next_release)
     repo_line = "deb [trusted=yes] http://{}:8080 {} main".format(
-        context.instances["ppa"].ip, release
+        context.machines["ppa"].instance.ip, release
     )
     repo_file = "/etc/apt/sources.list.d/local-ua.list"
     when_i_run_shell_command(
         context, "printf '{}\n' > {}".format(repo_line, repo_file), "with sudo"
     )
-    when_i_run_command_on_machine(
+    when_i_run_command(
         context,
         "sh -c 'nohup aptly serve > /dev/null 2>&1 &'",
         "with sudo",
-        "ppa",
+        machine_name="ppa",
     )
 
 
 def create_local_ppa(context, release):
-    when_i_run_command_on_machine(
+    when_i_run_command(
         context,
         "aptly repo create -distribution {} repo-{}".format(release, release),
         "with sudo",
-        "ppa",
+        machine_name="ppa",
     )
-    debs = build_debs_from_sbuild(context, release)
+    debs = build_debs(context, release)
     for deb in debs:
         deb_destination = "/tmp/" + deb.split("/")[-1]
-        context.instances["ppa"].push_file(deb, deb_destination)
-        when_i_run_command_on_machine(
+        context.machines["ppa"].instance.push_file(deb, deb_destination)
+        when_i_run_command(
             context,
             "aptly repo add repo-{} {}".format(release, deb_destination),
             "with sudo",
-            "ppa",
+            machine_name="ppa",
         )
-    when_i_run_command_on_machine(
+    when_i_run_command(
         context,
         "aptly publish repo -skip-signing repo-{}".format(release),
         "with sudo",
-        "ppa",
+        machine_name="ppa",
     )
 
 
 @when("I install ubuntu-advantage-pro")
 def when_i_install_pro(context):
     if context.config.install_from is InstallationSource.LOCAL:
-        deb_paths = build_debs_from_sbuild(context, context.series)
+        deb_paths = build_debs(context, context.machines[SUT].instance.series)
 
         for deb_path in deb_paths:
             if "pro" in deb_path:

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -4,8 +4,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
     @uses.config.machine_type.aws.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu pro AWS machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -76,8 +76,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
     @uses.config.machine_type.azure.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu pro Azure machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine with ingress ports `3128`
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given I a `focal` machine named `proxy` with ingress ports `3128`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
@@ -148,8 +148,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu Pro GCP machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I launch a `focal` `proxy` machine
-        And I run `apt install squid -y` `with sudo` on the `proxy` machine
+        Given a `focal` machine named `proxy`
+        When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
             dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_port 3389\nhttp_access allow all


### PR DESCRIPTION
This is a somewhat holistic refactor of our behave machine provisioning and u-a-t installing code. It does a few things that I think in combination make the code simpler and clearer:

1. Adds a new installation source: "prebuilt" for CI. Previously "local" was used in that scenario but I think separating it makes each scenario more straightforward.
2. Redefines how we store machine instance objects on the behave `context`. We now store a tuple of the series and the pycloudlib instance. (Before we didn't keep the series info for each instance).
3. Uses commands to install u-a-t instead of user data. This allows us to separate the function for launching an instance from the function for installing u-a-t. So each can be reused.
4. Defines one function for launching an instance and uses it everywhere
5. Introduces using multiple step decorators on a single function for variations of a step with different parameters. I don't apply this everywhere in this PR, but this pattern can reduce boilerplate in several places.

Every other change stems from one of the above goals. Let me know if you think anything is too much or if I missed anything.

In theory, everything should just continue working as normal after this PR is ready, but we'll have cleaned up test code that will make future iterating easier.