### PR TITLE
chore: add script to test local changes in multipass

### DIFF
--- a/tools/test-in-multipass.sh
+++ b/tools/test-in-multipass.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+series=$1
+
+set -x
+
+build_out=$(./tools/build.sh $series)
+hash=$(echo $build_out | jq -r .state_hash)
+deb=$(echo $build_out | jq -r .debs[] | grep tools)
+name=ua-$series-$hash
+
+multipass delete $name --purge
+multipass launch $series --name $name
+sleep 30
+# Snaps won't access /tmp
+cp $deb ~/ua.deb
+multipass transfer ~/ua.deb $name:/tmp/ua.deb
+rm -f ~/ua.deb
+
+if [ -n "$SHELL_BEFORE" ]; then
+    set +x
+    echo
+    echo
+    echo "New version of pro has not been installed yet."
+    echo "After you exit the shell we'll upgrade pro and bring you right back."
+    echo
+    set -x
+    multipass exec $name bash
+fi
+
+multipass exec $name -- sudo dpkg -i /tmp/ua.deb
+multipass shell $name


### PR DESCRIPTION
Inspired by a change that @orndorffgrant has done in #2167, to run local changes in VMs, and moved by my struggle to make Xenial/Bionic VMs run.
Also, multipass ships the generic kernel as default so testing livepatch there may be important on some scenarios.

I didn't bother to change our script to accept more parameters and act accordingly, but instead copypastaed it...
If you think it is better to change `test-in-lxd.sh`  to accept multipass as a parameter, just close this PR and I'll make that instead.
