### PR TITLE
attach: support attaching without being able to install snapd (SC-1356)

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -672,6 +672,45 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | bionic  |
 
+    @series.xenial
+    @series.bionic
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Attach works when snapd cannot be installed
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt-get remove -y snapd` with sudo
+        And I create the file `/etc/apt/preferences.d/no-snapd` with the following
+        """
+        Package: snapd
+        Pin: release o=*
+        Pin-Priority: -10
+        """
+        And I run `apt-get update` with sudo
+        When I attempt to attach `contract_token` with sudo
+        Then I will see the following on stderr:
+        """
+        Enabling default service esm-apps
+        Enabling default service esm-infra
+        Enabling default service livepatch
+        Failed to enable default services, check: sudo pro status
+        """
+        When I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        livepatch +yes +disabled
+        """
+        Then I verify that running `pro enable livepatch` `with sudo` exits `1`
+        Then I will see the following on stdout:
+        """
+        One moment, checking your subscription first
+        Installing snapd
+        Updating package lists
+        Failed to install snapd on the system
+        """
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+
     @series.bionic
     @series.xenial
     @uses.config.machine_type.lxd.vm
@@ -703,8 +742,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release |
            | xenial  |
            | bionic  |
-           | focal   |
-           | jammy   |
+
 
     @series.xenial
     @uses.config.machine_type.lxd.vm

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -161,11 +161,14 @@ class LivepatchEntitlement(UAEntitlement):
                     " Ignoring apt-get update failure: %s",
                     str(e),
                 )
-            system.subp(
-                ["apt-get", "install", "--assume-yes", "snapd"],
-                capture=True,
-                retry_sleeps=apt.APT_RETRIES,
-            )
+            try:
+                system.subp(
+                    ["apt-get", "install", "--assume-yes", "snapd"],
+                    retry_sleeps=apt.APT_RETRIES,
+                )
+            except exceptions.ProcessExecutionError:
+                raise exceptions.CannotInstallSnapdError()
+
         elif not snap.is_installed():
             raise exceptions.SnapdNotProperlyInstalledError(
                 snap_cmd=snap.SNAP_CMD, service=self.title

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -97,6 +97,12 @@ class SnapdNotProperlyInstalledError(UserFacingError):
         super().__init__(msg=msg.msg, msg_code=msg.name)
 
 
+class CannotInstallSnapdError(UserFacingError):
+    def __init__(self) -> None:
+        msg = messages.CANNOT_INSTALL_SNAPD
+        super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
 class ErrorInstallingLivepatch(UserFacingError):
     def __init__(self, error_msg: str) -> None:
         msg = messages.ERROR_INSTALLING_LIVEPATCH.format(error_msg=error_msg)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -541,7 +541,7 @@ APT_UPDATE_INVALID_REPO = FormattedNamedMessage(
     "apt-update-invalid-repo", "APT update failed.\n{repo_msg}"
 )
 
-APT_INSTALL_FAILED = NamedMessage("apt-install-failes", "APT install failed.")
+APT_INSTALL_FAILED = NamedMessage("apt-install-failed", "APT install failed.")
 
 APT_UPDATE_INVALID_URL_CONFIG = FormattedNamedMessage(
     "apt-update-invalid-url-config",
@@ -577,6 +577,10 @@ SNAPD_NOT_PROPERLY_INSTALLED = FormattedNamedMessage(
         "{snap_cmd} is present but snapd is not installed;"
         " cannot enable {service}"
     ),
+)
+
+CANNOT_INSTALL_SNAPD = NamedMessage(
+    "cannot-install-snapd", "Failed to install snapd on the system"
 )
 
 SSL_VERIFICATION_ERROR_CA_CERTIFICATES = FormattedNamedMessage(


### PR DESCRIPTION
The side effect is that Livepatch will not be installed/enabled, but esm will work.
LP: #1997514

## Test Steps
Run the new integration test.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
