### PR TITLE
test ubuntu pro: add correct cloud-init user-data (SC-1270)

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -628,14 +628,18 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
     Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
         Given a `<release>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
         # This user_data should not do anything, just guarantee that the ua-auto-attach service
-        # # does nothing
+        # does nothing
         """
         ubuntu_advantage:
+          features:
+            disable_auto_attach: true
         """
         When I run `cloud-init query userdata` with sudo
         Then stdout matches regexp:
         """
         ubuntu_advantage:
+          features:
+            disable_auto_attach: true
         """
         # On GCP, this service will auto-attach the machine automatically after we override
         # the uaclient.conf file. To guarantee that we are not auto-attaching on reboot
@@ -663,6 +667,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And stdout matches regexp:
         """
         Skipping auto-attach and deferring to cloud-init to setup and configure auto-attach
+        """
+        When I run `cloud-init status` with sudo
+        Then stdout matches regexp:
+        """
+        status: done
+        """
+        When I run `pro status --wait` with sudo
+        And I run `pro security-status --format json` with sudo
+        Then stdout matches regexp:
+        """
+        "attached": false
         """
 
         Examples: ubuntu release

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -673,12 +673,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         status: done
         """
-        When I run `pro status --wait` with sudo
-        And I run `pro security-status --format json` with sudo
-        Then stdout matches regexp:
-        """
-        "attached": false
-        """
 
         Examples: ubuntu release
            | release |


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
test ubuntu pro: add correct cloud-init user-data
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Additional context

https://github.com/canonical/ubuntu-advantage-client/pull/2277

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
