### PR TITLE
tests: fix upgrade test from jammy to kinetic

### DIFF
--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -53,7 +53,7 @@ Feature: Upgrade between releases when uaclient is attached
         | bionic  | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
         | bionic  | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
         | focal   | jammy        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         | true           |
-        | jammy   | kinetic      | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
+        | jammy   | kinetic      | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
 
     @slow
     @series.xenial

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -41,4 +41,4 @@ Feature: Upgrade between releases when uaclient is unattached
         | xenial  | bionic       | lts    |                 | enabled        |
         | bionic  | focal        | lts    |                 | enabled        |
         | focal   | jammy        | lts    | --devel-release | enabled        |
-        | jammy   | kinetic      | normal | --devel-release | n/a            |
+        | jammy   | kinetic      | normal |                 | n/a            |


### PR DESCRIPTION
`kinetic` is not the devel release anymore - the upgrade tests depend on this change to pass.

## Test Steps
Run the changed integration tests.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
