### PR TITLE
LHS nav bar now collapsed by default

### DIFF
--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -1,15 +1,15 @@
-Ubuntu Pro Client explanations
-==============================
+Ubuntu Pro Client explanation
+*****************************
 
-Our explanatory and conceptual guides are written to provide a better understanding of how the Ubuntu Pro Client (``pro``) works. They enable you to expand your knowledge and become better at using and configuring ``pro``.
+Our explanatory and conceptual guides are written to provide a better
+understanding of how the Ubuntu Pro Client (``pro``) works. They enable you
+to expand your knowledge and become better at using and configuring ``pro``.
 
-Explanations
-------------
+Explanation
+===========
 
 ..  toctree::
     :maxdepth: 1
     :glob:
 
     explanations/*
-
------

--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -1,18 +1,18 @@
 Ubuntu Pro Client how-to guides
-===============================
+*******************************
 
-If you have a specific goal and are already familiar with the Ubuntu Pro Client (``pro``), our How-to guides have more in-depth detail than our tutorials and can be applied to a wider range of situations.
+If you have a specific goal and are already familiar with the Ubuntu Pro Client
+(``pro``), our How-to guides have more in-depth detail than our tutorials and
+can be applied to a wider range of situations.
 
-They will help you to achieve a particular end result, but may require you to understand and adapt the steps to fit your specific requirements.
+They will help you to achieve a particular end result, but may require you to
+understand and adapt the steps to fit your specific requirements.
 
 How-to guides
--------------
+=============
 
 ..  toctree::
     :maxdepth: 1
     :glob:
 
     howtoguides/*
-
------
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,13 @@
 Ubuntu Pro Client
-=================
+#################
 
-The Ubuntu Pro Client (``pro``) is the offical tool to enable Canonical offerings on your
-system.
+The Ubuntu Pro Client (``pro``) is the offical tool to enable Canonical
+offerings on your system.
 
-``pro`` provides support to view, enable, and disable the following Canonical services:
+``pro`` provides support to view, enable, and disable the following Canonical
+services:
 
-- `Common Criteria EAL2 Certification Tooling`_
+- `Common Criteria EAL2 (CC EAL) Certification Tooling`_
 - `CIS Benchmark Audit Tooling`_
 - `Ubuntu Security Guide (USG) Tooling`_
 - `Ubuntu Expanded Security Maintenance (ESM)`_
@@ -14,9 +15,11 @@ system.
 - `FIPS 140-2 Certified Modules (and optional non-certified patches)`_
 - `Livepatch`_
 
-If you need any of those services for your machine, ``pro`` is the right tool for you.
+If you need any of those services for your machine, ``pro`` is the right tool
+for you.
 
-``pro`` is already installed on every Ubuntu system. Try it out by running ``pro help``!
+``pro`` is already installed on every Ubuntu system. Try it out by running
+``pro help``!
 
 -----
 
@@ -35,13 +38,13 @@ If you need any of those services for your machine, ``pro`` is the right tool fo
       
        Step-by-step guides covering key operations and common tasks
     
-   .. grid-item-card:: **Explanations**
+   .. grid-item-card:: **Explanation**
        :link: explanations
        :link-type: doc
           
        Discussion and clarification of key topics
     
-   .. grid-item-card:: **References**
+   .. grid-item-card:: **Reference**
        :link: references
        :link-type: doc
       
@@ -50,56 +53,51 @@ If you need any of those services for your machine, ``pro`` is the right tool fo
 -----
 
 Getting help
-************
+============
 
-Having trouble? We would like to help! For help on a specific page in this documentation, click on the "Have a question?" link at the top of that page. You can also...
+Having trouble? We would like to help! For help on a specific page in this
+documentation, click on the "Have a question?" link at the top of that page.
+You can also...
 
 - Ask a question in the ``#ubuntu-server`` `IRC channel on Libera`_
 - `Report bugs on Launchpad`_
 
 Project and community
-*********************
+=====================
 
-Ubuntu Pro Client is a member of the Ubuntu family. It’s an open source project that warmly welcomes
-community projects, contributions, suggestions, fixes and constructive feedback.
+Ubuntu Pro Client is a member of the Ubuntu family. It’s an open source project
+that warmly welcomes community projects, contributions, suggestions, fixes and
+constructive feedback.
 
 - Read our `Code of conduct`_
 - `Contribute`_
 
 .. toctree::
    :hidden:
-   :titlesonly:
-   :caption: Tutorials
-   :glob:
-   
-   tutorials/*
+   :maxdepth: 2
+
+   Tutorials <tutorials.rst>
    
 .. toctree::
    :hidden:
-   :titlesonly:
-   :caption: How-to guides
-   :glob:
-   
-   howtoguides/*
+   :maxdepth: 2
+
+   How-to guides <howtoguides.rst>
 
 .. toctree::
    :hidden:
-   :titlesonly:
-   :caption: Explanations
-   :glob:
-   
-   explanations/*
+   :maxdepth: 2
+
+   Explanation <explanations.rst>
 
 .. toctree::
    :hidden:
-   :titlesonly:
-   :caption: References
-   :glob:
-   
-   references/*
+   :maxdepth: 2
+
+   Reference <references.rst>
    
 .. LINKS:
-.. _Common Criteria EAL2 Certification Tooling: https://ubuntu.com/security/cc
+.. _Common Criteria EAL2 (CC EAL) Certification Tooling: https://ubuntu.com/security/cc
 .. _CIS Benchmark Audit Tooling: https://ubuntu.com/security/cis
 .. _Ubuntu Security Guide (USG) Tooling: https://ubuntu.com/security/certifications/docs/usg
 .. _Ubuntu Expanded Security Maintenance (ESM): https://ubuntu.com/security/esm

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,15 +1,15 @@
-Ubuntu Pro Client references
-============================
+Ubuntu Pro Client reference
+***************************
 
-Our Reference section contains support information for the Ubuntu Pro Client. This includes details on the network requirements, API definitions, support matrices and so on.
+Our reference section contains support information for the Ubuntu Pro Client.
+This includes details on the network requirements, API definitions, support
+matrices and so on.
 
-References
-----------
+Reference
+=========
 
 ..  toctree::
     :maxdepth: 1
     :glob:
 
     references/*
-
------

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,19 +1,21 @@
 Ubuntu Pro Client tutorials
-===========================
+***************************
 
-This section of our documentation contains step-by-step tutorials to help outline what the Ubuntu Pro Client (``pro``) is capable of, while helping you to achieve specific aims.
+This section of our documentation contains step-by-step tutorials to help
+outline what the Ubuntu Pro Client (``pro``) is capable of, while helping you
+to achieve specific aims.
 
-We hope our tutorials make as few assumptions as possible and are accessible to anyone with an interest in ``pro``. They should be a great place to start learning about ``pro``, how it works, and what it's capable of.
+We hope our tutorials make as few assumptions as possible and are accessible
+to anyone with an interest in ``pro``. They should be a great place to start
+learning about ``pro``, how it works, and what it's capable of.
 
 -----
 
 Tutorials
----------
+=========
 
 ..  toctree::
     :maxdepth: 1
     :glob:
 
     tutorials/*
-
------


### PR DESCRIPTION
## Proposed Commit Message
```
The navigation menu is now consistent with those docs
rendered via Discourse, where the default state is for the
Diataxis sections to be collapsed by default.

The spelling inconsistencies were my own fault when I 
created the landing pages, so I have taken the opportunity
to fix them. 

Finally, I added the CC EAL acronym to the front page list
of services, to be consistent with the other services that
already had their acronyms shown.
```

