### PR TITLE
system: make tempfile on the dir as target file

### DIFF
--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -373,7 +373,10 @@ def write_file(filename: str, content: str, mode: int = 0o644) -> None:
     """
     tmpf = None
     try:
-        tmpf = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        tmpf = tempfile.NamedTemporaryFile(
+            mode="wb", delete=False, dir=os.path.dirname(filename)
+        )
         logging.debug(
             "Writing file %s atomically via tempfile %s", filename, tmpf.name
         )
@@ -381,7 +384,6 @@ def write_file(filename: str, content: str, mode: int = 0o644) -> None:
         tmpf.flush()
         tmpf.close()
         os.chmod(tmpf.name, mode)
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
         os.rename(tmpf.name, filename)
     except Exception as e:
         if tmpf is not None:


### PR DESCRIPTION
## Proposed Commit Message
system: make tempfile on the dir as target file

When calling the write_file function, we write the content of the file first on a temp file moving it to target file. We are now creating the temp file on the same folder of the target file to avoid errors due to the files being on different filesystems

## Test Steps
Check if we can use the function to write a file on `/run` (This folder was the one that raised the issue being fixed)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
