### PR TITLE
tests: fix package versions in api integration test output

### DIFF
--- a/features/api_packages.feature
+++ b/features/api_packages.feature
@@ -30,7 +30,7 @@ Feature: Package related API endpoints
         Examples: ubuntu release
             | release | package         | outdated_version | candidate_version        | provided_by       |
             | xenial  | libcurl3-gnutls | 7.47.0-1ubuntu2  | 7.47.0-1ubuntu2.19\+esm6 | esm-infra         |
-            | bionic  | libcurl4        | 7.58.0-2ubuntu3  | 7.58.0-2ubuntu3.21       | standard-security |
-            | focal   | libcurl4        | 7.68.0-1ubuntu2  | 7.68.0-1ubuntu2.14       | standard-security |
-            | jammy   | libcurl4        | 7.81.0-1         | 7.81.0-1ubuntu1.6        | standard-security |
-            | kinetic | libcurl4        | 7.85.0-1         | 7.85.0-1ubuntu0.1        | standard-security |
+            | bionic  | libcurl4        | 7.58.0-2ubuntu3  | 7.58.0-2ubuntu3.22       | standard-security |
+            | focal   | libcurl4        | 7.68.0-1ubuntu2  | 7.68.0-1ubuntu2.15       | standard-security |
+            | jammy   | libcurl4        | 7.81.0-1         | 7.81.0-1ubuntu1.7        | standard-security |
+            | kinetic | libcurl4        | 7.85.0-1         | 7.85.0-1ubuntu0.2        | standard-security |


### PR DESCRIPTION
There was an update to `libcurl4` which is our test reference package.
I decided to bump it instead of turn it into `\d+` so we can check for the specific output. Please let me know if you prefer the regex.

## Test Steps
Run the integration test.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
