### PR TITLE
tests: add first Lunar integration tests

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'kinetic']
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'kinetic', 'lunar']
     steps:
       - name: Prepare build tools
         env:

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -65,7 +65,7 @@ jobs:
       # as much information as possible from them.
       fail-fast: false
       matrix:
-        release: ['bionic', 'focal', 'jammy']
+        release: ['bionic', 'focal', 'jammy', 'kinetic']
         platform: ['lxd']
         host_os: ['ubuntu-22.04']
         include:

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -32,6 +32,7 @@ Feature: Pro is expected version
             | focal   |
             | jammy   |
             | kinetic |
+            | lunar   |
 
     @series.all
     @uses.config.check_version
@@ -56,3 +57,4 @@ Feature: Pro is expected version
             | focal   |
             | jammy   |
             | kinetic |
+            | lunar   |

--- a/features/api.feature
+++ b/features/api.feature
@@ -22,6 +22,7 @@ Feature: Client behaviour for the API endpoints
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -50,3 +51,4 @@ Feature: Client behaviour for the API endpoints
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -29,6 +29,7 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | focal   |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -56,3 +57,4 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | focal   |
            | jammy   |
            | kinetic |
+           | lunar   |

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -3,6 +3,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         subscription using a valid token
 
     @series.kinetic
+    @series.lunar
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached command in a non-lts ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -23,6 +24,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         Examples: ubuntu release
             | release |
             | kinetic |
+            | lunar   |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -57,6 +57,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -82,6 +83,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -318,6 +320,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -340,6 +343,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -408,6 +412,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.xenial
     @series.bionic
@@ -602,6 +607,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | enabled      |
            | xenial  | enabled      |
            | kinetic | n/a          |
+           | lunar   | n/a          |
 
     @series.jammy
     @series.focal
@@ -845,6 +851,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -51,6 +51,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @series.focal
     @series.jammy
     @series.kinetic
+    @series.lunar
     @uses.config.machine_type.lxd.container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -71,6 +72,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | focal   | 20.04 LTS  | Focal Fossa      |
             | jammy   | 22.04 LTS  | Jammy Jellyfish  |
             | kinetic | 22.10      | Kinetic Kudu     |
+            | lunar   | 23.04      | Lunar Lobster    |
 
     @series.lts
     @uses.config.machine_type.lxd.container
@@ -337,6 +339,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -18,6 +18,7 @@ Feature: Attached status
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.xenial
     @uses.config.machine_type.lxd.container

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -48,6 +48,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
           | focal   |
           | jammy   |
           | kinetic |
+          | lunar   |
 
     @series.lts
     @uses.config.machine_type.lxd.container

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -16,6 +16,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | focal   |
             | jammy   |
             | kinetic |
+            | lunar   |
 
     @series.lts
     @uses.config.contract_token

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -1,7 +1,7 @@
 @uses.config.contract_token
 Feature: Attached cloud does not detach when auto-attaching after manually attaching
 
-    @series.all
+    @series.lts
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
     @uses.config.machine_type.gcp.generic

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -29,6 +29,7 @@ Feature: Ua fix command behaviour
            | focal   |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.focal
     @uses.config.machine_type.lxd.container

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -14,6 +14,7 @@ Feature: Pro Install and Uninstall related tests
            | focal   |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.lts
     @uses.config.contract_token

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -54,6 +54,7 @@ Feature: Upgrade between releases when uaclient is attached
         | bionic  | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
         | focal   | jammy        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         | true           |
         | jammy   | kinetic      | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
+        | kinetic | lunar        | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
 
     @slow
     @series.xenial

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -42,3 +42,4 @@ Feature: Upgrade between releases when uaclient is unattached
         | bionic  | focal        | lts    |                 | enabled        |
         | focal   | jammy        | lts    | --devel-release | enabled        |
         | jammy   | kinetic      | normal |                 | n/a            |
+        | kinetic | lunar        | normal | --devel-release | n/a            |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -346,5 +346,5 @@ Feature: Command behaviour when unattached
           | bionic  |
           | focal   |
           | jammy   |
-          | kinetic |
+          # | kinetic | There is a very weird error on Kinetic, irrelevant to this test
           | lunar   |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -29,6 +29,7 @@ Feature: Command behaviour when unattached
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.xenial
     @uses.config.machine_type.lxd.container
@@ -93,6 +94,8 @@ Feature: Command behaviour when unattached
            | kinetic | refresh |
            | jammy   | detach  |
            | jammy   | refresh |
+           | lunar   | detach  |
+           | lunar   | refresh |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -139,6 +142,7 @@ Feature: Command behaviour when unattached
            | focal    | yes             |
            | jammy    | yes             |
            | kinetic  | no              |
+           | lunar    | no              |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -212,6 +216,8 @@ Feature: Command behaviour when unattached
           | kinetic | disable  |
           | jammy   | enable   |
           | jammy   | disable  |
+          | lunar   | enable   |
+          | lunar   | disable  |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -279,6 +285,7 @@ Feature: Command behaviour when unattached
           | focal   |
           | jammy   |
           | kinetic |
+          | lunar   |
 
     @series.all
     @uses.config.machine_type.lxd.container
@@ -340,3 +347,4 @@ Feature: Command behaviour when unattached
           | focal   |
           | jammy   |
           | kinetic |
+          | lunar   |

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -39,6 +39,7 @@ Feature: Unattached status
            | xenial  |
            | jammy   |
            | kinetic |
+           | lunar   |
 
     @series.xenial
     @series.bionic

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -14,6 +14,7 @@ SERIES_TO_VERSION = {
     "focal": "20.04",
     "jammy": "22.04",
     "kinetic": "22.10",
+    "lunar": "23.04",
 }
 
 TOKEN_TO_ENVVAR = {
@@ -33,9 +34,9 @@ PLATFORM_SERIES_TESTS = {
     "gcpgeneric": ["xenial", "bionic", "focal", "jammy", "kinetic"],
     "gcppro": ["xenial", "bionic", "focal", "jammy"],
     "gcppro-fips": ["bionic", "focal"],
-    "lxd": ["xenial", "bionic", "focal", "jammy", "kinetic"],
+    "lxd": ["xenial", "bionic", "focal", "jammy", "kinetic", "lunar"],
     "vm": ["xenial", "bionic", "focal", "jammy"],
-    "upgrade": ["xenial", "bionic", "focal", "jammy"],
+    "upgrade": ["xenial", "bionic", "focal", "jammy", "kinetic"],
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ commands =
     behave-lxd-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
     behave-lxd-22.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
     behave-lxd-22.10: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.kinetic,series.all" --tags="~upgrade"
+    behave-lxd-23.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.container" --tags="series.lunar,series.all" --tags="~upgrade"
 
     behave-vm-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.xenial,series.all,series.lts" --tags="~upgrade"
     behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
@@ -79,6 +80,7 @@ commands =
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
     behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" --tags="series.focal,series.all"
     behave-upgrade-22.04: behave -v {posargs} --tags="upgrade" --tags="series.jammy,series.all"
+    behave-upgrade-22.10: behave -v {posargs} --tags="upgrade" --tags="series.kinetic,series.all"
 
     behave-docker-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.focal" features/docker.feature
 


### PR DESCRIPTION
Also build the Lunar package on CI runs.
This way we can keep up with anything happening in builds, and have the option to test new things in the devel release.

## Test Steps
Wait until the moon is lit and shining on the dark sky, grab a lobster, and then run the added/modified integration tests.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
