### PR TITLE
security-status: advertise esm-apps again as non beta

### DIFF
--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -134,8 +134,11 @@ Feature: Security status command behavior
         
         Ubuntu Pro with 'esm-infra' enabled provides security updates for
         Main/Restricted packages until 2026 and has \d+ pending security update[s]?\.
-        
-        Try Ubuntu Pro beta with a free personal subscription on up to 5 machines.
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2026 and has \d+ pending security update[s]?\.
+
+        Try Ubuntu Pro with a free personal subscription on up to 5 machines.
         Learn more at https://ubuntu.com/pro
         """
         When I attach `contract_token` with sudo
@@ -223,6 +226,10 @@ Feature: Security status command behavior
         Ubuntu Pro with 'esm-infra' enabled provides security updates for
         Main/Restricted packages until 2026 and has \d+ pending security update[s]?\.
         Enable esm-infra with: pro enable esm-infra
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2026 and has \d+ pending security update[s]?\.
+        Enable esm-apps with: pro enable esm-apps
         """
         When I verify root and non-root `pro security-status --thirdparty` calls have the same output
         And I run `pro security-status --thirdparty` as non-root
@@ -334,7 +341,10 @@ Feature: Security status command behavior
         
         Main/Restricted packages receive updates with LTS until 2025\.
         
-        Try Ubuntu Pro beta with a free personal subscription on up to 5 machines.
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2030 and has \d+ pending security update[s]?\.
+
+        Try Ubuntu Pro with a free personal subscription on up to 5 machines.
         Learn more at https://ubuntu.com/pro
         """
         When I attach `contract_token` with sudo
@@ -408,6 +418,10 @@ Feature: Security status command behavior
         for a list of available options\.
         
         Main/Restricted packages receive updates with LTS until 2025\.
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2030 and has \d+ pending security update[s]?\.
+        Enable esm-apps with: pro enable esm-apps
         """
         When I verify root and non-root `pro security-status --thirdparty` calls have the same output
         And I run `pro security-status --thirdparty` as non-root

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1004,7 +1004,7 @@ update{plural}."""  # noqa: E501
 
 SS_SERVICE_COMMAND = "Enable {service} with: pro enable {service}"
 SS_LEARN_MORE = """\
-Try Ubuntu Pro beta with a free personal subscription on up to 5 machines.
+Try Ubuntu Pro with a free personal subscription on up to 5 machines.
 Learn more at {url}
 """.format(
     url=BASE_UA_URL

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -529,7 +529,6 @@ def security_status(cfg: UAConfig):
     series = get_platform_info()["series"]
     is_lts = is_current_series_lts()
     is_attached = get_ua_info(cfg)["attached"]
-    esm_apps_enabled = "esm-apps" in get_ua_info(cfg)["enabled_services"]
 
     packages_by_origin = get_installed_packages_by_origin()
     security_upgradable_versions_infra = filter_security_updates(
@@ -566,14 +565,10 @@ def security_status(cfg: UAConfig):
             is_attached=is_attached,
         )
 
-    if (
-        esm_apps_enabled
-        and is_lts
-        and (
-            packages_by_origin["universe"]
-            or packages_by_origin["multiverse"]
-            or packages_by_origin["esm-apps"]
-        )
+    if is_lts and (
+        packages_by_origin["universe"]
+        or packages_by_origin["multiverse"]
+        or packages_by_origin["esm-apps"]
     ):
         _print_service_support(
             service="esm-apps",


### PR DESCRIPTION
Finish reverting the commit which hid and "re-betaed" `esm-apps`.

## Test Steps
Check and run integration tests for security status.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
