### PR TITLE
enable: show deduplicated list of supported arches

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -554,12 +554,13 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             affordance_arches is not None
             and platform["arch"] not in affordance_arches
         ):
+            deduplicated_arches = util.deduplicate_arches(affordance_arches)
             return (
                 ApplicabilityStatus.INAPPLICABLE,
                 messages.INAPPLICABLE_ARCH.format(
                     title=self.title,
                     arch=platform["arch"],
-                    supported_arches=", ".join(affordance_arches),
+                    supported_arches=", ".join(deduplicated_arches),
                 ),
             )
         affordance_series = affordances.get("series", None)

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -50,7 +50,7 @@ class TestCommonCriteriaEntitlementUserFacingStatus:
                 "xenial",
                 "16.04 LTS (Xenial Xerus)",
                 "CC EAL2 is not available for platform arm64.\n"
-                "Supported platforms are: x86_64, ppc64le, s390x.",
+                "Supported platforms are: amd64, ppc64el, s390x.",
             ),
             (
                 "s390x",

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -562,7 +562,7 @@ class TestLivepatchEntitlementCanEnable:
             assert CanEnableFailureReason.INAPPLICABLE == reason.reason
             msg = (
                 "Livepatch is not available for platform ppc64le.\n"
-                "Supported platforms are: x86_64."
+                "Supported platforms are: amd64."
             )
             assert msg == reason.message.msg
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -697,3 +697,41 @@ class TestGetProEnvironment:
             "UA_LOG_LEVEL": "DEBUG",
         }
         assert expected == util.get_pro_environment()
+
+
+class TestDeduplicateArches:
+    @pytest.mark.parametrize(
+        ["arches", "expected"],
+        [
+            ([], []),
+            (["anything"], ["anything"]),
+            (["amd64"], ["amd64"]),
+            (["amd64", "x86_64"], ["amd64"]),
+            (
+                ["amd64", "ppc64el", "ppc64le", "s390x", "x86_64"],
+                ["amd64", "ppc64el", "s390x"],
+            ),
+            (["amd64", "i386", "i686", "x86_64"], ["amd64", "i386"]),
+            (
+                ["amd64", "i386", "i686", "x86_64", "armhf", "arm64"],
+                ["amd64", "arm64", "armhf", "i386"],
+            ),
+            (
+                [
+                    "x86_64",
+                    "amd64",
+                    "i686",
+                    "i386",
+                    "ppc64le",
+                    "aarch64",
+                    "arm64",
+                    "armv7l",
+                    "armhf",
+                    "s390x",
+                ],
+                ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"],
+            ),
+        ],
+    )
+    def test_deduplicate_arches(self, arches, expected):
+        assert expected == util.deduplicate_arches(arches)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -605,3 +605,17 @@ def depth_first_merge_overlay_dict(base_dict, overlay_dict):
                 base_dict[key] = value
         else:
             base_dict[key] = value
+
+
+def deduplicate_arches(arches: List[str]) -> List[str]:
+    deduplicated_arches = set()
+    arch_aliases = {
+        "x86_64": "amd64",
+        "i686": "i386",
+        "ppc64le": "ppc64el",
+        "aarch64": "arm64",
+        "armv7l": "armhf",
+    }
+    for arch in arches:
+        deduplicated_arches.add(arch_aliases.get(arch.lower(), arch))
+    return sorted(list(deduplicated_arches))


### PR DESCRIPTION
Fixes: #917

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run `pro enable` in a way that causes the arch affordance check to fail. Ensure that a de-duplicated list of arches is printed.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
