### PR TITLE
Do not import version on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import glob
 
 import setuptools
 
-from uaclient import defaults, version
+from uaclient import defaults
 
 NAME = "ubuntu-advantage-tools"
 
@@ -30,14 +30,6 @@ def split_link_deps(reqs_filename):
 TEST_REQUIRES, TEST_LINKS = split_link_deps("test-requirements.txt")
 
 
-def _get_version():
-    parts = version.get_version().split("-")
-    if len(parts) == 1:
-        return parts[0]
-    major_minor, _subrev, _commitish = parts
-    return major_minor
-
-
 def _get_data_files():
     return [
         ("/etc/ubuntu-advantage", ["uaclient.conf", "help_data.yaml"]),
@@ -59,7 +51,9 @@ def _get_data_files():
 
 setuptools.setup(
     name=NAME,
-    version=_get_version(),
+    # This version does not matter, it is not used anywhere but in unit tests
+    # AND IT IS OVER 8000
+    version="8001",
     packages=setuptools.find_packages(
         exclude=[
             "*.testing",

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -11,6 +11,8 @@ import json
 import sys
 from typing import Any, Dict, List, Optional, Set, Union  # noqa: F401
 
+import yaml
+
 JSON_SCHEMA_VERSION = "0.1"
 EventFieldErrorType = Optional[Union[str, Dict[str, str]]]
 _event_logger = None
@@ -225,8 +227,6 @@ class EventLogger:
                 )
             )
         elif self._event_logger_mode == EventLoggerMode.YAML:
-            import yaml
-
             print(yaml.dump(output, default_flow_style=False))
 
     def process_events(self) -> None:

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -1,8 +1,5 @@
 """
-Version determination functions
-
-These are in their own file so they can be imported by setup.py before we have
-any of our dependencies installed.
+Client version related functions
 """
 import os.path
 import re
@@ -33,7 +30,8 @@ def get_version() -> str:
          XX.Y so return the --long version to allow daily build recipes
          to count commit offset from upstream's XX.Y signed tag.
       b. If run in a git-ubuntu pkg repo, upstream tags aren't visible,
-         parse the debian/changelog in that case
+         believe __VERSION__ is correct - there is and MUST always be a
+         test to make sure it matches debian/changelog
     """
     if not PACKAGED_VERSION.startswith("@@PACKAGED_VERSION"):
         return PACKAGED_VERSION


### PR DESCRIPTION
We rely on `version.py` (mainly on `get_version` to determine the version for the client for pretty much all situations, and this included `setup.py` of course.
The thing is: our package is installed on Ubuntu using apt, and all of the machinery is in place to properly version the package when building (whether locally or on PPAs) and report it appropriately.

The only tooling that relies on installing through setup.py is `tox`, for the tests, and we could not care less of what version it sees - currently it thinks it is running on 20.3 because of git tagging and runs fine.

The problem with `setup.py` importing from `version` brings the fact that `version` itself imports other modules, and:
a) There is no guarantee that those modules will not import version again, generating a circular dependency
b) There are guaranteed dependencies from the package perspective (yaml, apt) which break when importing in setup.py because no requirement installation was done yet, if any. 

This PR tells tox to go with `28.0.dev1` and do its thing, and removes the import from `setup.py`.

The visible side effects are: the ghost `20.3` version is not in the logs anymore, and we can finally import yaml in event_logger without being bothered by our own tooling.

## Test Steps
Tox and behave, as usual - and make sure building and testing it in containers still reports the correct version nonetheless.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any "documentation" accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No - unless you think SRUers will be sad
