### PR TITLE
chore: remove python35 mypy check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,6 @@ setenv =
 commands =
     test: py.test --junitxml=pytest_results.xml {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient lib setup.py features
-    mypy: mypy --explicit-package-bases --check-untyped-defs --python-version 3.5 uaclient/ features/ lib/
     mypy: mypy --explicit-package-bases --check-untyped-defs --python-version 3.6 uaclient/ features/ lib/
     mypy: mypy --explicit-package-bases --check-untyped-defs --python-version 3.8 uaclient/ features/ lib/
     mypy: mypy --explicit-package-bases --check-untyped-defs --python-version 3.10 uaclient/ features/ lib/


### PR DESCRIPTION
Since today, mypy started failing to call itself even passing  `--python-version 3.5` , because some init machinery is typing variables with proper annotations, which is a deadly sin as we know it. We can, as a "good practice", run this check locally and see what fails, but CI is not happy with it anymore.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
