### PR TITLE
Part 1: docs styleguide polishing

### DIFF
--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -2,17 +2,91 @@ Ubuntu Pro Client how-to guides
 *******************************
 
 If you have a specific goal and are already familiar with the Ubuntu Pro Client
-(``pro``), our How-to guides have more in-depth detail than our tutorials and
+(``pro``), our how-to guides have more in-depth detail than our tutorials and
 can be applied to a wider range of situations.
 
 They will help you to achieve a particular end result, but may require you to
 understand and adapt the steps to fit your specific requirements.
 
-How-to guides
-=============
+How to use ``pro`` commands
+===========================
+
+``attach``
+----------
 
 ..  toctree::
     :maxdepth: 1
-    :glob:
 
-    howtoguides/*
+    Get an Ubuntu Pro token and attach to a subscription <howtoguides/get_token_and_attach.md>
+    Attach with a configuration file <howtoguides/how_to_attach_with_config_file.md>
+
+``collect-logs``
+----------------
+
+..  toctree::
+    :maxdepth: 1
+
+    Collect data logs for bug reporting <howtoguides/how_to_collect_logs.md>
+
+``config``
+----------
+
+..  toctree::
+    :maxdepth: 1
+
+    Configure a proxy <howtoguides/configure_proxies.md>
+    Configure a timer job <howtoguides/configuring_timer_jobs.md>
+
+``enable``
+----------
+
+..  toctree::
+    :maxdepth: 1
+
+    Enable Pro Services in a Dockerfile <howtoguides/enable_in_dockerfile.md>
+    Enable CC EAL <howtoguides/enable_cc.md>
+    Enable CIS <howtoguides/enable_cis.md>
+    Enable Expanded Security Maintenance for Infrastructure <howtoguides/enable_esm_infra.md>
+    Enable FIPS <howtoguides/enable_fips.md>
+    Enable Livepatch <howtoguides/enable_livepatch.md>
+    Enable Real-Time Kernel <howtoguides/enable_realtime_kernel.md>
+
+``fix``
+-------
+
+..  toctree::
+    :maxdepth: 1
+
+    Run `fix` in "dry run" mode <howtoguides/how_to_run_fix_in_dry_run_mode.md>
+
+``refresh``
+-----------
+
+..  toctree::
+    :maxdepth: 1
+
+    Update MOTD and APT messages <howtoguides/update_motd_messages.md>
+
+``status``
+----------
+
+..  toctree::
+    :maxdepth: 1
+
+    Simulate the `attach` operation <howtoguides/how_to_simulate_attach.md>
+
+``version``
+-----------
+
+..  toctree::
+    :maxdepth: 1
+
+    Check Ubuntu Pro Client version <howtoguides/check_pro_version>
+    
+Create a ``pro`` Golden Image
+=============================
+
+..  toctree::
+    :maxdepth: 1
+
+    Create a customised Cloud Ubuntu Pro image <howtoguides/create_pro_golden_image.md>

--- a/docs/howtoguides/check_pro_version.md
+++ b/docs/howtoguides/check_pro_version.md
@@ -1,12 +1,13 @@
-# How to check the Ubuntu Pro client version
+# How to check your Ubuntu Pro Client version
 
-There are two ways to check the version of the Pro Client. You can use the command:
+There are two ways to check the current version of the Ubuntu Pro Client you
+are running. You can use the command:
 
 ```bash
 pro version
 ```
 
-Or the alternative
+Or the alternative:
 
 ```bash
 pro --version

--- a/docs/howtoguides/configure_proxies.md
+++ b/docs/howtoguides/configure_proxies.md
@@ -1,11 +1,13 @@
-# How to configure proxies
+# How to configure a proxy
 
-The Ubuntu Pro Client can be configured to use an HTTP/HTTPS proxy as needed for network requests. It will
-also honor the `no_proxy` environment variable if set to avoid using local proxies for certain
-outbound traffic. In addition, the Ubuntu Pro Client will automatically set up proxies for all programs
-required for enabling Ubuntu Pro services. This includes APT, Snaps, and Livepatch.
+The Ubuntu Pro Client can be configured to use an HTTP/HTTPS proxy as needed
+for network requests. It will also honor the `no_proxy` environment variable
+(if set) to avoid using local proxies for certain outbound traffic. In
+addition, the Ubuntu Pro Client will automatically set up proxies for all
+programs required for enabling Ubuntu Pro services. This includes APT, Snaps,
+and Livepatch.
 
-## HTTP/HTTPS Proxies
+## HTTP/HTTPS proxies
 
 To configure standard HTTP and/or HTTPS proxies, run the following commands:
 
@@ -14,14 +16,15 @@ $ sudo pro config set http_proxy=http://host:port
 $ sudo pro config set https_proxy=https://host:port
 ```
 
-After running the above commands, Ubuntu Pro Client:
+After running the above commands, Ubuntu Pro Client will:
 
-1. Verifies that the proxy is working by using it to reach `api.snapcraft.io`
-2. Configures itself to use the given proxy for all future network requests
-3. If snapd is installed, configures snapd to use the given proxy
-4. If Livepatch has already been enabled, configures Livepatch to use the given proxy
-   1. If Livepatch is enabled after this command, Ubuntu Pro Client will configure
-      Livepatch to use the given proxy at that time.
+1. Verify that the proxy is working by using it to reach `api.snapcraft.io`
+2. Configure itself to use the given proxy for all future network requests
+3. Configure `snapd` (if `snapd` is installed) to use the given proxy
+4. Configure Livepatch (if Livepatch has already been enabled) to use the given
+   proxy
+   1. If Livepatch is enabled after the `config` command, Ubuntu Pro Client
+      will configure Livepatch to use the given proxy at that time.
 
 To remove HTTP/HTTPS proxy configuration, run the following:
 
@@ -31,26 +34,27 @@ $ sudo pro config unset https_proxy
 ```
 
 After running the above commands, Ubuntu Pro Client will also remove proxy
-configuration from snapd (if installed) and Livepatch (if enabled).
+configuration from `snapd` (if installed) and Livepatch (if enabled).
 
-## APT Proxies
+## APT proxies
 
-APT proxy settings are configured separately. To have Ubuntu Pro Client manage your
-global APT proxy configuration, run the following commands:
+APT proxy settings are configured separately. To have Ubuntu Pro Client manage
+your global APT proxy configuration, run the following commands:
 
 ```console
 $ sudo pro config set global_apt_http_proxy=http://host:port
 $ sudo pro config set global_apt_https_proxy=https://host:port
 ```
 
-After running the above commands, Ubuntu Pro Client:
+After running the above commands, Ubuntu Pro Client will:
 
-1. Verifies that the proxy works by using it to reach `archive.ubuntu.com` or `esm.ubuntu.com`.
-2. Configures APT to use the given proxy by writing an apt configuration file to
+1. Verify that the proxy works by using it to reach `archive.ubuntu.com` or
+   `esm.ubuntu.com`.
+2. Configure APT to use the given proxy by writing an apt configuration file to
    `/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy`.
 
 ```{caution}
-Any configuration file that comes later in the apt.conf.d
+Any configuration file that comes later in the `apt.conf.d`
 directory could override the proxy configured by the Ubuntu Pro Client.
 ```
 
@@ -63,38 +67,41 @@ $ sudo pro config unset global_apt_https_proxy
 
 ```{attention}
 Starting in version 27.9, APT proxy config options changed.
-The old settings: `apt_http_proxy` and `apt_https_proxy` will still work and will be treated the
-same as `global_apt_http_proxy` and `global_apt_https_proxy`, respectively.
+The old settings: `apt_http_proxy` and `apt_https_proxy` will still work and
+will be treated the same as `global_apt_http_proxy` and
+`global_apt_https_proxy`, respectively.
 ```
 
-### Pro-service-only APT Proxies
+### Pro-service-only APT proxies
 
-To set an apt proxy that will only be used for Ubuntu Pro services, use the following commands instead:
+To set an APT proxy that will only be used for Ubuntu Pro services, use the
+following commands instead:
 
 ```console
 $ sudo pro config set ua_apt_http_proxy=http://host:port
 $ sudo pro config set ua_apt_https_proxy=https://host:port
 ```
 
-## Authenticating
+## Authenticate your proxy server
 
-If your proxy server requires authentication, you can pass
-the credentials directly in the URL when setting the
-configuration, as in:
+If your proxy server requires authentication, you can pass the credentials
+directly in the URL when setting the configuration, as in:
 
 ```
 $ sudo pro config set https_proxy=https://username:password@host:port
 ```
 
-## Checking the configuration
+## Check the configuration
 
-To see what proxies Ubuntu Pro Client is currently configured to use, you can use the show command.
+To see which proxies Ubuntu Pro Client is currently configured to use, you can
+use the `show` command.
 
 ```console
 $ sudo pro config show
 ```
 
-The above will output something that looks like the following if there are proxies set:
+The above will output something that looks like the following if there are
+proxies set:
 
 ```
 http_proxy             http://proxy

--- a/docs/howtoguides/configuring_timer_jobs.md
+++ b/docs/howtoguides/configuring_timer_jobs.md
@@ -1,29 +1,27 @@
 # How to configure a timer job
 
 All timer jobs can be configured through the `pro config set` command.
-We will show how we can properly use that command to interact with those jobs.
+We will show how you can properly use this command to interact with timer jobs.
 
+## Check a timer job's configuration
 
-## How to check timer jobs configuration
-
-To see each job’s running interval, use the show command:
+To see each job’s running interval, use the `show` command:
 
 ```console
 $ sudo pro config show
 ```
 
-You should see output which include the timer jobs:
+You should see output which includes the timer jobs:
 
 ```
 update_messaging_timer  21600
 metering_timer          14400
 ```
 
-
-## Changing a timer job interval
+## Change a timer job interval
 
 Each job has a configuration option of the form `<job_name>_timer`,
-which can be set with `pro config`.  The expected value is a positive
+which can be set with `pro config`. The expected value is a positive
 integer for the number of seconds in the interval. For example, to
 change the `update_messaging job` timer interval to run every 24 hours, run:
 
@@ -31,8 +29,7 @@ change the `update_messaging job` timer interval to run every 24 hours, run:
 $ sudo pro config set update_messaging_timer=86400
 ```
 
-
-## How to disable a timer job
+## Disable a timer job
 
 To disable a job, set its interval to zero. For instance, to disable
 the `update_messaging`  job, run:

--- a/docs/howtoguides/create_pro_golden_image.md
+++ b/docs/howtoguides/create_pro_golden_image.md
@@ -1,10 +1,14 @@
-# How to create a customized Cloud Ubuntu Pro image
+# How to create a customised Cloud Ubuntu Pro image
 
-* Launch a Ubuntu Pro instance on your cloud of choice
+* Launch an Ubuntu Pro instance on your cloud of choice
 * Customize the instance as you see fit
-* `sudo rm /etc/machine-id`
+* Run the command: `sudo rm /etc/machine-id`
 * Use your cloud platform to clone or snapshot this VM as a golden image
 
 ```{tip}
-Prior to version 27.11 - when launching instances based on this instance, you will need to re-enable any non-standard Ubuntu Pro services that you enabled on the image. This will be faster on the new instance because it was already enabled on the image. You will not need to reboot for e.g. `fips` or `fips-updates`.
+Prior to version 27.11 - when launching instances based on this instance,
+you will need to re-enable any non-standard Ubuntu Pro services that you
+enabled on the image. This will be faster on the new instance because it was
+already enabled on the image. You will not need to reboot for e.g. `fips` or
+`fips-updates`.
 ```

--- a/docs/howtoguides/enable_cc.md
+++ b/docs/howtoguides/enable_cc.md
@@ -11,7 +11,7 @@ please see https://ubuntu.com/security/cc
 
 ## Enable and auto-install
 
-To enable CC EAL through Ubuntu Advantage, please run:
+To enable CC EAL using the Ubuntu Pro Client, please run:
 
 ```console
 $ sudo pro enable cc-eal

--- a/docs/howtoguides/enable_cc.md
+++ b/docs/howtoguides/enable_cc.md
@@ -1,22 +1,24 @@
 # How to enable CC EAL
 
-> NOTE: CC EAL can be enabled on both Xenial and Bionic, but the installed scripts
-which configure CC EAL on those machines will only run on Xenial 16.04.4 and Bionic 18.04.4
-point releases.
+```{note}
+CC EAL can be enabled on both Xenial and Bionic, but the installed scripts
+that configure CC EAL on those machines will only run on Xenial 16.04.4 and
+Bionic 18.04.4 point releases.
 
-Common Criteria is supported only on 16.04 and 18.04. For more information on it,
+Common Criteria is supported only on 16.04 and 18.04. For more information,
 please see https://ubuntu.com/security/cc
+```
 
 ## Enable and auto-install
 
-To enable it through UA, please run:
+To enable CC EAL through Ubuntu Advantage, please run:
 
 ```console
 $ sudo pro enable cc-eal
 ```
 
-You should see output like the following, indicating that the CC EAL packages has
-been installed.
+You should see output like the following, indicating that the CC EAL package
+has been installed.
 
 ```
 (This will download more than 500MB of packages, so may take some time.)
@@ -31,7 +33,8 @@ Please follow instructions in /usr/share/doc/ubuntu-commoncriteria/README to con
 The --access-only flag is introduced in version 27.11
 ```
 
-If you would like to enable access to the CC EAL apt repository but not install the packages right away, use the `--access-only` flag while enabling.
+If you would like to enable access to the CC EAL apt repository but not install
+the packages right away, use the `--access-only` flag while enabling.
 
 ```console
 $ sudo pro enable cc-eal --access-only

--- a/docs/howtoguides/enable_cis.md
+++ b/docs/howtoguides/enable_cis.md
@@ -1,15 +1,20 @@
 # How to enable CIS
 
-> NOTE: On Focal and later releases, CIS was replaced by [USG](https://ubuntu.com/security/certifications/docs/usg),
-therefore, just change `cis` to `usg` when running the enable command on those releases.
+```{note}
+On Focal (and later releases), CIS was
+[replaced by USG](https://ubuntu.com/security/certifications/docs/usg),
+therefore, just change `cis` to `usg` when running the enable command on those
+releases.
+```
 
-To access the CIS tooling first enable the software repository.
+To access the CIS tooling, first enable the software repository as follows:
 
 ```console
 $ sudo pro enable cis
 ```
 
-You should see output like the following, indicating that the CIS package has been installed.
+You should see output like the following, indicating that the CIS package has
+been installed:
 
 ```
 Installing CIS Audit packages
@@ -17,5 +22,6 @@ CIS Audit enabled
 Visit https://security-certs.docs.ubuntu.com/en/cis to learn how to use CIS
 ```
 
-Once the feature is enabled please [follow the documentation](https://ubuntu.com/security/certifications/docs/cis)
-for the CIS tooling to run the provided hardening audit scripts.
+Once the feature is enabled please
+[follow the documentation](https://ubuntu.com/security/certifications/docs/cis)
+for the CIS tooling, to run the provided hardening audit scripts.

--- a/docs/howtoguides/enable_esm_infra.md
+++ b/docs/howtoguides/enable_esm_infra.md
@@ -1,26 +1,32 @@
 # How to enable Expanded Security Maintenance for Infrastructure (`esm-infra`)
 
-For Ubuntu LTS releases, `esm-infra` will be automatically enabled after attaching
-the Ubuntu Pro Client to your account. After ubuntu-advantage-tools is installed and your machine is
-attached, `esm-infra` should be enabled. If `esm-infra` is not enabled, you can enable it
-with the following command:
+For Ubuntu LTS releases, `esm-infra` will be automatically enabled after
+attaching the Ubuntu Pro Client to your account. After `ubuntu-advantage-tools`
+is installed and your machine is attached, `esm-infra` should be enabled. If
+`esm-infra` is not enabled, you can enable it with the following command:
 
 ```console
 $ sudo pro enable esm-infra
 ```
 
-With the `esm-infra` repository enabled, specially on Ubuntu 14.04 and 16.04, you may see
-a number of additional package updates available that were not available previously.
-Even if your system had indicated that it was up to date before installing the
-ubuntu-advantage-tools and attaching, make sure to check for new package updates after
-`esm-infra` is enabled using `apt upgrade`. If you have cron jobs set to install updates, or other
-unattended upgrades configured, be aware that this will likely result in a number of package updates
-with the `esm-infra` content.
+With the `esm-infra` repository enabled, especially on Ubuntu 14.04 and 16.04,
+you may see a number of additional package updates available that were not
+available previously.
 
-Running apt upgrade will now apply all of package updates available, including the ones in `esm-infra`.
+Even if your system had indicated that it was up to date before installing the
+`ubuntu-advantage-tools` and attaching, make sure to check for new package
+updates after `esm-infra` is enabled using `apt upgrade`. If you have cron jobs
+set to install updates, or other unattended upgrades configured, be aware that
+this will likely result in a number of package updates with the `esm-infra`
+content.
+
+Running `apt upgrade` will now apply all available package updates, including
+the ones in `esm-infra`.
 
 ```console
 $ sudo apt upgrade
 ```
 
-More information: https://ubuntu.com/security/esm
+```{seealso}
+For more information, see https://ubuntu.com/security/esm
+```

--- a/docs/howtoguides/enable_fips.md
+++ b/docs/howtoguides/enable_fips.md
@@ -1,32 +1,41 @@
 # How to enable FIPS
 
+```{important}
 [FIPS is supported on 16.04, 18.04 and 20.04 releases](https://ubuntu.com/security/certifications/docs/fips).
+```
 
-To use FIPS, one can either launch existing Ubuntu premium support images which already have FIPS
-kernel and security pre-enabled on first boot at [AWS Ubuntu Pro FIPS images](https://ubuntu.com/aws/fips), [Azure Pro FIPS images](https://ubuntu.com/azure/fips) and GCP Pro FIPS Images.
+To use FIPS, one can either launch existing Ubuntu premium support images which
+already have FIPS kernel and security pre-enabled on first boot at
+[AWS Ubuntu Pro FIPS images](https://ubuntu.com/aws/fips),
+[Azure Pro FIPS images](https://ubuntu.com/azure/fips) and GCP Pro FIPS Images.
 
-Alternatively, enable FIPS using the Ubuntu Pro Client will install a FIPS-certified kernel and core security-related
-packages such as openssh-server/client and libssl. Note: disabling FIPS on an image is not yet
-supported
+Alternatively, you can enable FIPS using the Ubuntu Pro Client, which will
+install a FIPS-certified kernel and core security-related packages such as
+`openssh-server/client` and `libssl`. 
 
-```{danger}
-Enabling FIPS should be performed during a system maintenance window because this operation
-makes changes to underlying SSL related libraries and requires a reboot into the FIPS certified
-kernel.
+```{note}
+Note that disabling FIPS on an image is not yet supported.
 ```
 
 ```{danger}
-Disabling FIPS is not currently supported, only use it on machines intended expressly for this
-purpose.
+Enabling FIPS should be performed during a system maintenance window because
+this operation makes changes to underlying SSL-related libraries and requires a
+reboot into the FIPS-certified kernel.
 ```
 
-To enable, run:
+```{danger}
+Disabling FIPS is not currently supported: only use it on machines intended
+expressly for this purpose.
+```
+
+To enable FIPS, run:
 
 ```console
 $ sudo pro enable fips
 ```
 
-You should see output like the following, indicating that the FIPS packages has been installed.
+You should see output like the following, indicating that the FIPS packages has
+been installed:
 
 ```
 Installing FIPS packages

--- a/docs/howtoguides/enable_fips.md
+++ b/docs/howtoguides/enable_fips.md
@@ -13,19 +13,15 @@ Alternatively, you can enable FIPS using the Ubuntu Pro Client, which will
 install a FIPS-certified kernel and core security-related packages such as
 `openssh-server/client` and `libssl`. 
 
-```{note}
-Note that disabling FIPS on an image is not yet supported.
+```{danger}
+Disabling FIPS is not currently supported: only use it on machines intended
+expressly for this purpose.
 ```
 
 ```{danger}
 Enabling FIPS should be performed during a system maintenance window because
 this operation makes changes to underlying SSL-related libraries and requires a
 reboot into the FIPS-certified kernel.
-```
-
-```{danger}
-Disabling FIPS is not currently supported: only use it on machines intended
-expressly for this purpose.
 ```
 
 To enable FIPS, run:

--- a/docs/howtoguides/enable_in_dockerfile.md
+++ b/docs/howtoguides/enable_in_dockerfile.md
@@ -1,17 +1,25 @@
-# How to Enable Ubuntu Pro Services in a Dockerfile
+# How to enable Ubuntu Pro Services in a Dockerfile
 
-> Requires at least Ubuntu Pro Client version 27.7
-
-Ubuntu Pro comes with several services, some of which can be useful in docker. For example, Expanded Security Maintenance of packages and FIPS certified packages may be desirable in a docker image. In this how-to-guide, we show how you can use the `pro` tool to take advantage of these services in your Dockerfile.
-
-
-## Step 1: Create an Ubuntu Pro Attach Config file
-
-```{attention}
-The Ubuntu Pro Attach Config file will contain your Ubuntu Pro Contract token and should be treated as a secret file.
+```{important}
+This requires at least Ubuntu Pro Client version 27.7
 ```
 
-An attach config file for `pro` is a yaml file that specifies some options when running `pro attach`. The file has two fields, `token` and `enable_services` and looks something like this:
+Ubuntu Pro comes with several services, some of which can be useful in Docker.
+For example, Expanded Security Maintenance (ESM) of packages and FIPS-certified
+packages may be desirable in a Docker image. In this how-to guide, we show how
+you can use the `pro` tool to take advantage of these services in your
+Dockerfile.
+
+## Create an Ubuntu Pro Attach Config file
+
+```{attention}
+The Ubuntu Pro Attach Config file will contain your Ubuntu Pro Contract token
+and should be treated as a secret file.
+```
+
+An Attach Config file for `pro` is a YAML file that specifies some options when
+running `pro attach`. The file has two fields, `token` and `enable_services`
+and looks something like this:
 
 ```yaml
 token: TOKEN
@@ -21,24 +29,28 @@ enable_services:
   - service3
 ```
 
-The `token` field is required and must be set to your Ubuntu Pro token that you can get from signing into [ubuntu.com/pro](https://ubuntu.com/pro).
+The `token` field is required and must be set to your Ubuntu Pro token that you
+can get from signing into [ubuntu.com/pro](https://ubuntu.com/pro).
 
-The `enable_services` field value is a list of Ubuntu Pro service names. When it is set, then the services specified will be automatically enabled after attaching with your Ubuntu Pro token.
+The `enable_services` field value is a list of Ubuntu Pro service names. When
+it is set, then the services specified will be automatically enabled after
+attaching with your Ubuntu Pro token.
 
-Service names that you may be interested in enabling in your docker builds include:
+Service names that you may be interested in enabling in your Docker builds
+include:
+
 - `esm-infra`
 - `esm-apps`
 - `fips`
 - `fips-updates`
 
-You can find out more about these services by running `pro help service-name` on any Ubuntu machine.
+You can find out more about these services by running `pro help service-name`
+on any Ubuntu machine.
 
+## Create a Dockerfile to use `pro` and your Attach Config file
 
-## Step 2: Create a Dockerfile to use `pro` and your attach config file
-
-Your Dockerfile is going to look something like this.
-
-There are comments inline explaining each line.
+Your Dockerfile is going to look something like the following -- there are
+inline comments explaining each line:
 
 ```dockerfile
 # Base off of the LTS of your choice
@@ -105,29 +117,40 @@ RUN --mount=type=secret,id=pro-attach-config \
 # from Ubuntu Pro services, you can continue the rest of your app-specific Dockerfile.
 ```
 
-An important point to note about the above Dockerfile is that all of the `apt` and `pro` commands happen inside of one Dockerfile `RUN` instruction. This is critical and must not be changed. Keeping everything as written inside of one `RUN` instruction has two key benefits:
+An important point to note about the above Dockerfile is that all of the `apt`
+and `pro` commands happen inside one Dockerfile `RUN` instruction. This is
+critical and must not be changed. Keeping everything as written inside of
+one `RUN` instruction has two key benefits:
 
-1. Prevents any Ubuntu Pro Subscription-related tokens and secrets from being leaked in an image layer
-2. Keeps the image as small as possible by cleaning up extra packages and files before the layer is finished.
+1. It prevents any Ubuntu Pro Subscription-related tokens and secrets from
+   being leaked in an image layer.
+2. It keeps the image as small as possible by cleaning up extra packages and
+   files before the layer is finished.
 
 ```{note}
 These benefits could also be attained by squashing the image.
 ```
 
-## Step 3: Build the Docker image
+## Build the Docker image
 
-
-Now, with our attach config file and Dockerfile created, we can build the image with a command like the following
+Now, with our Attach Config file and Dockerfile created, we can build the image
+with a command like the following:
 
 ```bash
 DOCKER_BUILDKIT=1 docker build . --secret id=pro-attach-config,src=pro-attach-config.yaml -t ubuntu-focal-pro
 ```
 
-There are two important pieces of this command.
+There are two important pieces to this command.
 
-1. We enable BuildKit with `DOCKER_BUILDKIT=1`. This is necessary to support the secret mount feature.
-2. We use the secret mount feature of BuildKit with `--secret id=pro-attach-config,src=pro-attach-config.yaml`. This is what passes our attach config file in to be securely used by the `RUN --mount=type=secret,id=pro-attach-config` command in the Dockerfile.
+1. We enable BuildKit with `DOCKER_BUILDKIT=1`. This is necessary to support
+   the secret mount feature.
+2. We use the secret mount feature of BuildKit with
+   `--secret id=pro-attach-config,src=pro-attach-config.yaml`. This is what
+   passes our Attach Config file in to be securely used by the
+   `RUN --mount=type=secret,id=pro-attach-config` command in the Dockerfile.
 
 ## Success
 
-Congratulations! At this point, you should have a docker image that has been built with Ubuntu Pro packages installed from whichever Ubuntu Pro service you required.
+Congratulations! At this point, you should have a docker image that has been
+built with Ubuntu Pro packages installed from whichever Ubuntu Pro service you
+required.

--- a/docs/howtoguides/enable_livepatch.md
+++ b/docs/howtoguides/enable_livepatch.md
@@ -1,15 +1,18 @@
 # How to enable Livepatch
 
-Check if your kernel is supported by Livepatch here: https://ubuntu.com/security/livepatch/docs/kernels
+```{important}
+Check if your kernel is supported by Livepatch here: 
+https://ubuntu.com/security/livepatch/docs/kernels
+```
 
-To enable, run:
+To enable Livepatch, run:
 
 ```console
 $ sudo pro enable livepatch
 ```
 
-You should see output like the following, indicating that the Livepatch snap package has
-been installed.
+You should see output like the following, indicating that the Livepatch snap
+package has been installed successfully:
 
 ```
 One moment, checking your subscription first
@@ -19,10 +22,13 @@ Installing canonical-livepatch snap
 Canonical livepatch enabled.
 ```
 
-To check the status of Livepatch once it has been installed use this command
+To check the status of Livepatch once it has been installed use the following
+command:
 
 ```console
 $ sudo canonical-livepatch status
 ```
 
-More information: https://ubuntu.com/security/livepatch
+```{seealso}
+For more information, see: https://ubuntu.com/security/livepatch
+```

--- a/docs/howtoguides/enable_realtime_kernel.md
+++ b/docs/howtoguides/enable_realtime_kernel.md
@@ -1,8 +1,8 @@
 # How to enable Real-Time Kernel
 
 ```{caution}
-Real-Time Kernel is currently in beta and is only supported on 22.04.
-For more information, please see https://ubuntu.com/realtime-kernel
+Real-Time Kernel is only supported on 22.04. For more information, please see
+https://ubuntu.com/realtime-kernel
 ```
 
 ## Enable and auto-install
@@ -10,7 +10,7 @@ For more information, please see https://ubuntu.com/realtime-kernel
 To `enable` Real-Time Kernel through Ubuntu Advantage, please run:
 
 ```console
-$ sudo pro enable realtime-kernel --beta
+$ sudo pro enable realtime-kernel
 ```
 
 You'll need to acknowledge a warning, and then you should see output like the
@@ -43,7 +43,7 @@ If you would like to enable access to the Real-Time Kernel APT repository but
 not install the kernel right away, use the `--access-only` flag while enabling.
 
 ```console
-$ sudo pro enable realtime-kernel --beta --access-only
+$ sudo pro enable realtime-kernel --access-only
 ```
 
 With this extra flag you'll see output like the following:

--- a/docs/howtoguides/enable_realtime_kernel.md
+++ b/docs/howtoguides/enable_realtime_kernel.md
@@ -1,21 +1,20 @@
 # How to enable Real-Time Kernel
 
 ```{caution}
-Real-Time Kernel is currently in beta.
+Real-Time Kernel is currently in beta and is only supported on 22.04.
+For more information, please see https://ubuntu.com/realtime-kernel
 ```
-
-Real-Time Kernel is supported only on 22.04. For more information on it,
-please see https://ubuntu.com/realtime-kernel
 
 ## Enable and auto-install
 
-To enable it through UA, please run:
+To `enable` Real-Time Kernel through Ubuntu Advantage, please run:
 
 ```console
 $ sudo pro enable realtime-kernel --beta
 ```
 
-You'll need to acknowledge a warning and then you should see output like the following, indicating that the Real-Time Kernel package has been installed.
+You'll need to acknowledge a warning, and then you should see output like the
+following, indicating that the Real-Time Kernel package has been installed.
 
 ```
 One moment, checking your subscription first
@@ -40,13 +39,14 @@ After rebooting you'll be running the Real-Time Kernel!
 The --access-only flag is introduced in version 27.11
 ```
 
-If you would like to enable access to the Real-Time Kernel apt repository but not install the kernel right away, use the `--access-only` flag while enabling.
+If you would like to enable access to the Real-Time Kernel APT repository but
+not install the kernel right away, use the `--access-only` flag while enabling.
 
 ```console
 $ sudo pro enable realtime-kernel --beta --access-only
 ```
 
-With that extra flag you'll see output like the following:
+With this extra flag you'll see output like the following:
 
 ```
 One moment, checking your subscription first

--- a/docs/howtoguides/get_token_and_attach.md
+++ b/docs/howtoguides/get_token_and_attach.md
@@ -1,9 +1,10 @@
 # How to get an Ubuntu Pro token and attach to a subscription
 
-Retrieve your Ubuntu Pro token from the [Ubuntu Pro portal](https://ubuntu.com/pro/). You will
-log in with your SSO credentials, the same credentials you use for https://login.ubuntu.com. Note that you
-can obtain a free personal token, which provides you with access to several of the Ubuntu Pro
-services.
+Retrieve your Ubuntu Pro token from the
+[Ubuntu Pro portal](https://ubuntu.com/pro/). You will log in with your "Single 
+Sign On" credentials, the same credentials you use for https://login.ubuntu.com.
+Note that you can obtain a free personal token, which provides you with access
+to several of the Ubuntu Pro services.
 
 Once that token is obtained, to attach your machine to a subscription, just run:
 
@@ -11,8 +12,8 @@ Once that token is obtained, to attach your machine to a subscription, just run:
 $ sudo pro attach YOUR_TOKEN
 ```
 
-You should see output like the following, indicating that you have successfully associated this
-machine with your account.
+You should see output like the following, indicating that you have successfully
+associated this machine with your account.
 
 ```
 Enabling default service esm-infra
@@ -31,6 +32,6 @@ Operation in progress: pro attach
 Enable services with: pro enable <service>
 ```
 
-Once the Ubuntu Pro Client is attached to your Ubuntu Pro account, you can use it to activate various services,
-including: access to ESM packages, Livepatch, FIPS, and CIS. Some features are specific to certain
-LTS releases
+Once the Ubuntu Pro Client is attached to your Ubuntu Pro account, you can use
+it to activate various services, including: access to ESM packages, Livepatch,
+FIPS, and CIS. Some features are specific to certain LTS releases.

--- a/docs/howtoguides/how_to_attach_with_config_file.md
+++ b/docs/howtoguides/how_to_attach_with_config_file.md
@@ -1,11 +1,15 @@
 # How to attach with a configuration file
 
-To attach with a configuration file, you must run `pro attach` with the `--attach-config` flag,
-passing the path of the configuration file you intend to use.
+To attach with a configuration file, you must run `pro attach` with the
+`--attach-config` flag, passing the path of the configuration file you intend
+to use.
 
-When using `--attach-config` the token must be passed in the file rather than on the command line. This is useful in situations where it is preferred to keep the secret token in a file.
+When using `--attach-config` the token must be passed in the file rather than
+on the command line. This is useful in situations where it is preferred to keep
+the secret token in a file.
 
-Optionally, the attach config file can be used to override the services that are automatically enabled as a part of the attach process.
+Optionally, the attached config file can be used to override the services that
+are automatically enabled as a part of the attach process.
 
 An attach config file looks like this:
 ```yaml
@@ -16,7 +20,8 @@ enable_services:        # optional list of service names to auto-enable
   - cis
 ```
 
-And can be passed on the cli like this:
+And can be passed via the CLI with the following command:
+
 ```shell
 sudo pro attach --attach-config /path/to/file.yaml
 ```

--- a/docs/howtoguides/how_to_collect_logs.md
+++ b/docs/howtoguides/how_to_collect_logs.md
@@ -1,21 +1,27 @@
 # How to collect Ubuntu Pro Client logs
 
-To collect all of the necessary logs for Ubuntu Pro Client (`pro`), please run the command:
+To collect all of the necessary logs for Ubuntu Pro Client (`pro`), please run
+the command:
 
 ```console
 $ sudo pro collect-logs
 ```
 
-This command creates a tarball with all relevant data for debugging possible problems with `pro`.
+This command creates a tarball with all relevant data for debugging possible
+problems with `pro`.
+
 It puts together:
-* The Ubuntu Pro Client configuration file (the default is `/etc/ubuntu-advantage/uaclient.conf`)
+
+* The Ubuntu Pro Client configuration file (the default is
+  `/etc/ubuntu-advantage/uaclient.conf`)
 * The Ubuntu Pro Client log files (the default is `/var/log/ubuntu-advantage*`)
-* The files in `/etc/apt/sources.list.d/*` related to UA
+* The files in `/etc/apt/sources.list.d/*` related to Ubuntu Advantage
 * Output of `systemctl status` for the Ubuntu Pro Client related services
-* Status of the timer jobs, `canonical-livepatch`, and the systemd timers
+* Status of the timer jobs, `canonical-livepatch`, and the `systemd` timers
 * Output of `cloud-id`, `dmesg` and `journalctl`
 
-Sensitive data is redacted from all files included in the tarball. As of now, the command must be run as root.
+Sensitive data is redacted from all files included in the tarball. As of now,
+the command must be run as root.
 
 Running the command creates a `ua_logs.tar.gz` file in the current directory.
 The output file path/name can be changed using the `-o` option.

--- a/docs/howtoguides/how_to_collect_logs.md
+++ b/docs/howtoguides/how_to_collect_logs.md
@@ -15,7 +15,7 @@ It puts together:
 * The Ubuntu Pro Client configuration file (the default is
   `/etc/ubuntu-advantage/uaclient.conf`)
 * The Ubuntu Pro Client log files (the default is `/var/log/ubuntu-advantage*`)
-* The files in `/etc/apt/sources.list.d/*` related to Ubuntu Advantage
+* The files in `/etc/apt/sources.list.d/*` related to Ubuntu Pro
 * Output of `systemctl status` for the Ubuntu Pro Client related services
 * Status of the timer jobs, `canonical-livepatch`, and the `systemd` timers
 * Output of `cloud-id`, `dmesg` and `journalctl`

--- a/docs/howtoguides/how_to_run_fix_in_dry_run_mode.md
+++ b/docs/howtoguides/how_to_run_fix_in_dry_run_mode.md
@@ -1,8 +1,9 @@
-# How to run fix command in dry run mode
+# How to run the `fix` command in "dry run" mode
 
-If you are unsure on what changes will happen on your system after you run `pro fix` to address a
-CVE/USN, you can use the `--dry-run` flag to see that packages will be installed in the system if
-the command was actually run. For example, this is the output of running `pro fix USN-5079-2 --dry-run`:
+If you are unsure on what changes will happen on your system after you run
+`pro fix` to address a CVE/USN, you can simulate a run using the `--dry-run`
+flag to see which packages will be installed on the system. For example, this
+is the output of running `pro fix USN-5079-2 --dry-run`:
 
 ```
 WARNING: The option --dry-run is being used.
@@ -25,10 +26,10 @@ this service.
 ✔ USN-5079-2 is resolved.
 ```
 
-You can see that using `--dry-run` will also indicate which actions would need to happen
-to completely address the USN/CVE. Here we can see that the package fix can only be accessed
-through the `esm-infra` service. Therefore, we need an Ubuntu Pro subscription, as can be seen on this
-part of the output:
+You can see that using `--dry-run` will also indicate which actions would need
+to happen to completely address the USN/CVE. Here we can see that the package
+fix can only be accessed through the `esm-infra` service. Therefore, we need an
+Ubuntu Pro subscription, as can be seen in this part of the output:
 
 ```
 The machine is not attached to an Ubuntu Pro subscription.
@@ -36,7 +37,7 @@ To proceed with the fix, a prompt would ask for a valid Ubuntu Pro token.
 { pro attach TOKEN }
 ```
 
-Additionally, we also inform you that even with a subscription, we need the specific
+Additionally, it informs you that even with a subscription, we need the specific
 `esm-infra` service to be enabled:
 
 ```
@@ -46,5 +47,7 @@ this service.
 { pro enable esm-infra }
 ```
 
-After performing these steps during a fix command without `--dry-run`, your machine should
-no longer be affected by that USN we used as an example.
+```{note}
+After performing these steps during a `fix` command without `--dry-run`, your
+machine should no longer be affected by the USN we used as an example.
+```

--- a/docs/howtoguides/how_to_simulate_attach.md
+++ b/docs/howtoguides/how_to_simulate_attach.md
@@ -1,14 +1,15 @@
-# How to simulate attach operation
+# How to simulate the `attach` operation
 
-If you are unsure on what will be the state of your machine after running attach
-with a specific token, you can simulate running the attach operation by running:
+If you are unsure what will be the state of your machine after running `attach`
+with a specific token, you can simulate running the `attach` operation by
+running:
 
 ```console
 $ pro status --simulate-with-token YOUR_TOKEN
 ```
 
-After running the command, you should see a modified status table, similar to this
-one:
+After running the command, you should see a modified status table, similar to
+this one:
 
 ```
 SERVICE          AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
@@ -20,10 +21,12 @@ fips-updates     yes        yes        no            NIST-certified core package
 livepatch        yes        yes        yes           Canonical Livepatch service
 ```
 
-Here, you can see which services are entitled for that token while also verifying
-which services will be enabled by default through the **AUTO_ENABLED** column.
-The services marked as yes here, will be automatically enabled when running an
-attach operation.
+Here, you can see which services are entitled for that token while also
+verifying which services will be enabled by default through the
+**AUTO_ENABLED** column. The services marked as "yes" here will be
+automatically enabled when running an `attach` operation.
 
-Additionally, if you want more information about the **AVAILABLE** and **ENTITLED** columns,
+```{seealso}
+If you want more information about the **AVAILABLE** and **ENTITLED** columns,
 please refer to this [explanation](../explanations/status_columns.md).
+```

--- a/docs/howtoguides/update_motd_messages.md
+++ b/docs/howtoguides/update_motd_messages.md
@@ -1,11 +1,12 @@
 # How to update MOTD and APT messages
 
-Since ubuntu-advantage-tools is responsible for enabling ESM services, we advertise them on different
-applications thorough the system, such as MOTD and apt commands like upgrade.
+Since `ubuntu-advantage-tools` is responsible for enabling ESM services, we
+advertise them on different applications through the system, such as MOTD and
+APT commands like upgrade.
 
-To verify that APT and MOTD message is advertising the ESM packages, ensure that we have ESM
-source list files in the system. If that is the case, please run the following command to
-update the state of MOTD and APT messages:
+To verify that the APT and MOTD message is advertising the ESM packages, ensure
+that we have ESM source list files in the system. If that is the case, please
+run the following command to update the state of MOTD and APT messages:
 
 ```sh
 pro refresh messages

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,5 +1,5 @@
-Ubuntu Pro Client tutorials
-***************************
+Ubuntu Pro Client tutorial
+**************************
 
 This section of our documentation contains step-by-step tutorials to help
 outline what the Ubuntu Pro Client (``pro``) is capable of, while helping you
@@ -11,11 +11,30 @@ learning about ``pro``, how it works, and what it's capable of.
 
 -----
 
-Tutorials
-=========
+Core tutorial
+=============
+
+This tutorial will help you get started with ``pro``. It introduces the main
+commands available and helps to orient you with the basics of ``pro``.
+It is the ideal starting place if you're unfamiliar with ``pro`` and how it
+works.
 
 ..  toctree::
     :maxdepth: 1
-    :glob:
 
-    tutorials/*
+    tutorials/basic_commands.md
+
+Further tutorials
+=================
+
+These tutorials provide a bit more experience with common tasks. If you are
+already comfortable with the basics and want to start exploring some of the
+other things you can do with ``pro``, these tutorials are the ideal place to
+start. They are not sequential, so you can approach them in any order you like!
+
+..  toctree::
+    :maxdepth: 1
+
+    tutorials/fix_scenarios.md
+    tutorials/create_a_fips_docker_image.md
+    tutorials/create_a_fips_updates_pro_cloud_image.md

--- a/docs/tutorials/basic_commands.md
+++ b/docs/tutorials/basic_commands.md
@@ -1,54 +1,61 @@
-# Getting started with Ubuntu Pro Client
+# Get started with Ubuntu Pro Client
 
-The Ubuntu Pro Client (`pro`) provides a simple mechanism for viewing, enabling and
-disabling offerings from Canonical on your system. In this tutorial
-we will cover the base `pro` commands that allow you to successfully manage the offering
+The Ubuntu Pro Client (`pro`) provides a simple mechanism for viewing, enabling
+and disabling offerings from Canonical on your system. In this tutorial we will
+cover the base `pro` commands that help you to successfully manage the offering
 on your machine.
 
-## Prerequisites
+## Main `pro` commands
 
-In this tutorial, you will use [Multipass](https://multipass.run/) virtual machines (VM).
+When dealing with `pro` through the command line, there are six commands that
+cover the main functionalites of the tool. They are:
 
-We have chosen Multipass for this tutorial because it allows us to easily launch VMs while not
-requiring any complicated setup for the tool.
+* `status`
+* `attach`
+* `refresh`
+* `detach`
+* `enable`
+* `disable`
 
-To install Multipass on your computer, please run the following command on your machine:
+In this tutorial, we will go through all these commands and learn how to
+properly use them. To achieve this without making any modifications to your
+machine, we will use a Xenial Multipass VM.
+
+We have chosen [Multipass](https://multipass.run/) for this tutorial because it
+allows us to easily launch VMs without the need for any complicated setup.
+
+## How to use this tutorial
+
+The commands in each code block can be copied and pasted directly into your
+terminal. You can use the "copy code" button to the right-hand side of the block
+and this will copy the code for you (without the command prompt!).
+
+## Install Multipass
+
+To install Multipass on your computer, please run the following command on your
+machine:
 
 ```console
 $ sudo snap install multipass
 ```
 
-## Main `pro` commands
+## Create the Xenial Multipass virtual machine
 
-When dealing with `pro` through the CLI, there are six commands that cover the main
-functionalites of the tool. They are:
-
-* **status**
-* **attach**
-* **refresh**
-* **detach**
-* **enable**
-* **disable**
-
-In this tutorial, we will go through all those commands to show how to properly use them.
-To achieve this without making any modifications to your machine, we will use a Xenial Multipass VM.
-
-## Creating the Xenial Multipass virtual machine
-
-The first step in creating our VM is to install Multipass, as mentioned in the
-[Prerequisites](#prerequisites) section. After that, just run the command:
+Now that we have installed Multipass, we can launch our Multipass VM by running
+this command:
 
 ```console
 $ multipass launch xenial --name dev-x
 ```
 
-After running that, let's access the VM by running:
+We can easily access our new VM by running:
 
 ```console
 $ multipass shell dev-x
 ```
 
-Notice that when you run that command, that your terminal username and hostname will change to:
+Notice that when you run this command, your terminal username and hostname
+change to:
 
 ```
 ubuntu@dev-x
@@ -56,8 +63,8 @@ ubuntu@dev-x
 
 This indicates that you are now inside the VM.
 
-Finally, let's run an `apt update` and `apt upgrade` command on the virtual machine
-machine to ensure that you are operating on the correct version:
+Finally, let's run `apt update` and `apt upgrade` on the VM to make sure we are
+operating on the correct version:
 
 ```console
 $ sudo apt update && sudo apt upgrade -y
@@ -65,18 +72,19 @@ $ sudo apt update && sudo apt upgrade -y
 
 ## Base `pro` commands
 
-### Status
+### `status`
 
-The `status` command of `pro` allows you to see the status of any Ubuntu Pro service on your machine.
-It also helps you to easily verify if your machine is attached to an Ubuntu Pro subscription or not.
+The `status` command of `pro` will show you the status of any Ubuntu Pro
+service on your machine. It also helps you to easily verify that your machine is
+attached to an Ubuntu Pro subscription.
 
-Let's run it on the VM:
+Let's run it on our VM:
 
 ```console
 $ pro status
 ```
 
-It is expected for you to see an output similar to this one:
+You can expect to see an output similar to this:
 
 ```
 SERVICE       AVAILABLE  DESCRIPTION
@@ -90,31 +98,37 @@ This machine is not attached to an Ubuntu Pro subscription.
 See https://ubuntu.com/pro
 ```
 
-You can see that the status command shows the services available to your machine,
-while also presenting a short description for each service.
+You can see that the `status` command shows the services available to your
+machine, while also presenting a short description for each service.
 
-Additionally, if you look at the last lines of the output, you can identify that this machine is not
-currently attached to an Ubuntu Pro subscription.
+If you also look at the last lines of the output, you can see that this machine
+is not currently attached to an Ubuntu Pro subscription.
+
 ```
 This machine is not attached to an Ubuntu Pro subscription.
 See https://ubuntu.com/pro
 ```
 
-### Attach
+### `attach`
 
-To access any of those service offerings, you need to attach to an Ubuntu Pro subscription. This is
-achieved by running the `attach` command. Before you run it, you need to get an Ubuntu Pro token.
-Any user with an Ubuntu One account is entitled to a free personal token to use with Ubuntu Pro.
+We have seen which service offerings are available to us, but to access them we
+first need to attach an Ubuntu Pro subscription. We can do this by running the
+`attach` command.
 
-You can retrieve your Ubuntu Pro token from the [Ubuntu Pro portal](https://ubuntu.com/pro/).
-You will log in with your SSO credentials, the same credentials you use for https://login.ubuntu.com.
-After getting your Ubuntu Pro token, go to the VM and run:
+Before you run this command, you will need to get your Ubuntu Pro token. Any
+user with an Ubuntu One account is entitled to a free personal token to use
+with Ubuntu Pro.
+
+You can retrieve your Ubuntu Pro token from the
+[Ubuntu Pro portal](https://ubuntu.com/pro/). Log in with your "single sign on"
+(SSO) credentials -- the same credentials you use for https://login.ubuntu.com.
+Copy your Ubuntu Pro token, then go to the VM and run:
 
 ```console
 $ sudo pro attach YOUR_TOKEN
 ```
 
-It is expected for you to see an output similar to this one:
+You should then see output similar to this:
 
 ```
 Enabling default service esm-infra
@@ -140,21 +154,27 @@ Enable services with: pro enable <service>
 Technical support level: essential
 ```
 
-From this output, you can see that the attach command enables all of the services specified by the user subscription.
-After the command ends, `pro` displays the new state of the machine.
-That status output is exactly what you will see if you run the status command again.
-You can confirm this by running:
+From this output, you can see that the `attach` command has introduced the
+"status" column. This shows which services (specified by your user
+subscription) have been enabled by default.
+
+After the command ends, `pro` displays the new state of the machine. This status
+output is exactly what you see if you run the `status` command. Let's confirm
+this by running the `status` command again:
 
 ```console
 $ pro status
 ```
 
-One question that may arise is that the output of `pro status` while attached is different from
-the output of `pro status` when unattached. When attached, status presents two new columns,
-**ENTITLED** and **STATUS**, while also dropping the **AVAILABLE** column. For more information
-of why the output is different, please refer to this [explanation](../explanations/status_columns.md).
+```{seealso}
+You may be wondering why the output of `status` is different depending on
+whether `pro` is attached or unattached. For more information on why this is,
+please refer to our
+[explanation on the different columns](../explanations/status_columns.md).
+```
 
-Finally, another useful bit at the end of both attach and status is the contract expiration date:
+Finally, another useful bit at the end of the output for both `attach` and
+`status` is the contract expiration date:
 
 ```
     Account: USER ACCOUNT
@@ -162,44 +182,47 @@ Subscription: USER SUBSCRIPTION
 Valid until: 9999-12-31 00:00:00+00:00
 ```
 
-The `Valid until` field describes when your contract will be expired, so you can be aware of when it
-needs to be renewed.
+The `Valid until` field describes when your contract will expire, so you can be
+aware of when it needs to be renewed.
 
+### `refresh`
 
-### Refresh
+Although *free* tokens never expire, if you buy an Ubuntu Pro subscription and
+later need to renew your contract, how can you make your machine aware of it?
 
-In the last section, we mentioned that your contract can expire. Although free tokens never expire, if
-you buy an Ubuntu Pro subscription and later need to renew the contract, how can you make your machine aware of
-it? You can do this through the `refresh` command:
+This is where the `refresh` command comes in:
 
 ```console
 $ sudo pro refresh
 ```
 
-This command will refresh the contract on your machine. This command is also really useful if you
-want to change any definitions on your subscription. For example, let's assume that you now want
-`cis` to be enabled by default when attaching. After you modify your subscription on the Ubuntu Pro
-website, running the refresh command will process any changes that were performed in the subscription, enabling
-`cis` because of this.
+This command will "refresh" the contract on your machine. It's also really
+useful if you want to change any definitions on your subscription. 
 
-```{seealso}
-The refresh command does more than just update the contract in the machine. If you want
-more information about the command, please take a look at this [explanation](../explanations/what_refresh_does.md).
+For example, let's assume that you now want `cis` to be enabled by default when
+attaching. After you modify your subscription on the Ubuntu Pro website to
+enable it by default, running the refresh command will process the changes you
+made, and `cis` will then be enabled.
+
+```{hint}
+The `refresh` command does more than just update the contract in the machine.
+If you would like more information about the command, please take a look at
+[this deeper explanation](../explanations/what_refresh_does.md).
 ```
 
-### Enable
+### `enable`
 
-There is another way to enable a service that wasn't activated during attach or refresh.
-Suppose that you want to enable `cis` on the machine manually. To achieve this, you can use the
-enable command.
+There is another way to enable a service that wasn't activated during `attach`
+or `refresh`. Let us suppose that you now want to enable `cis` on the machine
+manually. To achieve this, you can use the `enable` command.
 
-Let's enable `cis` on our VM by running:
+Let's try enabling `cis` on our VM by running:
 
 ```console
 $ sudo pro enable cis
 ```
 
-After running it, you should see an output similar to this one:
+After running the command, you should see output similar to this:
 
 ```
 One moment, checking your subscription first
@@ -209,7 +232,8 @@ CIS Audit enabled
 Visit https://security-certs.docs.ubuntu.com/en/cis to learn how to use CIS
 ```
 
-You can confirm that `cis` is enabled now by running:
+We can then confirm that `cis` is now enabled by using the `status` command
+again:
 
 ```console
 $ pro status
@@ -228,16 +252,17 @@ livepatch     yes       n/a       Canonical Livepatch service
 You can see now that `cis` is marked as `enabled` under 'status'.
 
 
-### Disable
+### `disable`
 
-Let's suppose that you don't want a service anymore, you can also disable any service offering
-through `pro`. For example, let's disable the `cis` service you just enabled by running on the VM:
+What happens if you don't want a service anymore? You can very simply disable
+any service offering through `pro`. For example, let's disable the `cis`
+service we just enabled by running `disable` on our VM:
 
 ```console
 $ sudo pro disable cis
 ```
 
-After running the command, let's now run `pro status` to see what happened to `cis`:
+Let's now run `pro status` to see what happened to `cis`:
 
 ```
 SERVICE       ENTITLED  STATUS    DESCRIPTION
@@ -248,45 +273,63 @@ fips-updates  yes       n/a       NIST-certified core packages with priority sec
 livepatch     yes       n/a       Canonical Livepatch service
 ```
 
-You can see that `cis` status is back to disabled.
+You can see that `cis` status is back to being disabled.
 
-```{note}
-The disable command doesn't uninstall any package that was installed by
-the service. The command only removes the access you have to the service, but it
-doesn't undo any configuration that was applied on the machine.
+```{important}
+The `disable` command doesn't uninstall any package that was installed by
+the service, or undo any configuration that was applied to the machine -- it
+only removes the access you have to the service.
 ```
 
-### Detach
+### `detach`
 
-Finally, what if you don't want this machine to be attached to an Ubuntu Pro subscription any longer?
-You can achieve that using the `detach` command:
+Finally, what if you decide you no longer want this machine to be attached to an
+Ubuntu Pro subscription? To disable all of the Ubuntu Pro services and remove
+the subscription you stored on your machine during attach, you can use the
+`detach` command:
 
 ```console
 $ sudo pro detach
 ```
 
-This command will disable all of the Ubuntu Pro services on the machine for you and
-remove the subscription stored on your machine during attach.
+Just like the `disable` command, `detach` will also not uninstall any packages
+that were installed by any of the services enabled through `pro`.
 
-```{note}
-The detach command will also not uninstall any packages that were installed by
-any service enabled through `pro`.
+
+## Close down the VM
+
+Congratulations! You successfully ran a Multipass VM and used it to try out the
+six main commands of the Ubuntu Pro Client.
+
+If you want to continue testing the different features and functions of `pro`,
+you can run the command:
+
+```
+$ pro help
 ```
 
-### Final steps
+This will provide you with a full list of all the commands available, and
+details of how to use them. Feel free to play around with them in your VM and
+see what else `pro` can do for you!
 
-Before you finish this tutorial, exit the VM by running `CTRL-D` and delete it by running
-the following commands on the machine:
+When you are finished and want to leave the tutorial, you can shut down the VM
+by first pressing <kbd>CTRL</kbd>+<kbd>D</kbd> to exit it, and then running the
+following commands to delete the VM completely:
 
 ```console
 $ multipass delete dev-x
 $ multipass purge
 ```
 
-### Next steps
+## Next steps
 
-Great, you successfully ran a Multipass VM and used it to test out the 6 main commands of Ubuntu Pro. Congratulations!
-If you would now like to see some more advanced options to configure the tool,
-please take a look at our _How To Guides_. If that still doesn't cover
-your needs, feel free to reach the `pro` team on `#ubuntu-server` on Libera IRC.
+If you would now like to see some more advanced options to configure `pro`,
+we recommending taking a look at our [how-to guides](../howtoguides).
 
+If you have any questions or need some help, please feel free to reach out to
+the `pro` team on `#ubuntu-server` on
+[Libera IRC](https://kiwiirc.com/nextclient/irc.libera.chat/ubuntu-server) --
+we're happy to help! 
+
+Alternatively, if you have a GitHub account, click on the "Have a question?"
+link at the top of this page to leave us a message. We'd love to hear from you!

--- a/docs/tutorials/create_a_fips_docker_image.md
+++ b/docs/tutorials/create_a_fips_docker_image.md
@@ -1,36 +1,53 @@
 # Create an Ubuntu FIPS Docker image
 
-> Requires at least Ubuntu Pro Client version 27.7
+```{attention}
 
-If you are unsure if your Pro Client version fits the specified requirements,
-please refer to this [guide](../howtoguides/check_pro_version.md).
-
-## Step 1: Acquire your Ubuntu Pro token
-
-Your Ubuntu Pro token can be found on your Ubuntu Pro dashboard. To access your dashboard, you need an [Ubuntu One](https://login.ubuntu.com/) account. If you purchased an Ubuntu Pro subscription and don't yet have an Ubuntu One account, be sure to use the same email address used to purchase your subscription. If you haven't purchased an Ubuntu Pro subscription, don't worry! You get a free token for personal use with your Ubuntu One account, no purchase necessary.
-
-The Ubuntu One account functions as a Single Sign On, so once logged in we can go straight to the Ubuntu Pro dashboard at [ubuntu.com/pro](https://ubuntu.com/pro). Then we should see a list of our subscriptions (including the free for personal use subscription) in the left-hand column. Click on the subscription that you wish to use for this tutorial if it is not already selected. On the right we will now see the details of our subscription including our secret token under the "Subscription" header next to the "🔗" symbol.
-
-```{caution}
-The Ubuntu Pro token should be kept secret. It is used to uniquely identify your Ubuntu Pro subscription.
+This tutorial requires at least Ubuntu Pro Client version 27.7 -- to check what
+version of the Pro Client you are using, run `pro version`. 
 ```
 
-## Step 2: Create an Ubuntu Pro Client Attach Config file
+## Acquire your Ubuntu Pro token
 
-First create a directory for this tutorial.
+Your Ubuntu Pro token can be found on your Ubuntu Pro dashboard. To access your
+dashboard, you need an [Ubuntu One](https://login.ubuntu.com/) account. If you
+purchased an Ubuntu Pro subscription and don't yet have an Ubuntu One account,
+be sure to use the same email address you used to purchase your subscription.
+If you haven't purchased an Ubuntu Pro subscription, don't worry! Everyone gets
+a free token for personal use with their Ubuntu One account -- no purchase
+necessary.
+
+The Ubuntu One account functions as a Single Sign On (SSO), so after you log in
+we can go straight to the Ubuntu Pro dashboard at
+[ubuntu.com/pro](https://ubuntu.com/pro). Here, you should see a list of your
+subscriptions (including the "free for personal use" subscription) in the
+left-hand column.
+
+Click on the subscription that you wish to use for this tutorial, if it is not
+already selected. On the right you will now see the details of your
+subscription, including your secret token (under the "Subscription" header and
+next to the "🔗" symbol).
+
+```{caution}
+The Ubuntu Pro token must be kept secret. It is used to uniquely identify your
+Ubuntu Pro subscription.
+```
+
+## Create an Ubuntu Pro Client attach config file
+
+First, let's create a directory for this tutorial and navigate there.
 
 ```bash
 mkdir pro_fips_tutorial
 cd pro_fips_tutorial
 ```
 
-Create a file named `pro-attach-config.yaml`.
+Now we need to create our config file called `pro-attach-config.yaml`:
 
 ```bash
 touch pro-attach-config.yaml
 ```
 
-Edit the file and add the following contents:
+Edit the file, add the following contents, and save it:
 
 ```yaml
 token: YOUR_TOKEN
@@ -38,15 +55,19 @@ enable_services:
   - fips
 ```
 
-Replace `YOUR_TOKEN` with the Ubuntu Pro token we got from [ubuntu.com/pro](https://ubuntu.com/pro) in Step 1.
+Replace `YOUR_TOKEN` with the Ubuntu Pro token we got from
+[ubuntu.com/pro](https://ubuntu.com/pro).
 
-## Step 3: Create a Dockerfile
+## Create a Dockerfile
 
-Create a file named `Dockerfile`.
+Next, let us create a file named `Dockerfile` by running the following command:
 
 ```bash
 touch Dockerfile
 ```
+
+This file will later enable FIPS in the container, upgrade all the packages,
+and install the FIPS version of `openssl`. 
 
 Edit the file and add the following contents:
 
@@ -63,42 +84,55 @@ RUN --mount=type=secret,id=pro-attach-config \
     && rm -rf /var/lib/apt/lists/*
 ```
 
-This Dockerfile will enable FIPS in the container, upgrade all packages and install the FIPS version of `openssl`. For more details on how this works, see [How to Enable Ubuntu Pro Services in a Dockerfile](../howtoguides/enable_in_dockerfile.md)
+```{seealso}
+For more details on how this works, see our how-to guide on [enabling Ubuntu
+Pro Services in a Dockerfile](../howtoguides/enable_in_dockerfile.md)
+```
 
-## Step 4: Build the Docker image
+## Build the Docker image
 
-Build the docker image with the following command:
+Now let's build the docker image by running the following command:
 
 ```bash
 DOCKER_BUILDKIT=1 docker build . --secret id=pro-attach-config,src=pro-attach-config.yaml -t ubuntu-focal-fips
 ```
 
-This will pass the attach-config as a [BuildKit Secret](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information) so that the finished docker image will not contain your Ubuntu Pro token.
+This will pass the `pro-attach-config.yaml` file we created earlier as a
+[BuildKit Secret](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information)
+so that the finished Docker image will not contain your Ubuntu Pro token.
 
-## Step 5: Test the Docker image
+## Test the Docker image
 
 ```{important}
-The docker image isn't considered fully FIPS compliant unless it is running on a host Ubuntu machine that is FIPS compliant.
+The Docker image isn't considered fully FIPS compliant unless it is running on
+a host Ubuntu machine that is also FIPS compliant.
 ```
 
-Let's check to make sure the FIPS version of openssl is installed in the container.
+Let's check to make sure the FIPS version of `openssl` is installed in the
+container. First, let us run:
 
 ```bash
 docker run -it ubuntu-focal-fips dpkg-query --show openssl
 ```
-Should show something like `openssl	1.1.1f-1ubuntu2.fips.2.8` (notice "fips" in the version name).
 
-We can now use the build docker image's FIPS compliant `openssl` to connect to `https://ubuntu.com`.
+This should show something like: `openssl	1.1.1f-1ubuntu2.fips.2.8` (notice
+"fips" in the version name).
+
+We can now use the build Docker image's FIPS compliant `openssl` to connect to
+`https://ubuntu.com`:
 
 ```bash
 docker run -it ubuntu-focal-fips sh -c "echo | openssl s_client -connect ubuntu.com:443"
 ```
 
-That should print information about the certificates of ubuntu.com and the algorithms used during the TLS handshake.
-
+This should print information about the certificates of ubuntu.com and the
+algorithms used during the TLS handshake.
 
 ## Success
 
-That's it! You could now push this image to a private registry and use it as the base of other docker images using `FROM`.
+That's it! You could now push this image to a private registry and use it as
+the base of other Docker images using `FROM`.
 
-If you want to learn more about how the steps in this tutorial work, take a look at the more generic [How to Enable Ubuntu Pro Services in a Dockerfile](../howtoguides/enable_in_dockerfile.md).
+If you want to learn more about how the steps in this tutorial work, take a
+look at the more generic how-to guide on
+[enabling Ubuntu Pro Services in a Dockerfile](../howtoguides/enable_in_dockerfile.md).

--- a/docs/tutorials/create_a_fips_updates_pro_cloud_image.md
+++ b/docs/tutorials/create_a_fips_updates_pro_cloud_image.md
@@ -1,61 +1,70 @@
-# Create a customized Cloud Ubuntu Pro image with FIPS Updates
+# Customised Cloud Ubuntu Pro images with FIPS updates
 
-## Step 1: Launch an Ubuntu Pro instance on your cloud
+## Launch an Ubuntu Pro instance on your cloud
 
-See the following links for up to date information for each supported cloud:
+See the following links for up to date information for each supported Cloud:
+
 * https://ubuntu.com/aws/pro
 * https://ubuntu.com/azure/pro
 * https://ubuntu.com/gcp/pro
 
-## Step 2: Enable FIPS Updates
+## Enable FIPS updates
 
-First wait for the standard Ubuntu Pro services to be set up.
+First, we need to wait for the standard Ubuntu Pro services to be set up:
 
 ```bash
 sudo pro status --wait
 ```
 
-Then use [the enable command](../howtoguides/enable_fips.md) to setup FIPS Updates.
+We can then use [the `enable` command](../howtoguides/enable_fips.md) to set up
+FIPS updates.
+
 ```bash
 sudo pro enable fips-updates --assume-yes
 ```
 
-Now reboot the instance
+Now, we need to reboot the instance:
+
 ```bash
 sudo reboot
 ```
 
-And verify that `fips-updates` is enabled in the output of `pro status`
+And verify that `fips-updates` is enabled in the output of `pro status`:
 ```bash
 sudo pro status
 ```
 
-Also remove the machine-id so that it is regenerated for each instance launch from the snapshot.
+Also remove the `machine-id` so that it is regenerated for each instance
+launched from the snapshot.
+
 ```bash
 sudo rm /etc/machine-id
 ```
 
-## Step 3: Snapshot the instance as a cloud image
+## Snapshot the instance as a Cloud image
 
 Cloud-specific instructions are here:
+
 * [AWS](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/tkv-create-ami-from-instance.html)
 * [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource)
 * [GCP](https://cloud.google.com/compute/docs/machine-images/create-machine-images)
 
-## Step 4: Launch your custom image!
+## Launch your custom image!
 
-Use your specific cloud to launch a new instance from your custom image.
+Use your specific Cloud to launch a new instance from your custom image.
 
 ````{note}
-For versions prior to 27.11, you will need to re-enable fips-updates on each instance that is launched from the custom image.
+For versions prior to 27.11, you will need to re-enable `fips-updates` on each
+instance launched from the custom image.
 
-This won't require a reboot and is only necessary to ensure the instance gets updates to fips packages when they become available.
+This won't require a reboot and is only necessary to ensure the instance gets
+updates to FIPS packages when they become available.
 
 ```bash
 sudo pro enable fips-updates --assume-yes
 ```
 
-You can easily script this using [cloud-init user-data](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd) at launch time
+You can easily script this using [cloud-init user data](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd) at launch time:
 ```yaml
 #cloud-config
 # Enable fips-updates after pro auto-attach and reboot after cloud-init completes

--- a/docs/tutorials/fix_scenarios.md
+++ b/docs/tutorials/fix_scenarios.md
@@ -1,47 +1,52 @@
-# Using fix command to solve CVE/USNs on the machine
+# Use `pro fix` to solve CVE/USN
 
 The Ubuntu Pro Client (`pro`) can be used to inspect and resolve
-[Common Vulnerabilities and Exposures](https://ubuntu.com/security/cves)(CVE) and [Ubuntu Security Notices](https://ubuntu.com/security/notices) (USN)
-on this machine.
+[Common Vulnerabilities and Exposures](https://ubuntu.com/security/cves) (CVE)
+and [Ubuntu Security Notices](https://ubuntu.com/security/notices) (USN)
+on your machine.
 
-Every CVE/USN is fixed by trying to upgrade all of the affected packages described by the CVE or
-USN. Sometimes, the packages fixes can only be applied if an Ubuntu Pro service is already enabled on the
-machine.
+Every CVE/USN is fixed by trying to upgrade all of the affected packages
+described by the CVE or USN. Sometimes, the package fixes can only be applied
+if an Ubuntu Pro service is already enabled on your machine.
 
-On this tutorial, we will cover the main scenarios that can happen when running the `pro fix` command.
+In this tutorial, we will introduce the `pro fix` command and test some common
+scenarios that you may encounter.
 
-## Prerequisites
+## How to use this tutorial
 
-In this tutorial, you will use [Multipass](https://multipass.run/) virtual machines (VM).
+The commands in each code block can be copied and pasted directly into your
+terminal. You can use the "copy code" button to the right-hand side of the block
+and this will copy the code for you (without the command prompt!).
 
-We have chosen Multipass for this tutorial because it allows us to easily launch VMs while not
-requiring any complicated setup for the tool.
+## Install Multipass
 
-To install Multipass on your computer, please run the following command on your machine:
+In this tutorial, we will use a Xenial Multipass virtual machine (VM) to avoid
+making any modifications to your machine. We have chosen
+[Multipass](https://multipass.run/) for this tutorial because it allows us to
+easily launch VMs without requiring any complicated setup.
+
+To install Multipass on your computer, please run the following command on your
+machine:
 
 ```console
 $ sudo snap install multipass
 ```
 
+## Create the Xenial Multipass virtual machine
 
-## Creating the Xenial Multipass virtual machine
-
-To test some scenarios for the `pro fix` command, we will need to attach a
-Pro subscription to the machine. To avoid modifying your machine, let's create
-a Xenial Multipass VM instead. Remember to install Multipass as mentioned in the
-[Prerequisites](#prerequisites) section. After that, just run the command:
+Now that we have installed Multipass, we can launch our Multipass VM by running:
 
 ```console
 $ multipass launch xenial --name dev-x
 ```
 
-After running that, let's access the VM by running:
+Now we can access the VM easily by running the command:
 
 ```console
 $ multipass shell dev-x
 ```
 
-Notice that when you run that command, that your terminal username and hostname will change to:
+Notice that your terminal username and hostname will change to:
 
 ```
 ubuntu@dev-x
@@ -49,28 +54,29 @@ ubuntu@dev-x
 
 This indicates that you are now inside the VM.
 
-Finally, let's run an `apt update` and `apt upgrade` command on the virtual machine
+Finally, let's run `apt update` and `apt upgrade` on the VM to make sure we are
+operating on the correct version:
 
 ```console
 $ sudo apt update && sudo apt upgrade -y
 ```
 
-Every time we say: "run the command" our intention will be for
-you to run that command on your VM.
+From now on, every time we say: "run the command" our intention is for you to
+run that command in your VM.
 
-## Using `pro fix`
+## Use `pro fix`
 
-First, let's see what happens on your system when `pro fix` runs. We will choose
-to fix a CVE that does not affect the VM,
-[CVE-2020-15180](https://ubuntu.com/security/CVE-2020-15180). This CVE address security
-issues for the `MariaDB` package, which is not installed on the system. Let's confirm that
-it doesn't affect the system by running this command:
+First, let's see what happens to your system when `pro fix` runs. We will choose
+to fix a CVE that does not affect the VM -- in this case,
+[CVE-2020-15180](https://ubuntu.com/security/CVE-2020-15180). This CVE address
+security issues for the `MariaDB` package, which is not installed on the system.
+Let's first confirm that it doesn't affect the system by running this command:
 
 ```console
 $ pro fix CVE-2020-15180
 ```
 
-You should see an output like this one:
+You should see an output like this:
 
 ```
 CVE-2020-15180: MariaDB vulnerabilities
@@ -79,20 +85,21 @@ No affected source packages are installed.
 ✔ CVE-2020-15180 does not affect your system.
 ```
 
-Every `pro fix` output will have a similar output structure where we describe the CVE/USN,
-display the affected packages, fix the affected packages and at the end, show if the
-CVE/USN is fully fixed in the machine.
+Every `pro fix` output has a similar output structure: it describes the
+CVE/USN; displays the affected packages; fixes the affected packages; and at the
+end, shows if the CVE/USN is fully fixed in the machine.
 
-You can better see this in a `pro fix` call that does fix a package. Let's install a package
-on the VM that we know is associated with [CVE-2020-25686](https://ubuntu.com/security/CVE-2020-25686).
-You can install that package by running these commands:
+This is better demonstrated in a `pro fix` call that *does* fix a package!
+Let's install a package on the VM that we know is associated with
+[CVE-2020-25686](https://ubuntu.com/security/CVE-2020-25686).
+You can install the package by running these commands:
 
 ```console
 $ sudo apt update
 $ sudo apt install dnsmasq=2.75-1
 ```
 
-Now you can run the following command:
+Now, let's run `pro fix` on the package:
 
 ```console
 $ sudo pro fix CVE-2020-25686
@@ -111,19 +118,21 @@ A fix is available in Ubuntu standard updates.
 ```
 
 ```{note}
-We need to run the command with sudo because we are now installing a package on the system.
+We need to run the command with `sudo` because we are now installing a package
+on the system.
 ```
 
-Whenever `pro fix` has a package to upgrade, it follows a consistent structure and displays the
-following in order
+Whenever `pro fix` has a package to upgrade, it follows a consistent structure
+and displays the following, in this order:
 
 1. The affected package
 2. The availability of a fix
 3. The location of the fix, if one is available
 4. The command that will fix the issue
 
-Also, in the end of the output is the confirmation that the CVE was fixed by the command.
-You can confirm that fix was successfully applied by running the same `pro fix` command again:
+Also, at the end of the output you can see confirmation that the CVE was fixed
+by the command. Just to confirm that the fix was successfully applied, let's
+run the `pro fix` command again, and we should now see the following:
 
 ```
 CVE-2020-25686: Dnsmasq vulnerabilities
@@ -135,16 +144,17 @@ The update is already installed.
 ✔ CVE-2020-25686 is resolved.
 ```
 
-## CVE/USN without released fix
+## CVE/USN without a released fix
 
-Some CVE/USNs do not have a fix released yet. When that happens, `pro fix` will let you know
-about this situation. Before we reproduce that scenario, you will first install a package by running:
+Some CVE/USN do not have a fix released yet. When that happens, `pro fix` will
+let you know! Before we reproduce this scenario, let us first install a package
+that we know has no fix available by running:
 
 ```console
 $ sudo apt install -y libawl-php
 ```
 
-Now, you can confirm that scenario by running the following command:
+Now, we can confirm that there is no fix by running the following command:
 
 ```console
 $ pro fix USN-4539-1
@@ -163,21 +173,20 @@ Sorry, no fix is available.
 ✘ USN-4539-1 is not resolved.
 ```
 
-Notice that we inform that the is no fix available and in the last line the commands also
-mentions that the USN is not resolved.
+As you can see, we are informed by `pro fix` that there is no fix available. In
+the last line, we can also see that the USN is not resolved.
 
 ## CVE/USN that require an Ubuntu Pro subscription
 
-Some package fixes can only be installed when the machine is attached to an Ubuntu Pro subscription.
-When that happens, `pro fix` will let you know about that. To see an example of this scenario,
-you can run the following fix command:
-
+Some package fixes can only be installed when the machine is attached to an
+Ubuntu Pro subscription. When that happens, `pro fix` will let you know about
+that. To see an example of this scenario, you can run the following fix command:
 
 ```console
 $ sudo pro fix USN-5079-2
 ```
 
-You will see that the command will prompt you like this:
+The command will prompt you for a response, like this:
 
 ```
 USN-5079-2: curl vulnerabilities
@@ -194,16 +203,19 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel
 > 
 ```
 
-You can see that the prompt is asking for an Ubuntu Pro subscription token. Any user with
-a Ubuntu One account is entitled to a free personal token to use with Ubuntu Pro.
-If you choose the `Subscribe` option on the prompt, the command will ask you to go
-to the [Ubuntu Pro portal](https://ubuntu.com/pro/). You can go into that portal
-and get yourself a free subscription token by logging in with your
-SSO credentials, the same credentials you use for https://login.ubuntu.com.
+You can see that the prompt is asking for an Ubuntu Pro subscription token. Any
+user with a Ubuntu One account is entitled to a free personal token to use with
+Ubuntu Pro. 
 
-After getting your Ubuntu Pro token, you can hit `Enter` on the prompt and it will ask you
-to provide the token you just obtained. After entering the token you are expected to
-see now the following output:
+If you choose the `Subscribe` option on the prompt, the command
+will ask you to go to the
+[Ubuntu Pro portal](https://ubuntu.com/pro/). In the portal, you can get a free
+subscription token by logging in with your "Single Sign On" (SSO) credentials;
+the same credentials you use to log into https://login.ubuntu.com.
+
+After getting your Ubuntu Pro token, you can hit <kbd>Enter</kbd> on the prompt
+and it will ask you to provide the token you just obtained. After entering the
+token you should now see the following output:
 
 ```
 USN-5079-2: curl vulnerabilities
@@ -248,9 +260,10 @@ Technical support level: essential
 ✔ USN-5079-2 is resolved.
 ```
 
-We can see that that the attach command was successful, which can be verified by
-the status output we see when executing the command. Additionally, we can also observe
-that the USN is indeed fixed, which you can confirm by running the command again:
+We can see that that the attach command was successful, which can be verified
+by the status output we see when executing the command. Additionally, we can
+observe that the USN is indeed fixed, which you can confirm by running the
+`pro fix` command again:
 
 ```
 N-5079-2: curl vulnerabilities
@@ -265,15 +278,17 @@ The update is already installed.
 ```
 
 ```{note}
-Even though we are not covering this scenario here, if you have an expired contract,
-`pro fix` will detect that and prompt you to attach a new token for your machine.
+Even though we are not covering this scenario here, if you have an expired
+contract, `pro fix` will detect that and prompt you to attach a new token for
+your machine.
 ```
 
-## CVE/USN that requires an Ubuntu Pro service
+## CVE/USN that require a Ubuntu Pro service
 
-Now, let's assume that you have attached to an Ubuntu Pro subscription, but when running `pro fix`,
-the required service that fixes the issue is not enabled. In that situation, `pro fix` will
-also prompt you to enable that service.
+Now, let's assume that you have attached to an Ubuntu Pro subscription, but
+when running `pro fix`, the required service that fixes the issue is not
+enabled. In that situation, `pro fix` will also prompt you to enable that
+service.
 
 To confirm that, run the following command to disable `esm-infra`:
 
@@ -287,7 +302,8 @@ Now, you can run the following command:
 $ sudo pro fix CVE-2021-44731
 ```
 
-And you should see the following output (if you type `E` when prompted):
+And you should see the following output (if you type `E` when
+prompted):
 
 ```
 CVE-2021-44731: snapd vulnerabilities
@@ -308,14 +324,14 @@ Ubuntu Pro: ESM Infra enabled
 ✔ CVE-2021-44731 is resolved.
 ```
 
-You can observe that the required service was enabled and `pro fix` was able to successfully upgrade
-the affected package.
+You can observe that the required service was enabled and `pro fix` was able to
+successfully upgrade the affected package.
 
-## CVE/USN that requires reboot
+## CVE/USN that require a reboot
 
-When running an `pro fix` command, sometimes we can install a package that requires
-a system reboot to complete. The `pro fix` command can detect that and will inform you
-about it.
+When running the `pro fix` command, sometimes we can install a package that
+requires a system reboot to complete. The `pro fix` command can detect that and
+will inform you about it.
 
 You can confirm this by running the following fix command:
 
@@ -336,7 +352,8 @@ A reboot is required to complete fix operation.
 ✘ CVE-2022-0778 is not resolved.
 ```
 
-If we reboot the machine and run the command again, you will see that it is indeed fixed:
+If we reboot the machine and run the command again, you will see that it is
+indeed fixed:
 
 ```
 CVE-2022-0778: OpenSSL vulnerability
@@ -348,13 +365,15 @@ The update is already installed.
 ✔ CVE-2022-0778 is resolved.
 ```
 
-## Partially resolved CVE/USNs
+## Partially resolved CVE/USN
 
-Finally, you might run a `pro fix` command that only partially fixes some of the packages affected.
-This happens when only a subset of the packages have available updates to fix for that CVE/USN.
-In this case, `pro fix` will inform of which package it can and cannot fix.
+Finally, you might run a `pro fix` command that only fixes some of the packages
+affected. This happens when only a subset of the packages have available updates
+to fix for that CVE/USN.
 
-But first, let's install some package so we can run `pro fix` to exercise that scenario.
+In this case, `pro fix` will tell you which package(s) it can or cannot fix.
+But first, let's install a package so we can run `pro fix` to demonstrate this
+scenario.
 
 ```console
 $ sudo apt-get install expat=2.1.0-7 swish-e matanza ghostscript
@@ -366,7 +385,7 @@ Now, you can run the following command:
 $ sudo pro fix CVE-2017-9233
 ```
 
-And you will see the following command:
+And you will see the following output:
 
 ```
 CVE-2017-9233: Expat vulnerability
@@ -381,21 +400,36 @@ A fix is available in Ubuntu standard updates.
 ✘ CVE-2017-9233 is not resolved.
 ```
 
-We can see that two packages, `matanza` and `swish-e`, don't have any fixes available, but there
-is one for `expat`. In that scenario, we install the fix for `expat` and report at the end that
-some packages are still affected. Also, observe that in this scenario we mark the CVE/USN as not
+We can see that two packages, `matanza` and `swish-e`, don't have any fixes
+available, but there is one for `expat`. So, we install the fix for `expat` and
+at the end of the report we can see that some packages are still affected.
+
+As before, we can also observe that in this scenario we mark the CVE/USN as not
 resolved.
 
-### Final thoughts
+## Close down the VM
 
-This tutorial has covered the main scenario that can happen to you when running `pro fix`.
-If you need more information about the command please feel free to reach the Ubuntu Pro Client team on
-`#ubuntu-server` on Libera IRC.
+Congratulations! You successfully ran a Multipass VM and used it to encounter
+and resolve the main scenarios that you might find when you run `pro fix`.
 
-Before you finish this tutorial, exit the VM by running `CTRL-D` and delete it by running
-this command on the host machine:
+When you are finished and want to leave the tutorial, you can shut down the VM
+by first pressing <kbd>CTRL</kbd>+<kbd>D</kbd> to exit it, and then running the
+following commands to delete the VM completely:
 
 ```console
 $ multipass delete dev-x
 $ multipass purge
 ```
+
+## Next steps
+
+We have successfully encountered and resolved the main scenarios that you might
+find when you run `pro fix`.
+
+If you need more information about this command, please feel free to reach out
+to the Ubuntu Pro Client team on `#ubuntu-server` on
+[Libera IRC](https://kiwiirc.com/nextclient/irc.libera.chat/ubuntu-server) --
+we're happy to help! 
+
+Alternatively, if you have a GitHub account, click on the "Have a question?"
+link at the top of this page to leave us a message. We'd love to hear from you!


### PR DESCRIPTION
## Proposed Commit Message
```
Part 1 polishing (tutorials/how-tos)

- Tutorial and How-to landing pages have been revised/expanded.
- All tutorial/how-to pages have been "polished".
- Headings in the nav bar have been shortened for readability.
- All pages specifically ordered (no longer "random"). See below.

Goals here were improving navigation, readability, and
standardising.

Polishing = making sure pages conform to the Ubuntu style guide. 
Also includes minor language edits for clarity or to avoid word
repetitions, etc. Changed from passive to active, where possible.

All "notes" of all kinds have been standardised to the most
prevalent style used, which was the MyST Markdown format. I will 
add the various options for this to our style guide (current WIP).

The headings were good (descriptive :+1:) but a bit too long due to
repetition of "how to ...", so I have standardised these too. The
nav bar now has all pages organised in a particular order, and no
longer alphabetical by page name. I have grouped all pages by what
command they cover, and organised these commands alphabetically, 
which I think makes more sense.

If I've made any errors, lmk - but should be straightforward since
it was already mostly standardised.
```

