### PR TITLE
Esm apps non beta

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -301,6 +301,9 @@ Feature: APT Messages
         Building dependency tree...
         Reading state information...
         Calculating upgrade...
+        The following security updates require Ubuntu Pro with 'esm-apps' enabled:
+          hello
+        Learn more about Ubuntu Pro at https://ubuntu.com/pro
         #
         # News about significant security updates, features and services will
         # appear here to raise awareness and perhaps tease /r/Linux ;)
@@ -333,37 +336,35 @@ Feature: APT Messages
         The following packages will be upgraded:
           hello
         """
-        # When I create the file `/tmp/machine-token-overlay.json` with the following:
-        # """
-        # {
-        #     "machineTokenInfo": {
-        #         "contractInfo": {
-        #             "effectiveTo": "$behave_var{today -20}"
-        #         }
-        #     }
-        # }
-        # """
-        # And I append the following on uaclient config:
-        # """
-        # features:
-        #   machine_token_overlay: "/tmp/machine-token-overlay.json"
-        # """
-        # When I run `pro refresh messages` with sudo
-        # When I run `apt-get upgrade --dry-run` with sudo
-        # Then stdout matches regexp:
-        # """
-        # Reading package lists...
-        # Building dependency tree...
-        # Reading state information...
-        # Calculating upgrade...
+        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        """
+        {
+            "machineTokenInfo": {
+              "contractInfo": {
+                  "effectiveTo": "$behave_var{today -20}"
+              }
+            }
+        }
+        """
+        And I append the following on uaclient config:
+        """
+        features:
+          machine_token_overlay: "/tmp/machine-token-overlay.json"
+        """
+        When I run `pro refresh messages` with sudo
+        When I run `apt upgrade --dry-run` with sudo
+        Then stdout matches regexp:
+        """
+        Reading package lists...
+        Building dependency tree...
+        Reading state information...
+        Calculating upgrade...
 
-        # \*Your Ubuntu Pro subscription has EXPIRED\*
-        # The following security updates require Ubuntu Pro with 'esm-apps' enabled:
-        #   hello
-        # Renew your service at https:\/\/ubuntu.com\/pro
-
-        # The following packages will be upgraded:
-        # """
+        \*Your Ubuntu Pro subscription has EXPIRED\*
+        The following security updates require Ubuntu Pro with 'esm-apps' enabled:
+          hello
+        Renew your service at https:\/\/ubuntu.com\/pro
+        """
         When I run `apt-get upgrade -y` with sudo
         When I run `pro detach --assume-yes` with sudo
         When I run `pro refresh messages` with sudo
@@ -374,6 +375,8 @@ Feature: APT Messages
         Building dependency tree...
         Reading state information...
         Calculating upgrade...
+        Receive additional future security updates with Ubuntu Pro.
+        Learn more about Ubuntu Pro at https://ubuntu.com/pro
         #
         # News about significant security updates, features and services will
         # appear here to raise awareness and perhaps tease /r/Linux ;\)
@@ -410,7 +413,7 @@ Feature: APT Messages
         Examples: ubuntu release
           | release | msg                                                                    |
           | xenial  | Learn more about Ubuntu Pro for 16\.04 at https:\/\/ubuntu\.com\/16-04 |
-#          | bionic  | Learn more about Ubuntu Pro on AWS at https:\/\/ubuntu\.com\/aws\/pro  |
+          | bionic  | Learn more about Ubuntu Pro on AWS at https:\/\/ubuntu\.com\/aws\/pro  |
 
     @series.xenial
     @series.bionic
@@ -427,7 +430,7 @@ Feature: APT Messages
         Examples: ubuntu release
           | release | msg                                                                                    |
           | xenial  | Learn more about Ubuntu Pro for 16\.04 on Azure at https:\/\/ubuntu\.com\/16-04\/azure |
-#          | bionic  | Learn more about Ubuntu Pro on Azure at https:\/\/ubuntu\.com\/azure\/pro              |
+          | bionic  | Learn more about Ubuntu Pro on Azure at https:\/\/ubuntu\.com\/azure\/pro              |
 
     @series.xenial
     @series.bionic
@@ -444,4 +447,4 @@ Feature: APT Messages
         Examples: ubuntu release
           | release | msg                                                                    |
           | xenial  | Learn more about Ubuntu Pro for 16\.04 at https:\/\/ubuntu\.com\/16-04 |
-#          | bionic  | Learn more about Ubuntu Pro on GCP at https:\/\/ubuntu\.com\/gcp\/pro  |
+          | bionic  | Learn more about Ubuntu Pro on GCP at https:\/\/ubuntu\.com\/gcp\/pro  |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -657,6 +657,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/livepatch\)
          - realtime-kernel: Ubuntu kernel with PREEMPT_RT patches integrated
            \(https://ubuntu.com/realtime-kernel\)
+         - ros-updates: All Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
+         - ros: Security Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
          - usg: Security compliance and audit tools
            \(https://ubuntu.com/security/certifications/docs/usg\)
         """
@@ -678,6 +682,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/livepatch\)
          - realtime-kernel: Ubuntu kernel with PREEMPT_RT patches integrated
            \(https://ubuntu.com/realtime-kernel\)
+         - ros-updates: All Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
+         - ros: Security Updates for the Robot Operating System
+           \(https://ubuntu.com/robotics/ros-esm\)
          - usg: Security compliance and audit tools
            \(https://ubuntu.com/security/certifications/docs/usg\)
         """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -541,6 +541,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/cc-eal\)
          - cis: Security compliance and audit tools
            \(https://ubuntu.com/security/certifications/docs/usg\)
+         - esm-apps: Expanded Security Maintenance for Applications
+           \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-updates: NIST-certified core packages with priority security updates
@@ -558,6 +560,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/cc-eal\)
          - cis: Security compliance and audit tools
            \(https://ubuntu.com/security/certifications/docs/usg\)
+         - esm-apps: Expanded Security Maintenance for Applications
+           \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-updates: NIST-certified core packages with priority security updates
@@ -641,6 +645,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Client to manage Ubuntu Pro services on a machine.
          - cc-eal: Common Criteria EAL2 Provisioning Packages
            \(https://ubuntu.com/cc-eal\)
+         - esm-apps: Expanded Security Maintenance for Applications
+           \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-updates: NIST-certified core packages with priority security updates
@@ -660,6 +666,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Client to manage Ubuntu Pro services on a machine.
          - cc-eal: Common Criteria EAL2 Provisioning Packages
            \(https://ubuntu.com/cc-eal\)
+         - esm-apps: Expanded Security Maintenance for Applications
+           \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-updates: NIST-certified core packages with priority security updates

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -165,11 +165,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
             {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": ["foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
-        And I verify that running `pro enable ros foobar --format json --assume-yes` `with sudo` exits `1`
+        And I verify that running `pro enable blah foobar --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
         """
-        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'foobar, ros'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": ["foobar", "ros"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        {"_schema_version": "0.1", "errors": [{"message": "Cannot enable unknown service 'blah, foobar'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": ["blah", "foobar"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
         """
         And I verify that running `pro enable esm-infra --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
@@ -200,11 +200,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                                                     |
-           | xenial  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel. |
-           | bionic  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel. |
-           | focal   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg. |
-           | jammy   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg. |
+           | release | valid_services                                                                                       |
+           | xenial  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel, ros, ros-updates. |
+           | bionic  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel, ros, ros-updates. |
+           | focal   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nros, ros-updates, usg. |
+           | jammy   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nros, ros-updates, usg. |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -224,17 +224,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And stderr matches regexp:
         """
         Cannot enable unknown service 'foobar'.
-        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel, ros, ros-updates.
         """
-        And I verify that running `pro enable ros foobar` `with sudo` exits `1`
+        And I verify that running `pro enable blah foobar` `with sudo` exits `1`
         And I will see the following on stdout:
         """
         One moment, checking your subscription first
         """
         And stderr matches regexp:
         """
-        Cannot enable unknown service 'foobar, ros'.
-        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel.
+        Cannot enable unknown service 'blah, foobar'.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel, ros, ros-updates.
         """
         And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -280,17 +280,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And stderr matches regexp:
         """
         Cannot enable unknown service 'foobar'.
-        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg.
+        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nros, ros-updates, usg.
         """
-        And I verify that running `pro enable ros foobar` `with sudo` exits `1`
+        And I verify that running `pro enable blah foobar` `with sudo` exits `1`
         And I will see the following on stdout:
         """
         One moment, checking your subscription first
         """
         And stderr matches regexp:
         """
-        Cannot enable unknown service 'foobar, ros'.
-        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg.
+        Cannot enable unknown service 'blah, foobar'.
+        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nros, ros-updates, usg.
         """
         And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         Then I will see the following on stdout:
@@ -937,7 +937,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         ros           +yes                disabled           Security Updates for the Robot Operating System
         """
-        When I run `pro enable ros --assume-yes --beta` with sudo
+        When I run `pro enable ros --assume-yes` with sudo
         And I run `pro status --all` as non-root
         Then stdout matches regexp
         """
@@ -973,13 +973,13 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         esm-apps      +yes                disabled           Expanded Security Maintenance for Applications
         """
-        When I verify that running `pro enable ros --beta` `with sudo` and stdin `N` exits `1`
+        When I verify that running `pro enable ros` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp
         """
         ROS ESM Security Updates cannot be enabled with Ubuntu Pro: ESM Apps disabled.
         Enable Ubuntu Pro: ESM Apps and proceed to enable ROS ESM Security Updates\? \(y\/N\) Cannot enable ROS ESM Security Updates when Ubuntu Pro: ESM Apps is disabled.
         """
-        When I run `pro enable ros --beta` `with sudo` and stdin `y`
+        When I run `pro enable ros` `with sudo` and stdin `y`
         Then stdout matches regexp
         """
         One moment, checking your subscription first
@@ -1010,7 +1010,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I run `apt install python3-catkin-pkg -y` with sudo
         Then I verify that `python3-catkin-pkg` is installed from apt source `<ros-security-source>`
 
-        When I run `pro enable ros-updates --assume-yes --beta` with sudo
+        When I run `pro enable ros-updates --assume-yes` with sudo
         And I run `pro status --all` as non-root
         Then stdout matches regexp
         """
@@ -1030,7 +1030,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Disable ROS ESM All Updates and proceed to disable ROS ESM Security Updates\? \(y\/N\) Disabling dependent service: ROS ESM All Updates
         Updating package lists
         """
-        When I run `pro enable ros-updates --beta` `with sudo` and stdin `y`
+        When I run `pro enable ros-updates` `with sudo` and stdin `y`
         Then stdout matches regexp
         """
         One moment, checking your subscription first
@@ -1053,7 +1053,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I run `pro disable ros --assume-yes` with sudo
         When I run `pro disable esm-apps --assume-yes` with sudo
         When I run `pro disable esm-infra --assume-yes` with sudo
-        When I run `pro enable ros-updates --assume-yes --beta` with sudo
+        When I run `pro enable ros-updates --assume-yes` with sudo
         When I run `pro status --all` as non-root
         Then stdout matches regexp
         """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -200,11 +200,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                                          |
-           | xenial  | cc-eal, cis, esm-infra, fips, fips-updates, livepatch, realtime-kernel. |
-           | bionic  | cc-eal, cis, esm-infra, fips, fips-updates, livepatch, realtime-kernel. |
-           | focal   | cc-eal, esm-infra, fips, fips-updates, livepatch, realtime-kernel, usg. |
-           | jammy   | cc-eal, esm-infra, fips, fips-updates, livepatch, realtime-kernel, usg. |
+           | release | valid_services                                                                     |
+           | xenial  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel. |
+           | bionic  | cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel. |
+           | focal   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg. |
+           | jammy   | cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg. |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -213,36 +213,36 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable foobar` `as non-root` exits `1`
         And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo).
-            """
+        """
+        This command must be run as root (try using sudo).
+        """
         And I verify that running `pro enable foobar` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
+        """
+        One moment, checking your subscription first
+        """
         And stderr matches regexp:
-            """
-            Cannot enable unknown service 'foobar'.
-            Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch, realtime-kernel.
-            """
+        """
+        Cannot enable unknown service 'foobar'.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel.
+        """
         And I verify that running `pro enable ros foobar` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
+        """
+        One moment, checking your subscription first
+        """
         And stderr matches regexp:
         """
         Cannot enable unknown service 'foobar, ros'.
-        Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch, realtime-kernel.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel.
         """
         And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         And I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Ubuntu Pro: ESM Infra is already enabled.
-            See: sudo pro status
-            """
+        """
+        One moment, checking your subscription first
+        Ubuntu Pro: ESM Infra is already enabled.
+        See: sudo pro status
+        """
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has permission `500`
         """
@@ -280,7 +280,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And stderr matches regexp:
         """
         Cannot enable unknown service 'foobar'.
-        Try cc-eal, esm-infra, fips, fips-updates, livepatch, realtime-kernel, usg.
+        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg.
         """
         And I verify that running `pro enable ros foobar` `with sudo` exits `1`
         And I will see the following on stdout:
@@ -290,7 +290,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And stderr matches regexp:
         """
         Cannot enable unknown service 'foobar, ros'.
-        Try cc-eal, esm-infra, fips, fips-updates, livepatch, realtime-kernel, usg.
+        Try cc-eal, esm-apps, esm-infra, fips, fips-updates, livepatch, realtime-kernel,\nusg.
         """
         And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         Then I will see the following on stdout:
@@ -555,14 +555,14 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo
         And I verify that running `pro enable usg` `with sudo` exits `1`
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            """
-        Then I will see the following on stderr:
-            """
-            Cannot enable unknown service 'usg'.
-            Try cc-eal, cis, esm-infra, fips, fips-updates, livepatch, realtime-kernel.
-            """
+        """
+        One moment, checking your subscription first
+        """
+        And stderr matches regexp:
+        """
+        Cannot enable unknown service 'usg'.
+        Try cc-eal, cis, esm-apps, esm-infra, fips, fips-updates, livepatch,\nrealtime-kernel.
+        """
 
         Examples: cis service
            | release |

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -76,6 +76,8 @@ Feature: Attached status
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
         fips            +yes      +disabled +NIST-certified core packages
         fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        ros             +yes      +disabled +Security Updates for the Robot Operating System
+        ros-updates     +yes      +disabled +All Updates for the Robot Operating System
 
         Enable services with: pro enable <service>
         """

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -257,4 +257,4 @@ Feature: MOTD Messages
         Examples: ubuntu release
            | release | service   |
            | xenial  | esm-infra |
-           #| bionic  | esm-apps  |
+           | bionic  | esm-apps  |

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -82,13 +82,13 @@ Feature: Security status command behavior
         Then I will see the following on stderr:
         """
         usage: security-status [-h] [--format {json,yaml,text}]
-                               [--thirdparty | --unavailable | --esm-infra]
+                               [--thirdparty | --unavailable | --esm-infra | --esm-apps]
         argument --format: invalid choice: 'unsupported' (choose from 'json', 'yaml', 'text')
         """
         Examples: ubuntu release
            | release | package   | service   |
            | xenial  | apport    | esm-infra |
-        #    | bionic  | libkrb5-3 | esm-apps  |
+           | bionic  | libkrb5-3 | esm-apps  |
 
     @series.xenial
     @uses.config.machine_type.lxd.vm
@@ -183,28 +183,28 @@ Feature: Security status command behavior
             apt-cache policy .+
         to learn more about that package\.
         """
-        # When I verify root and non-root `pro security-status --esm-apps` calls have the same output
-        # And I run `pro security-status --esm-apps` as non-root
-        # Then stdout matches regexp:
-        # """
-        # \d+ packages installed:
-        #  +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+        When I verify root and non-root `pro security-status --esm-apps` calls have the same output
+        And I run `pro security-status --esm-apps` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
-        # Universe/Multiverse packages are receiving security updates from
-        # Ubuntu Pro with 'esm-apps' enabled until 2026\. You have received (\d+|no) security
-        # update[s]?\.
+        Universe/Multiverse packages are receiving security updates from
+        Ubuntu Pro with 'esm-apps' enabled until 2026\. You have received (\d+|no) security
+        update[s]?\.
 
-        # Run 'pro help esm-apps' to learn more
+        Run 'pro help esm-apps' to learn more
 
-        # Package names in .*bold.* currently have an available update
-        # with 'esm-apps' enabled
-        # Packages:
-        # (.|\n)+
+        Package names in .*bold.* currently have an available update
+        with 'esm-apps' enabled
+        Packages:
+        (.|\n)+
 
-        # For example, run:
-        #     apt-cache policy .+
-        # to learn more about that package\.
-        # """
+        For example, run:
+            apt-cache policy .+
+        to learn more about that package\.
+        """
         When I run `pro disable esm-infra esm-apps` with sudo
         And I verify root and non-root `pro security-status` calls have the same output
         And I run `pro security-status` as non-root
@@ -280,32 +280,32 @@ Feature: Security status command behavior
             apt-cache policy .+
         to learn more about that package\.
         """
-        # When I verify root and non-root `pro security-status --esm-apps` calls have the same output
-        # And I run `pro security-status --esm-apps` as non-root
-        # Then stdout matches regexp:
-        # """
-        # \d+ packages installed:
-        #  +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+        When I verify root and non-root `pro security-status --esm-apps` calls have the same output
+        And I run `pro security-status --esm-apps` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
-        # Ubuntu Pro with 'esm-apps' enabled provides security updates for
-        # Universe/Multiverse packages until 2026 and has 1 pending security update[s]?\.
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2026 and has 1 pending security update[s]?\.
 
-        # Run 'pro help esm-apps' to learn more
+        Run 'pro help esm-apps' to learn more
 
-        # Package names in .*bold.* currently have an available update
-        # with 'esm-apps' enabled
-        # Packages:
-        # (.|\n)+
+        Package names in .*bold.* currently have an available update
+        with 'esm-apps' enabled
+        Packages:
+        (.|\n)+
 
-        # For example, run:
-        #     apt-cache policy .+
-        # to learn more about that package\.
-        # """
+        For example, run:
+            apt-cache policy .+
+        to learn more about that package\.
+        """
         When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
         Then I will see the following on stderr
         """
         usage: security-status [-h] [--format {json,yaml,text}]
-                               [--thirdparty | --unavailable | --esm-infra]
+                               [--thirdparty | --unavailable | --esm-infra | --esm-apps]
         argument --unavailable: not allowed with argument --thirdparty
         """
 
@@ -370,28 +370,28 @@ Feature: Security status command behavior
         After the LTS period ends, Main/Restricted packages will get security updates
         from Ubuntu Pro with 'esm-infra' enabled\.
         """
-        # When I verify root and non-root `pro security-status --esm-apps` calls have the same output
-        # And I run `pro security-status --esm-apps` as non-root
-        # Then stdout matches regexp:
-        # """
-        # \d+ packages installed:
-        #  +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+        When I verify root and non-root `pro security-status --esm-apps` calls have the same output
+        And I run `pro security-status --esm-apps` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
-        # Universe/Multiverse packages are receiving security updates from
-        # Ubuntu Pro with 'esm-apps' enabled until 2030\. You have received (\d+|no) security
-        # update[s]?\.
+        Universe/Multiverse packages are receiving security updates from
+        Ubuntu Pro with 'esm-apps' enabled until 2030\. You have received (\d+|no) security
+        update[s]?\.
 
-        # Run 'pro help esm-apps' to learn more
+        Run 'pro help esm-apps' to learn more
 
-        # Package names in .*bold.* currently have an available update
-        # with 'esm-apps' enabled
-        # Packages:
-        # (.|\n)+
+        Package names in .*bold.* currently have an available update
+        with 'esm-apps' enabled
+        Packages:
+        (.|\n)+
 
-        # For example, run:
-        #     apt-cache policy .+
-        # to learn more about that package\.
-        # """
+        For example, run:
+            apt-cache policy .+
+        to learn more about that package\.
+        """
         When I run `pro disable esm-infra esm-apps` with sudo
         And I verify root and non-root `pro security-status` calls have the same output
         And I run `pro security-status` as non-root
@@ -456,32 +456,32 @@ Feature: Security status command behavior
         After the LTS period ends, Main/Restricted packages will get security updates
         from Ubuntu Pro with 'esm-infra' enabled\.
         """
-        # When I verify root and non-root `pro security-status --esm-apps` calls have the same output
-        # And I run `pro security-status --esm-apps` as non-root
-        # Then stdout matches regexp:
-        # """
-        # \d+ packages installed:
-        #  +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+        When I verify root and non-root `pro security-status --esm-apps` calls have the same output
+        And I run `pro security-status --esm-apps` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
-        # Ubuntu Pro with 'esm-apps' enabled provides security updates for
-        # Universe/Multiverse packages until 2030 and has 1 pending security update[s]?\.
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2030 and has 1 pending security update[s]?\.
 
-        # Run 'pro help esm-apps' to learn more
+        Run 'pro help esm-apps' to learn more
 
-        # Package names in .*bold.* currently have an available update
-        # with 'esm-apps' enabled
-        # Packages:
-        # (.|\n)+
+        Package names in .*bold.* currently have an available update
+        with 'esm-apps' enabled
+        Packages:
+        (.|\n)+
 
-        # For example, run:
-        #     apt-cache policy .+
-        # to learn more about that package\.
-        # """
+        For example, run:
+            apt-cache policy .+
+        to learn more about that package\.
+        """
         When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
         Then I will see the following on stderr
         """
         usage: security-status [-h] [--format {json,yaml,text}]
-                               [--thirdparty | --unavailable | --esm-infra]
+                               [--thirdparty | --unavailable | --esm-infra | --esm-apps]
         argument --unavailable: not allowed with argument --thirdparty
         """
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -307,26 +307,30 @@ Feature: Command behaviour when unattached
         When I press tab twice to autocomplete the `ua enable` command
         Then stdout matches regexp:
         """
-        cc-eal  +esm-infra  +fips-updates  +realtime-kernel\r
-        cis     +fips       +livepatch
+        cc-eal  +esm-infra +livepatch +ros-updates\r
+        cis     +fips +realtime-kernel +\r
+        esm-apps +fips-updates +ros +\r
         """
         When I press tab twice to autocomplete the `pro enable` command
         Then stdout matches regexp:
         """
-        cc-eal  +esm-infra  +fips-updates  +realtime-kernel\r
-        cis     +fips       +livepatch
+        cc-eal  +esm-infra +livepatch +ros-updates\r
+        cis     +fips +realtime-kernel +\r
+        esm-apps +fips-updates +ros +\r
         """
         When I press tab twice to autocomplete the `ua disable` command
         Then stdout matches regexp:
         """
-        cc-eal  +esm-infra  +fips-updates  +realtime-kernel\r
-        cis     +fips       +livepatch
+        cc-eal  +esm-infra +livepatch +ros-updates\r
+        cis     +fips +realtime-kernel +\r
+        esm-apps +fips-updates +ros +\r
         """
         When I press tab twice to autocomplete the `pro disable` command
         Then stdout matches regexp:
         """
-        cc-eal  +esm-infra  +fips-updates  +realtime-kernel\r
-        cis     +fips       +livepatch
+        cc-eal  +esm-infra +livepatch +ros-updates\r
+        cis     +fips +realtime-kernel +\r
+        esm-apps +fips-updates +ros +\r
         """
 
         Examples: ubuntu release

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -40,23 +40,11 @@ Feature: Command behaviour when unattached
         """
         -32768 <esm-infra-url> <release>-infra-updates/main amd64 Packages
         """
-        And stdout does not match regexp:
-        """
-        -32768 <esm-apps-url> <release>-apps-updates/main amd64 Packages
-        """
-        And stdout does not match regexp:
-        """
-        -32768 <esm-apps-url> <release>-apps-security/main amd64 Packages
-        """
-        When I append the following on uaclient config:
-            """
-            features:
-              allow_beta: true
-            """
-        And I run `dpkg-reconfigure ubuntu-advantage-tools` with sudo
-        And I run `apt-get update` with sudo
-        When I run `apt-cache policy` with sudo
         Then stdout matches regexp:
+        """
+        -32768 <esm-infra-url> <release>-infra-security/main amd64 Packages
+        """
+        And stdout matches regexp:
         """
         -32768 <esm-apps-url> <release>-apps-updates/main amd64 Packages
         """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -57,6 +57,8 @@ Feature: Unattached status
         fips            +yes       +NIST-certified core packages
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         livepatch       +yes       +Canonical Livepatch service
+        ros             +yes       +Security Updates for the Robot Operating System
+        ros-updates     +yes       +All Updates for the Robot Operating System
 
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro
@@ -121,6 +123,7 @@ Feature: Unattached status
         Then stdout matches regexp:
         """
         SERVICE         +AVAILABLE +DESCRIPTION
+        esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +yes       +NIST-certified core packages
         fips-updates    +yes       +NIST-certified core packages with priority security updates
@@ -186,6 +189,7 @@ Feature: Unattached status
         Then stdout matches regexp:
         """
         SERVICE         +AVAILABLE +DESCRIPTION
+        esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -309,6 +313,7 @@ Feature: Unattached status
         Then stdout matches regexp:
         """
         SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified core packages
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
@@ -368,6 +373,7 @@ Feature: Unattached status
         Then stdout matches regexp:
         """
         SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         """
@@ -454,6 +460,8 @@ Feature: Unattached status
             fips            +yes       +yes       +no           +NIST-certified core packages
             fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
             livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+            ros             +yes       +no        +no           +Security Updates for the Robot Operating System
+            ros-updates     +yes       +no        +no           +All Updates for the Robot Operating System
             """
 
         Examples: ubuntu release

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -52,6 +52,7 @@ Feature: Unattached status
         SERVICE         +AVAILABLE +DESCRIPTION
         cc-eal          +yes       +Common Criteria EAL2 Provisioning Packages
         cis             +yes       +Security compliance and audit tools
+        esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +yes       +NIST-certified core packages
         fips-updates    +yes       +NIST-certified core packages with priority security updates
@@ -249,6 +250,7 @@ Feature: Unattached status
         SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
         cc-eal          +yes       +yes       +no           +Common Criteria EAL2 Provisioning Packages
         cis             +yes       +yes       +no           +Security compliance and audit tools
+        esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified core packages
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
@@ -447,6 +449,7 @@ Feature: Unattached status
             SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
             cc-eal          +yes       +yes       +no           +Common Criteria EAL2 Provisioning Packages
             cis             +yes       +yes       +no           +Security compliance and audit tools
+            esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
             esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
             fips            +yes       +yes       +no           +NIST-certified core packages
             fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
@@ -488,6 +491,7 @@ Feature: Unattached status
         Contract \".*\" expired on .*
 
         SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified core packages
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
@@ -529,6 +533,7 @@ Feature: Unattached status
         Contract \".*\" expired on .*
 
         SERVICE         +AVAILABLE +ENTITLED  +AUTO_ENABLED +DESCRIPTION
+        esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -516,11 +516,11 @@ def security_status_parser(parser):
         help=("List and present information about esm-infra packages"),
         action="store_true",
     )
-    # group.add_argument(
-    #     "--esm-apps",
-    #     help=("List and present information about esm-apps packages"),
-    #     action="store_true",
-    # )
+    group.add_argument(
+        "--esm-apps",
+        help=("List and present information about esm-apps packages"),
+        action="store_true",
+    )
     return parser
 
 
@@ -567,8 +567,8 @@ def action_security_status(args, *, cfg, **kwargs):
             security_status.list_unavailable_packages()
         elif args.esm_infra:
             security_status.list_esm_infra_packages(cfg)
-        # elif args.esm_apps:
-        #     security_status.list_esm_apps_packages(cfg)
+        elif args.esm_apps:
+            security_status.list_esm_apps_packages(cfg)
         else:
             security_status.security_status(cfg)
     elif args.format == "json":

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -76,7 +76,6 @@ class ESMAppsEntitlement(ESMBaseEntitlement):
     description = "Expanded Security Maintenance for Applications"
     repo_key_file = "ubuntu-advantage-esm-apps.gpg"
     apt_repo_name = "apps"
-    is_beta = True
 
     @property
     def repo_pin_priority(self) -> Optional[str]:

--- a/uaclient/entitlements/ros.py
+++ b/uaclient/entitlements/ros.py
@@ -7,7 +7,6 @@ from uaclient.entitlements.base import UAEntitlement
 class ROSCommonEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/robotics/ros-esm"
     repo_key_file = "ubuntu-advantage-ros.gpg"
-    is_beta = True
 
 
 class ROSEntitlement(ROSCommonEntitlement):

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -197,7 +197,6 @@ class TestESMInfraEntitlementEnable:
                 }
             },
             suites=["xenial"],
-            allow_beta=True,
         )
         patched_packages = ["a", "b"]
         original_exists = os.path.exists
@@ -386,17 +385,12 @@ class TestESMInfraEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         assert 0 == m_add_pinning.call_count
         assert subp_calls == m_subp.call_args_list
-        if entitlement.name == "esm-infra":
-            # Enable esm-infra xenial removes apt preferences pin 'never' file
-            remove_file_calls = [
-                mock.call(
-                    "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name)
-                )
-            ]
-        else:
-            remove_file_calls = (
-                []
-            )  # esm-apps there is no apt pref file to remove
+        # Enable esm-infra/apps xenial removes apt preferences pin 'never' file
+        remove_file_calls = [
+            mock.call(
+                "/etc/apt/preferences.d/ubuntu-{}".format(entitlement.name)
+            )
+        ]
         assert remove_file_calls == m_remove_file.call_args_list
         assert [
             mock.call(run_apt_update=False)

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -78,6 +78,8 @@ Client to manage Ubuntu Pro services on a machine.
    (https://ubuntu.com/cc-eal)
  - cis: Security compliance and audit tools
    (https://ubuntu.com/security/certifications/docs/usg)
+ - esm-apps: Expanded Security Maintenance for Applications
+   (https://ubuntu.com/security/esm)
  - esm-infra: Expanded Security Maintenance for Infrastructure
    (https://ubuntu.com/security/esm)
  - fips-updates: NIST-certified core packages with priority security updates

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -40,7 +40,7 @@ Disable an Ubuntu Pro service.
 Arguments:
   service              the name(s) of the Ubuntu Pro services to disable. One
                        of: cc-eal, cis, esm-apps, esm-infra, fips, fips-
-                       updates, livepatch, realtime-kernel
+                       updates, livepatch, realtime-kernel, ros, ros-updates
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -39,8 +39,8 @@ Disable an Ubuntu Pro service.
 
 Arguments:
   service              the name(s) of the Ubuntu Pro services to disable. One
-                       of: cc-eal, cis, esm-infra, fips, fips-updates,
-                       livepatch, realtime-kernel
+                       of: cc-eal, cis, esm-apps, esm-infra, fips, fips-
+                       updates, livepatch, realtime-kernel
 
 Flags:
   -h, --help           show this help message and exit
@@ -63,6 +63,7 @@ class TestDisable:
                 ):
                     main()
         out, _err = capsys.readouterr()
+        print(out)
         assert HELP_OUTPUT == out
 
     @pytest.mark.parametrize("service", [["testitlement"], ["ent1", "ent2"]])

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -20,8 +20,8 @@ Enable an Ubuntu Pro service.
 
 Arguments:
   service              the name(s) of the Ubuntu Pro services to enable. One
-                       of: cc-eal, cis, esm-infra, fips, fips-updates,
-                       livepatch, realtime-kernel
+                       of: cc-eal, cis, esm-apps, esm-infra, fips, fips-
+                       updates, livepatch, realtime-kernel
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -21,7 +21,7 @@ Enable an Ubuntu Pro service.
 Arguments:
   service              the name(s) of the Ubuntu Pro services to enable. One
                        of: cc-eal, cis, esm-apps, esm-infra, fips, fips-
-                       updates, livepatch, realtime-kernel
+                       updates, livepatch, realtime-kernel, ros, ros-updates
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -17,7 +17,7 @@ M_PATH = "uaclient.cli."
 HELP_OUTPUT = textwrap.dedent(
     """\
 usage: security-status \[-h\] \[--format {json,yaml,text}\]
-                       \[--thirdparty \| --unavailable \| --esm-infra\]
+                       \[--thirdparty \| --unavailable \| --esm-infra\ \| --esm-apps]
 
 Show security updates for packages in the system, including all
 available Expanded Security Maintenance \(ESM\) related content.
@@ -45,6 +45,7 @@ complete status on Ubuntu Pro services, run 'pro status'.
   --unavailable         List and present information about unavailable
                         packages
   --esm-infra           List and present information about esm-infra packages
+  --esm-apps            List and present information about esm-apps packages
 """  # noqa
 )
 

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -800,25 +800,6 @@ class TestActionStatus:
         ), mock.patch.object(event, "_command", "status"):
             assert 0 == action_status(args, cfg=cfg)
 
-        beta_services = [
-            {
-                "auto_enabled": "no",
-                "available": "no",
-                "description": (
-                    "Security Updates for the Robot Operating System"
-                ),
-                "entitled": "no",
-                "name": "ros",
-            },
-            {
-                "auto_enabled": "no",
-                "available": "no",
-                "description": "All Updates for the Robot Operating System",
-                "entitled": "no",
-                "name": "ros-updates",
-            },
-        ]
-
         services = [
             {
                 "auto_enabled": "yes",
@@ -864,11 +845,25 @@ class TestActionStatus:
                 "entitled": "no",
                 "name": "realtime-kernel",
             },
+            {
+                "auto_enabled": "no",
+                "available": "no",
+                "description": (
+                    "Security Updates for the Robot Operating System"
+                ),
+                "entitled": "no",
+                "name": "ros",
+            },
+            {
+                "auto_enabled": "no",
+                "available": "no",
+                "description": "All Updates for the Robot Operating System",
+                "entitled": "no",
+                "name": "ros-updates",
+            },
         ]
 
-        expected_services = sorted(
-            services + beta_services, key=lambda x: x["name"]
-        )
+        expected_services = sorted(services, key=lambda x: x["name"])
         if not use_all:
             expected_services = [
                 service

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -82,6 +82,7 @@ ros-updates      no         no         no            All Updates for the Robot O
 
 SIMULATED_STATUS = """\
 SERVICE          AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
+esm-apps         yes        no         yes           Expanded Security Maintenance for Applications
 esm-infra        yes        yes        yes           Expanded Security Maintenance for Infrastructure
 livepatch        yes        yes        no            Canonical Livepatch service
 """  # noqa: E501
@@ -103,6 +104,7 @@ See https://ubuntu.com/pro
 
 UNATTACHED_STATUS = """\
 SERVICE          AVAILABLE  DESCRIPTION
+esm-apps         yes        Expanded Security Maintenance for Applications
 esm-infra        yes        Expanded Security Maintenance for Infrastructure
 livepatch        yes        Canonical Livepatch service
 
@@ -132,6 +134,7 @@ Technical support level: n/a
 # Omit beta services from status
 ATTACHED_STATUS = """\
 SERVICE          ENTITLED  STATUS    DESCRIPTION
+esm-apps         no        {dash}         Expanded Security Maintenance for Applications
 esm-infra        no        {dash}         Expanded Security Maintenance for Infrastructure
 livepatch        no        {dash}         Canonical Livepatch service
 {notices}{features}
@@ -143,7 +146,6 @@ Enable services with: pro enable <service>
 Technical support level: n/a
 """  # noqa: E501
 
-BETA_SVC_NAMES = ["esm-apps", "realtime-kernel", "ros", "ros-updates"]
 
 SERVICES_JSON_ALL = [
     {
@@ -231,6 +233,16 @@ SERVICES_JSON_ALL = [
 ]
 
 SERVICES_JSON = [
+    {
+        "description": "Expanded Security Maintenance for Applications",
+        "description_override": None,
+        "entitled": "no",
+        "name": "esm-apps",
+        "status": "—",
+        "status_details": "",
+        "available": "yes",
+        "blocked_by": [],
+    },
     {
         "description": "Expanded Security Maintenance for Infrastructure",
         "description_override": None,
@@ -790,17 +802,11 @@ class TestActionStatus:
 
         beta_services = [
             {
-                "auto_enabled": "yes",
-                "available": "yes",
-                "description": "Expanded Security Maintenance for Applications",  # noqa
-                "entitled": "no",
-                "name": "esm-apps",
-            },
-            {
                 "auto_enabled": "no",
                 "available": "no",
-                "description": "Security Updates for the Robot Operating"
-                " System",
+                "description": (
+                    "Security Updates for the Robot Operating System"
+                ),
                 "entitled": "no",
                 "name": "ros",
             },
@@ -814,6 +820,13 @@ class TestActionStatus:
         ]
 
         services = [
+            {
+                "auto_enabled": "yes",
+                "available": "yes",
+                "description": "Expanded Security Maintenance for Applications",  # noqa
+                "entitled": "no",
+                "name": "esm-apps",
+            },
             {
                 "auto_enabled": "yes",
                 "available": "yes",


### PR DESCRIPTION
## Proposed Commit Message
make esm-apps non-beta

Make `esm-apps` non-beta again. Because of that we are also making both `ros` and `ros-updates` non-beta as well

## Test Steps
Verify that all existing esm-apps are not commented out and passing as expected 

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
