### PR TITLE
ci: fix gh actions' warnings

### DIFF
--- a/.github/workflows/check-secrets-available.yaml
+++ b/.github/workflows/check-secrets-available.yaml
@@ -22,4 +22,4 @@ jobs:
         env:
           SECRET_TO_CHECK: '${{ secrets.SECRET_TO_CHECK }}'
         if: ${{ env.SECRET_TO_CHECK != '' }}
-        run: echo "::set-output name=has-secrets::true"
+        run: echo "has-secrets=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -20,7 +20,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Formatting
         run: tox -e black -e isort
       - name: Mypy
@@ -48,7 +48,7 @@ jobs:
           sudo add-apt-repository --yes ppa:deadsnakes/ppa
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install "${{ matrix.testenv.deadsnake }}" "${{ matrix.testenv.deadsnake }}-dev"
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Flake8
         run: tox -e "${{ matrix.testenv.pyver }}-flake8"
       - name: Unit

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -39,7 +39,7 @@ jobs:
           sudo sbuild-adduser $USER
           cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build package
         env:
           DEBFULLNAME: GitHub CI Auto Builder
@@ -84,7 +84,7 @@ jobs:
         if: matrix.platform == 'lxd' || matrix.platform == 'vm'
         run: sudo lxd init --auto
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Retieve debs
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -20,7 +20,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install yamllint
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Linting and style
         working-directory: .github/workflows
         run: yamllint --strict .


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
ci: fix gh actions' warnings

Upgrade to actions/checkout@v3 and migrate to Environment Files instead of `set-output`.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [x] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
