### PR TITLE
more datetime json decoding

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -268,7 +268,7 @@ create_public_machine_token_file() {
 from uaclient.files import MachineTokenFile
 machine_token_file = MachineTokenFile()
 content = machine_token_file.read()
-machine_token_file.write(content=content)
+machine_token_file.write(content)
 "
 }
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -652,7 +652,7 @@ def is_contract_changed(cfg: UAConfig) -> bool:
         .get("effectiveTo", None)
     )
     new_expiry = (
-        util.parse_rfc3339_date(resp_expiry)
+        resp_expiry
         if resp_expiry
         else cfg.machine_token_file.contract_expiry_datetime
     )

--- a/uaclient/contract_data_types.py
+++ b/uaclient/contract_data_types.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from uaclient.data_types import (
     BoolDataValue,
     DataObject,
+    DatetimeDataValue,
     Field,
     IntDataValue,
     StringDataValue,
@@ -67,7 +68,7 @@ class AccountInfo(DataObject):
     fields = [
         Field("name", StringDataValue, False),
         Field("id", StringDataValue, False),
-        Field("createdAt", StringDataValue, False),
+        Field("createdAt", DatetimeDataValue, False),
         Field("type", StringDataValue, False),
         Field("userRoleOnAccount", StringDataValue, False),
         Field("externalAccountIDs", data_list(ExternalID), False),
@@ -238,12 +239,12 @@ class ContractInfo(DataObject):
     fields = [
         Field("name", StringDataValue, False),
         Field("id", StringDataValue, False),
-        Field("createdAt", StringDataValue, False),
+        Field("createdAt", DatetimeDataValue, False),
         Field("createdBy", StringDataValue, False),
         Field("resourceEntitlements", data_list(Entitlement), False),
         Field("specificResourceEntitlements", data_list(Entitlement), False),
-        Field("effectiveFrom", StringDataValue, False),
-        Field("effectiveTo", StringDataValue, False),
+        Field("effectiveFrom", DatetimeDataValue, False),
+        Field("effectiveTo", DatetimeDataValue, False),
         Field("products", data_list(StringDataValue), False),
         Field("origin", StringDataValue, False),
     ]
@@ -278,7 +279,7 @@ class MachineTokenInfo(DataObject):
         Field("machineId", StringDataValue, False),
         Field("accountInfo", AccountInfo, False),
         Field("contractInfo", ContractInfo, False),
-        Field("expires", StringDataValue, False),
+        Field("expires", DatetimeDataValue, False),
     ]
 
     def __init__(

--- a/uaclient/data_types.py
+++ b/uaclient/data_types.py
@@ -3,51 +3,46 @@ import json
 from enum import Enum
 from typing import Any, List, Optional, Type, TypeVar, Union
 
-from uaclient import exceptions, util
-
-INCORRECT_TYPE_ERROR_MESSAGE = (
-    "Expected value with type {expected_type} but got type: {got_type}"
-)
-INCORRECT_LIST_ELEMENT_TYPE_ERROR_MESSAGE = (
-    "Got value with incorrect type at index {index}: {nested_msg}"
-)
-INCORRECT_FIELD_TYPE_ERROR_MESSAGE = (
-    'Got value with incorrect type for field "{key}": {nested_msg}'
-)
-INCORRECT_ENUM_VALUE_ERROR_MESSAGE = (
-    "Value provided was not found in {enum_class}'s allowed: value: {values}"
-)
+from uaclient import exceptions, messages, util
 
 
 class IncorrectTypeError(exceptions.UserFacingError):
     def __init__(self, expected_type: str, got_type: str):
-        super().__init__(
-            INCORRECT_TYPE_ERROR_MESSAGE.format(
-                expected_type=expected_type, got_type=got_type
-            )
+        msg = messages.INCORRECT_TYPE_ERROR_MESSAGE.format(
+            expected_type=expected_type, got_type=got_type
         )
+        super().__init__(msg.msg, msg.name)
 
 
 class IncorrectListElementTypeError(IncorrectTypeError):
     def __init__(self, err: IncorrectTypeError, at_index: int):
-        self.msg = INCORRECT_LIST_ELEMENT_TYPE_ERROR_MESSAGE.format(
+        msg = messages.INCORRECT_LIST_ELEMENT_TYPE_ERROR_MESSAGE.format(
             index=at_index, nested_msg=err.msg
         )
+        self.msg = msg.msg
+        self.msg_code = msg.name
+        self.additional_info = None
 
 
 class IncorrectFieldTypeError(IncorrectTypeError):
     def __init__(self, err: IncorrectTypeError, key: str):
-        self.msg = INCORRECT_FIELD_TYPE_ERROR_MESSAGE.format(
+        msg = messages.INCORRECT_FIELD_TYPE_ERROR_MESSAGE.format(
             key=key, nested_msg=err.msg
         )
+        self.msg = msg.msg
+        self.msg_code = msg.name
+        self.additional_info = None
         self.key = key
 
 
 class IncorrectEnumValueError(IncorrectTypeError):
     def __init__(self, values: List[str], enum_class: Any):
-        self.msg = INCORRECT_ENUM_VALUE_ERROR_MESSAGE.format(
+        msg = messages.INCORRECT_ENUM_VALUE_ERROR_MESSAGE.format(
             values=values, enum_class=repr(enum_class)
         )
+        self.msg = msg.msg
+        self.msg_code = msg.name
+        self.additional_info = None
 
 
 class DataValue:

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -210,7 +210,11 @@ class EventLogger:
             "needs_reboot": self._needs_reboot,
         }
 
-        print(json.dumps(response, sort_keys=True))
+        from uaclient.util import DatetimeAwareJSONEncoder
+
+        print(
+            json.dumps(response, cls=DatetimeAwareJSONEncoder, sort_keys=True)
+        )
 
     def _process_events_status(self):
         output = format_machine_readable_output(self._output_content)

--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -78,19 +78,23 @@ class MachineTokenFile:
         self._entitlements = None
         self._contract_expiry_datetime = None
 
-    def write(self, content: dict):
+    def write(self, private_content: dict):
         """Update the machine_token file for both pub/private files"""
         if self.is_root:
-            content_str = json.dumps(
-                content, cls=util.DatetimeAwareJSONEncoder
+            private_content_str = json.dumps(
+                private_content, cls=util.DatetimeAwareJSONEncoder
             )
-            self.private_file.write(content_str)
-            content = json.loads(content_str)  # taking care of datetime type
-            content = PublicMachineTokenData.from_dict(content).to_dict(False)
-            content_str = json.dumps(
-                content, cls=util.DatetimeAwareJSONEncoder
+            self.private_file.write(private_content_str)
+
+            # PublicMachineTokenData only has public fields defined and
+            # ignores all other (private) fields in from_dict
+            public_content = PublicMachineTokenData.from_dict(
+                private_content
+            ).to_dict(keep_none=False)
+            public_content_str = json.dumps(
+                public_content, cls=util.DatetimeAwareJSONEncoder
             )
-            self.public_file.write(content_str)
+            self.public_file.write(public_content_str)
 
             self._machine_token = None
             self._entitlements = None

--- a/uaclient/jobs/update_messaging.py
+++ b/uaclient/jobs/update_messaging.py
@@ -388,7 +388,7 @@ def update_contract_expiry(cfg: config.UAConfig):
         .get("effectiveTo", None)
     )
     new_expiry = (
-        util.parse_rfc3339_date(resp_expiry)
+        resp_expiry
         if resp_expiry
         else cfg.machine_token_file.contract_expiry_datetime
     )

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1103,3 +1103,20 @@ RETRY_ERROR_DETAIL_URL_ERROR_CODE = "a {code} while reaching {url}"
 RETRY_ERROR_DETAIL_URL_ERROR_URL = "an error while reaching {url}"
 RETRY_ERROR_DETAIL_URL_ERROR_GENERIC = "a network error"
 RETRY_ERROR_DETAIL_UNKNOWN = "an unknown error"
+
+INCORRECT_TYPE_ERROR_MESSAGE = FormattedNamedMessage(
+    "incorrect-type",
+    "Expected value with type {expected_type} but got type: {got_type}",
+)
+INCORRECT_LIST_ELEMENT_TYPE_ERROR_MESSAGE = FormattedNamedMessage(
+    "incorrect-list-element-type",
+    "Got value with incorrect type at index {index}: {nested_msg}",
+)
+INCORRECT_FIELD_TYPE_ERROR_MESSAGE = FormattedNamedMessage(
+    "incorrect-field-type",
+    'Got value with incorrect type for field "{key}": {nested_msg}',
+)
+INCORRECT_ENUM_VALUE_ERROR_MESSAGE = FormattedNamedMessage(
+    "incorrect-enum-value",
+    "Value provided was not found in {enum_class}'s allowed: value: {values}",
+)

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -56,7 +56,9 @@ class UAServiceClient(metaclass=abc.ABCMeta):
         if not headers:
             headers = self.headers()
         if headers.get("content-type") == "application/json" and data:
-            data = json.dumps(data).encode("utf-8")
+            data = json.dumps(data, cls=util.DatetimeAwareJSONEncoder).encode(
+                "utf-8"
+            )
         url = urljoin(getattr(self.cfg, self.cfg_url_base_attr), path)
         fake_response, fake_headers = self._get_fake_responses(url)
         if fake_response:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -432,7 +432,7 @@ def simulate_status(
     now = datetime.now(timezone.utc)
     if contract_info.get("effectiveTo"):
         response["expires"] = contract_info.get("effectiveTo")
-        expiration_datetime = util.parse_rfc3339_date(response["expires"])
+        expiration_datetime = response["expires"]
         delta = expiration_datetime - now
         if delta.total_seconds() <= 0:
             message = messages.ATTACH_FORBIDDEN_EXPIRED.format(
@@ -444,7 +444,7 @@ def simulate_status(
             ret = 1
     if contract_info.get("effectiveFrom"):
         response["effective"] = contract_info.get("effectiveFrom")
-        effective_datetime = util.parse_rfc3339_date(response["effective"])
+        effective_datetime = response["effective"]
         delta = now - effective_datetime
         if delta.total_seconds() <= 0:
             message = messages.ATTACH_FORBIDDEN_NOT_YET.format(

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 import yaml
 
-from uaclient import event_logger, messages, status
+from uaclient import event_logger, messages, status, util
 from uaclient.cli import (
     UA_AUTH_TOKEN_URL,
     action_attach,
@@ -64,8 +64,8 @@ BASIC_MACHINE_TOKEN = {
         "contractInfo": {
             "name": "mycontract",
             "id": "contract-1",
-            "createdAt": "2020-05-08T19:02:26Z",
-            "effectiveTo": "9999-12-31T00:00:00Z",
+            "createdAt": util.parse_rfc3339_date("2020-05-08T19:02:26Z"),
+            "effectiveTo": util.parse_rfc3339_date("9999-12-31T00:00:00Z"),
             "resourceEntitlements": [],
             "products": ["free"],
         },
@@ -558,7 +558,9 @@ class TestActionAttach:
                     "accountInfo": {
                         "id": "acct-1",
                         "name": "acc-name",
-                        "createdAt": "2019-06-14T06:45:50Z",
+                        "createdAt": util.parse_rfc3339_date(
+                            "2019-06-14T06:45:50Z"
+                        ),
                         "externalAccountIDs": [
                             {"IDs": ["id1"], "origin": "AWS"}
                         ],

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -11,7 +11,7 @@ import mock
 import pytest
 import yaml
 
-from uaclient import exceptions, messages, status
+from uaclient import exceptions, messages, status, util
 from uaclient.cli import action_status, get_parser, main, status_parser
 from uaclient.event_logger import EventLoggerMode
 
@@ -31,15 +31,15 @@ RESPONSE_AVAILABLE_SERVICES = [
 
 RESPONSE_CONTRACT_INFO = {
     "accountInfo": {
-        "createdAt": "2019-06-14T06:45:50Z",
+        "createdAt": util.parse_rfc3339_date("2019-06-14T06:45:50Z"),
         "id": "some_id",
         "name": "Name",
         "type": "paid",
     },
     "contractInfo": {
-        "createdAt": "2021-05-21T20:00:53Z",
+        "createdAt": util.parse_rfc3339_date("2021-05-21T20:00:53Z"),
         "createdBy": "someone",
-        "effectiveTo": "9999-12-31T00:00:00Z",
+        "effectiveTo": util.parse_rfc3339_date("9999-12-31T00:00:00Z"),
         "id": "some_id",
         "name": "Name",
         "products": ["uai-essential-virtual"],
@@ -880,13 +880,13 @@ class TestActionStatus:
             "features": {},
             "notices": [],
             "account": {
-                "created_at": "2019-06-14T06:45:50Z",
+                "created_at": util.parse_rfc3339_date("2019-06-14T06:45:50Z"),
                 "external_account_ids": [],
                 "id": "some_id",
                 "name": "Name",
             },
             "contract": {
-                "created_at": "2021-05-21T20:00:53Z",
+                "created_at": util.parse_rfc3339_date("2021-05-21T20:00:53Z"),
                 "id": "some_id",
                 "name": "Name",
                 "products": ["uai-essential-virtual"],
@@ -895,7 +895,7 @@ class TestActionStatus:
             "environment_vars": [],
             "execution_status": "inactive",
             "execution_details": "No Ubuntu Pro operations are running",
-            "expires": "9999-12-31T00:00:00Z",
+            "expires": util.parse_rfc3339_date("9999-12-31T00:00:00Z"),
             "effective": None,
             "services": expected_services,
             "simulated": True,
@@ -908,8 +908,17 @@ class TestActionStatus:
         }
 
         if format_type == "json":
-            assert expected == json.loads(capsys.readouterr()[0])
+            assert expected == json.loads(
+                capsys.readouterr()[0], cls=util.DatetimeAwareJSONDecoder
+            )
         else:
+            expected["account"]["created_at"] = yaml.safe_load(
+                "2019-06-14 06:45:50+00:00"
+            )
+            expected["contract"]["created_at"] = yaml.safe_load(
+                "2021-05-21 20:00:53+00:00"
+            )
+            expected["expires"] = yaml.safe_load("9999-12-31 00:00:00+00:00")
             assert expected == yaml.safe_load(capsys.readouterr()[0])
 
     def test_error_on_connectivity_errors(
@@ -1038,13 +1047,13 @@ class TestActionStatus:
                 "expired_token",
                 'Contract "some_id" expired on December 31, 2019',
                 "effectiveTo",
-                "2019-12-31T00:00:00Z",
+                util.parse_rfc3339_date("2019-12-31T00:00:00Z"),
             ),
             (
                 "token_not_valid_yet",
                 'Contract "some_id" is not effective until December 31, 9999',
                 "effectiveFrom",
-                "9999-12-31T00:00:00Z",
+                util.parse_rfc3339_date("9999-12-31T00:00:00Z"),
             ),
         ),
     )

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -999,10 +999,10 @@ class TestContractChanged:
         self, get_updated_contract_info, has_contract_expired, FakeConfig
     ):
         if has_contract_expired:
-            expiry_date = "2041-05-08T19:02:26Z"
+            expiry_date = util.parse_rfc3339_date("2041-05-08T19:02:26Z")
             ret_val = True
         else:
-            expiry_date = "2040-05-08T19:02:26Z"
+            expiry_date = util.parse_rfc3339_date("2040-05-08T19:02:26Z")
             ret_val = False
         get_updated_contract_info.return_value = {
             "machineTokenInfo": {
@@ -1029,7 +1029,9 @@ class TestContractChanged:
                 "machineId": "test_machine_id",
                 "resourceTokens": resourceTokens,
                 "contractInfo": {
-                    "effectiveTo": "2040-05-08T19:02:26Z",
+                    "effectiveTo": util.parse_rfc3339_date(
+                        "2040-05-08T19:02:26Z"
+                    ),
                     "resourceEntitlements": resourceEntitlements,
                 },
             },

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -329,7 +329,7 @@ def readurl(
     setattr(resp, "body", resp.read().decode("utf-8"))
     content = resp.body
     if "application/json" in str(resp.headers.get("Content-type", "")):
-        content = json.loads(content)
+        content = json.loads(content, cls=DatetimeAwareJSONDecoder)
     sorted_header_str = ", ".join(
         ["'{}': '{}'".format(k, resp.headers[k]) for k in sorted(resp.headers)]
     )


### PR DESCRIPTION
machine-token: avoid extra json parsing step by recognizing datetime fields
* uses DatetimeDataValue in PublicMachineToken data object to avoid an extra json.loads (DatetimeDataValue didn't exist at the time that was written)

data_types: fix error classes to be proper UserFacingErrors
* while fixing test cases from these changes, I found out that IncorrectFieldType errors fail during our main_error_handler function because they don't have msg_code or additional_info defined.
* This commit is the simplest fix to this - maybe not the best. I want a common IncorrectTypeError that all the more specific errors inherit from, and can't find a better way to make the constructors call super nicely. LMK what you think

util: always parse datetimes in readurl
* uses JsonDatetimeAwareDecoder in util.readurl so we can always be sure datetimes are decoded later on.
* This removes the need for a few other instances of `parse_rfc3339_date`

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Everything should still work

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
