### PR TITLE
chore: remove preferred commit type from GH PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,12 +21,6 @@ this is a bug fix) this change on a live deployed system,
 including any necessary configuration files, user-data,
 setup, and teardown. Scripts used may be attached directly to this PR. -->
 
-## Desired commit type
-<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
- - [ ] Squash and merge: Using the "Proposed Commit Message"
- - [ ] Create a merge commit and use "Proposed Commit Message"
- - [ ] Rebase and merge, no merge commit, rely only on existing commit messages
-
 ## Checklist
 <!-- Go over all the following points, and put an `x` in all the boxes
 that apply. -->


### PR DESCRIPTION
We don't really use this for anything.
1. Rebase and merge is the chosen strategy for the team for a long while now
2. Merge commits are not a thing for a while too
3. Squashing implies commits divided for review but on the same functionality, which implies complexity, which implies (by PR policy) that we won't merge it without paying attention - so we will know when it is needed.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages (as always)

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
