### PR TITLE
cli: add magic-attach flow

### DIFF
--- a/features/magic_attach.feature
+++ b/features/magic_attach.feature
@@ -1,0 +1,61 @@
+Feature: Magic attach flow related tests
+
+    @series.lts
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attach using the magic attach flow
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I change contract to staging with sudo
+        And I create the file `/tmp/response-overlay.json` with the following:
+        """
+        {
+            "https://contracts.staging.canonical.com/v1/magic-attach": [
+            {
+              "code": 200,
+              "response": {
+                "userCode": "123",
+                "token": "testToken",
+                "expires": "expire-date",
+                "expiresIn": 2000
+              }
+            },
+            {
+                "code": 200,
+                "response": {
+                    "userCode": "123",
+                    "token": "testToken",
+                    "expires": "expire-date",
+                    "expiresIn": 2000,
+                    "contractID": "test-contract-id",
+                    "contractToken": "$behave_var{contract_token_staging}"
+                }
+            }]
+        }
+        """
+        And I append the following on uaclient config:
+        """
+        features:
+          serviceclient_url_responses: "/tmp/response-overlay.json"
+        """
+        And I run `pro attach` with sudo
+        Then stdout matches regexp:
+        """
+        Initiating attach operation...
+
+        Please sign in to your Ubuntu Pro account at this link:
+        https://ubuntu.com/pro/attach
+        And provide the following code: .*123.*
+
+        Attaching the machine...
+        """
+        When I run `pro status --format yaml` with sudo
+        Then stdout matches regexp:
+        """
+        attached: true
+        """
+
+        Examples: ubuntu release
+            | release |
+            | xenial  |
+            | bionic  |
+            | focal   |
+            | jammy   |

--- a/features/util.py
+++ b/features/util.py
@@ -312,5 +312,11 @@ def process_template_vars(context, template: str) -> str:
             processed_template = _replace_and_log(
                 processed_template, match.group(0), dt_str
             )
+        elif function_name == "contract_token_staging":
+            processed_template = _replace_and_log(
+                processed_template,
+                match.group(0),
+                context.config.contract_token_staging,
+            )
 
     return processed_template

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -221,6 +221,14 @@ class MagicAttachUnavailable(UserFacingError):
         )
 
 
+class MagicAttachInvalidParam(UserFacingError):
+    def __init__(self, param, value):
+        msg = messages.MAGIC_ATTACH_INVALID_PARAM.format(
+            param=param, value=value
+        )
+        super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
 class LockHeldError(UserFacingError):
     """An exception for when another pro operation is in progress
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -523,6 +523,11 @@ MAGIC_ATTACH_UNAVAILABLE = NamedMessage(
     "Service unavailable, please try again later.",
 )
 
+MAGIC_ATTACH_INVALID_PARAM = FormattedNamedMessage(
+    "magic-attach-invalid-param",
+    "This attach flow does not support {param} with value: {value}",
+)
+
 REQUIRED_SERVICE_NOT_FOUND = FormattedNamedMessage(
     "required-service-not-found", "Required service {service} not found."
 )


### PR DESCRIPTION
## Proposed Commit Message
cli: add magic-attach flow on CLI

Add support for the magic-attach flow through the `pro attach` CLI. This flow allows users to attach to Ubuntu Pro subscription without a token. When running `pro attach` without providing a token, the Pro client will output a user code on the screen and the user will then login into the Pro portal url and input that token there. Once that is done, our code will detect that and fetch the token directly from the Contract Server. Once we have the token, we can than attach as usual.

PS: We are still waiting on some functionality to be delivered to make that flow useful

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
