### PR TITLE
tests: modify pro status output on non-LTS release

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -2,30 +2,6 @@
 Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         subscription using a valid token
 
-    @series.kinetic
-    @series.lunar
-    @uses.config.machine_type.lxd.container
-    Scenario Outline: Attached command in a non-lts ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `pro status --all` as non-root
-        Then stdout matches regexp:
-            """
-            SERVICE       +ENTITLED  STATUS    DESCRIPTION
-            cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-            cis           +yes      +n/a      +Security compliance and audit tools
-            esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
-            esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
-            fips          +yes      +n/a      +NIST-certified core packages
-            fips-updates  +yes      +n/a      +NIST-certified core packages with priority security updates
-            livepatch     +yes      +n/a      +Canonical Livepatch service
-            """
-
-        Examples: ubuntu release
-            | release |
-            | kinetic |
-            | lunar   |
-
     @series.lts
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attach command in a ubuntu lxd container

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -20,6 +20,7 @@ Feature: Attached status
            | kinetic |
            | lunar   |
 
+
     @series.xenial
     @uses.config.machine_type.lxd.container
     Scenario Outline: Non-root status can see in-progress operations
@@ -184,3 +185,43 @@ Feature: Attached status
         Examples: ubuntu release
            | release |
            | jammy   |
+
+    @series.kinetic
+    @series.lunar
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached command in a non-lts ubuntu machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+            """
+            You are running Ubuntu <release_id> \(<release_name>\) interim release.
+            Interim Ubuntu releases are supported for 9 months and do not offer
+            Ubuntu Pro features, such as the full 10 years security maintenance. If
+            you wish to use Ubuntu Pro, please switch to an LTS release. Learn more
+            about Ubuntu Pro at https://ubuntu.com/pro
+            """
+        When I run `pro status --all --format json` as non-root
+        Then stdout matches regexp:
+            """
+            {"environment_vars": \[\], "errors": \[\], "result": "success", "services": \[\], "warnings": \[{"message": "You are running Ubuntu <release_id> \(<release_name>\) interim release.\\nInterim Ubuntu releases are supported for 9 months and do not offer\\nUbuntu Pro features, such as the full 10 years security maintenance. If\\nyou wish to use Ubuntu Pro, please switch to an LTS release. Learn more\\nabout Ubuntu Pro at https://ubuntu.com/pro", "message_code": "pro\-status\-for\-non\-lts", "service": null, "type": "system"}\]}
+            """
+        When I attach `contract_token` with sudo
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+            """
+            You are running Ubuntu <release_id> \(<release_name>\) interim release.
+            Interim Ubuntu releases are supported for 9 months and do not offer
+            Ubuntu Pro features, such as the full 10 years security maintenance. If
+            you wish to use Ubuntu Pro, please switch to an LTS release. Learn more
+            about Ubuntu Pro at https://ubuntu.com/pro
+            """
+        When I run `pro status --all --format json` as non-root
+        Then stdout matches regexp:
+            """
+            {"environment_vars": \[\], "errors": \[\], "result": "success", "services": \[\], "warnings": \[{"message": "You are running Ubuntu <release_id> \(<release_name>\) interim release.\\nInterim Ubuntu releases are supported for 9 months and do not offer\\nUbuntu Pro features, such as the full 10 years security maintenance. If\\nyou wish to use Ubuntu Pro, please switch to an LTS release. Learn more\\nabout Ubuntu Pro at https://ubuntu.com/pro", "message_code": "pro\-status\-for\-non\-lts", "service": null, "type": "system"}\]}
+            """
+
+        Examples: ubuntu release
+            | release | release_id | release_name  |
+            | kinetic | 22.10      | Kinetic Kudu  |
+            | lunar   | 23.04      | Lunar Lobster |

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -165,7 +165,12 @@ class EventLogger:
                 additional_info=additional_info,
             )
 
-    def warning(self, warning_msg: str, service: Optional[str] = None):
+    def warning(
+        self,
+        warning_msg: str,
+        service: Optional[str] = None,
+        warning_code: Optional[str] = None,
+    ):
         """
         Store a warning in the event logger.
 
@@ -175,6 +180,7 @@ class EventLogger:
         if self._event_logger_mode != EventLoggerMode.CLI:
             self._record_dict_event(
                 msg=warning_msg,
+                code=warning_code,
                 service=service,
                 event_dict=self._warning_events,
             )

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -280,6 +280,15 @@ class UnattachedError(UserFacingError):
         super().__init__(msg=msg.msg, msg_code=msg.name)
 
 
+class NotAvailableOnNonLTSError(UserFacingError):
+    """An exception to be raised when running a cmd ona non-LTS machine."""
+
+    def __init__(
+        self, msg: messages.NamedMessage = messages.RUNNING_CMD_ON_NON_LTS
+    ) -> None:
+        super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
 class SecurityAPIMetadataError(UserFacingError):
     """An exception raised with Security API metadata returns invalid data."""
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1131,3 +1131,20 @@ Either switch to a supported kernel or `pro disable livepatch` to dismiss this w
 )
 LIVEPATCH_KERNEL_NOT_SUPPORTED_DESCRIPTION = "Current kernel is not supported"
 LIVEPATCH_KERNEL_NOT_SUPPORTED_UNATTACHED = "Supported livepatch kernels are listed here: https://ubuntu.com/security/livepatch/docs/kernels"  # noqa: E501
+
+RUNNING_CMD_ON_NON_LTS = NamedMessage(
+    name="running-cmd-on-non-lts",
+    msg="This command is not supported in a non-LTS release",
+)
+
+PRO_STATUS_NON_LTS = FormattedNamedMessage(
+    name="pro-status-for-non-lts",
+    msg="""\
+You are running Ubuntu {{release_version}} interim release.
+Interim Ubuntu releases are supported for 9 months and do not offer
+Ubuntu Pro features, such as the full 10 years security maintenance. If
+you wish to use Ubuntu Pro, please switch to an LTS release. Learn more
+about Ubuntu Pro at {url}""".format(
+        url=BASE_UA_URL
+    ),
+)

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -170,6 +170,7 @@ def get_platform_info() -> Dict[str, str]:
         {
             "release": match_dict["release"],
             "series": match_dict["series"].lower(),
+            "version": version,
         }
     )
 


### PR DESCRIPTION
## Proposed Commit Message
tests: modify pro status output on non-LTS release

On non-LTS releases, we don't provide any support to the exising services delivered by the pro client. Because of that, we are modifying the pro status output to reflect that

LP: 1994923

## Test Steps
Verify if the new output for `pro status` on non-LTS releases make sense

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
