### PR TITLE
docs: add github issue feedback link to each page

### DIFF
--- a/docs/_static/css/github_issue_links.css
+++ b/docs/_static/css/github_issue_links.css
@@ -1,0 +1,7 @@
+.github-issue-link-container {
+    padding-right: 0.5rem;
+}
+.github-issue-link {
+    font-size: var(--font-size--small);
+    font-weight: bold;
+}

--- a/docs/_static/js/github_issue_links.js
+++ b/docs/_static/js/github_issue_links.js
@@ -1,0 +1,25 @@
+window.onload = function() {
+    const link = document.createElement("a");
+    link.classList.add("muted-link");
+    link.classList.add("github-issue-link");
+    link.text = "Have a question?";
+    link.href = (
+        "https://github.com/canonical/ubuntu-advantage-client/issues/new?"
+        + "title=docs%3A+TYPE+YOUR+QUESTION+HERE"
+        + "&body=*Please describe the question or issue you're facing with "
+        + `"${document.title}"`
+        + ".*"
+        + "%0A%0A%0A%0A%0A"
+        + "---"
+        + "%0A"
+        + `*Reported+from%3A+${location.href}*`
+    );
+    link.target = "_blank";
+
+    const div = document.createElement("div");
+    div.classList.add("github-issue-link-container");
+    div.append(link)
+
+    const container = document.querySelector(".article-container > .content-icon-container");
+    container.prepend(div);
+};

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,4 +57,11 @@ html_logo = "_static/circle_of_friends.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = ["css/logo.css"]
+
+html_css_files = [
+    "css/logo.css",
+    "css/github_issue_links.css",
+]
+html_js_files = [
+    "js/github_issue_links.js",
+]


### PR DESCRIPTION
The goal here is to add a link to each page to easily open a GitHub
issue related to that page's contents. This can be an easy way to ask a
question or report a problem with that piece of documentation.

Instead of forking the furo theme, this uses some custom CSS/JS to add
an extra element to the theme after the page loads. We will likely
switch to a more Ubuntu-styled theme in the future, so this is just a
hack for now to prove the concept. This hack can be adapted to a
future theme, or, ideally, this feature would get built into the
future theme.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`tox -e dev-docs` and open the docs in your browser. Make sure the link at the top of each page makes sense and links to an appropriate github issue form.

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
