### PR TITLE
auto-attach: remove motd message if failure happen

### DIFF
--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -81,7 +81,6 @@ def main(cfg: UAConfig):
         logging.debug(
             "Skipping auto-attach. Config disable_auto_attach is set."
         )
-        return
     except EntitlementsNotEnabledError as e:
         logging.warning(e.msg)
     except Exception as e:

--- a/uaclient/tests/test_lib_auto_attach.py
+++ b/uaclient/tests/test_lib_auto_attach.py
@@ -53,6 +53,7 @@ class TestCheckCloudinitUserdataForUAInfo:
         assert expected is check_cloudinit_userdata_for_ua_info()
 
 
+@mock.patch("lib.auto_attach.system.remove_file")
 @mock.patch("lib.auto_attach.system.write_file")
 class TestMain:
     @pytest.mark.parametrize(
@@ -69,6 +70,7 @@ class TestMain:
         m_api_full_auto_attach,
         m_check_cloudinit,
         m_write_file,
+        m_remove_file,
         ubuntu_advantage_in_userdata,
         caplog_text,
         FakeConfig,
@@ -83,6 +85,9 @@ class TestMain:
                 )
             ] == m_write_file.call_args_list
             assert 1 == m_api_full_auto_attach.call_count
+            assert [
+                mock.call(AUTO_ATTACH_STATUS_MOTD_FILE)
+            ] == m_remove_file.call_args_list
         else:
             assert 0 == m_api_full_auto_attach.call_count
             assert (
@@ -114,6 +119,7 @@ class TestMain:
         m_api_full_auto_attach,
         m_check_cloudinit,
         m_write_file,
+        m_remove_file,
         api_side_effect,
         log_msg,
         caplog_text,
@@ -133,3 +139,7 @@ class TestMain:
         )
         assert m_api_full_auto_attach.call_count == 1
         assert log_msg in caplog_text()
+        assert (
+            mock.call(AUTO_ATTACH_STATUS_MOTD_FILE)
+            in m_remove_file.call_args_list
+        )


### PR DESCRIPTION
## Proposed Commit Message
auto-attach: remove motd message if failure happen

On auto-attach, we add a MOTD message informing the users that auto-attach is running. However, we don't clear that message if the operation fails and returns early. We are changing that logic to always cleanup that message.

## Test Steps
* Launch a Pro instance
* Check if the instance endup attached after boot
* Run `pro detach`
* Add the `disable_auto_attach` under `features` on config on `/etc/ubuntu-advantage/uaclient.conf`
* Reboot the machine
* Verify that the message no longer appears on MOTD

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
