### PR TITLE
dev-docs: add PR review policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ from the architecture of the project to how you should test any code changes.
 * [Directory layout](./dev-docs/references/directory_layout.md)
 * [Daily Builds](./dev-docs/references/daily_builds.md)
 * [Version String Formatting](./dev-docs/references/version_string_formatting.md)
+* [PR review policy](./dev-docs/references/pr_review_policy.md)
 
 ### Explanation
 

--- a/dev-docs/references/pr_review_policy.md
+++ b/dev-docs/references/pr_review_policy.md
@@ -1,0 +1,19 @@
+# PR review policy
+
+The team follows this policy for PR reviews:
+
+* Simple PRs: PRs that fix typos or perform one line changes require **one** approval from a team
+  member and can be merged immediately by the reviewer.
+* Low complexity PRs: For short PRs we require **one** approval to merge. However, after approving the
+  PR we will wait for **one** day before merging it. This will allow other team members to review
+  the PR if they want. When one day has passed after the approval and there are no new requested
+  changes, any team member can merge.
+* Complex PRs: Minimum of **two** approvals from team members. After there are two team-member approvals
+  and there are no remaining requested changes, any team member can merge.
+* SRU blocker PRs: Some PRs may also require review from members that are not on the team, like SRU
+  reviewers. This is the case, for example, when adding/creating new systemd units. For those PRs, we
+  will directly ask for feedback from members outside the team that have a more suitable background to review
+  the change we are proposing. Therefore, we not only require at least **two** approvals from team members,
+  but also approvals from every external reviewer we assigned. After the required approvals have been given,
+  the additional review feedback has been taken into account, and there are no requested changes remaining,
+  any team member can merge.


### PR DESCRIPTION
## Proposed Commit Message
dev-docs: add PR review policy

Add document describing how the team handle PR reviews

## Test Steps
Double check to see if the policy is correct

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
