### PR TITLE
fix: add support for attach without a token

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1427,16 +1427,12 @@ def _magic_attach(args, *, cfg, **kwargs):
             value=args.format,
         )
 
-    event.info("Initiating attach operation...")
+    event.info(messages.CLI_MAGIC_ATTACH_INIT)
     initiate_resp = _initiate(cfg=cfg)
-
-    event.info("\nPlease sign in to your Ubuntu Pro account at this link:")
-    event.info("https://ubuntu.com/pro/attach")
     event.info(
-        "And provide the following code: {}{}{}".format(
-            messages.TxtColor.BOLD,
-            initiate_resp.user_code,
-            messages.TxtColor.ENDC,
+        "\n"
+        + messages.CLI_MAGIC_ATTACH_SIGN_IN.format(
+            user_code=initiate_resp.user_code
         )
     )
 
@@ -1445,7 +1441,7 @@ def _magic_attach(args, *, cfg, **kwargs):
     try:
         wait_resp = _wait(options=wait_options, cfg=cfg)
     except exceptions.MagicAttachTokenError as e:
-        event.info("Failed to perform magic-attach")
+        event.info(messages.CLI_MAGIC_ATTACH_FAILED)
 
         revoke_options = MagicAttachRevokeOptions(
             magic_token=initiate_resp.token
@@ -1453,7 +1449,7 @@ def _magic_attach(args, *, cfg, **kwargs):
         _revoke(options=revoke_options, cfg=cfg)
         raise e
 
-    event.info("\nAttaching the machine...")
+    event.info("\n" + messages.CLI_MAGIC_ATTACH_PROCESSING)
     return wait_resp.contract_token
 
 

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -29,6 +29,7 @@ BASE_ESM_URL = "https://ubuntu.com/esm"
 APT_NEWS_URL = "https://motd.ubuntu.com/aptnews.json"
 CLOUD_BUILD_INFO = "/etc/cloud/build.info"
 ESM_APT_ROOTDIR = DEFAULT_DATA_DIR + "/apt-esm/"
+PRO_ATTACH_URL = BASE_UA_URL + "/attach"
 
 DOCUMENTATION_URL = (
     "https://discourse.ubuntu.com/t/ubuntu-advantage-client/21788"

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional  # noqa: F401
 
-from uaclient.defaults import BASE_UA_URL, DOCUMENTATION_URL
+from uaclient.defaults import BASE_UA_URL, DOCUMENTATION_URL, PRO_ATTACH_URL
 
 
 class NamedMessage:
@@ -60,6 +60,8 @@ Failed to find the machine token overlay file: {file_path}"""
 ERROR_JSON_DECODING_IN_FILE = """\
 Found error: {error} when reading json file: {file_path}"""
 
+SECURITY_FIX_ATTACH_PROMPT = """\
+Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel"""
 SECURITY_FIX_NOT_FOUND_ISSUE = "Error: {issue_id} not found."
 SECURITY_FIX_RELEASE_STREAM = "A fix is available in {fix_stream}."
 SECURITY_UPDATE_NOT_INSTALLED = "The update is not yet installed."
@@ -150,6 +152,19 @@ Auto-attach image support is not available on this image
 See: """
     + BASE_UA_URL
 )
+
+CLI_MAGIC_ATTACH_INIT = "Initiating attach operation..."
+CLI_MAGIC_ATTACH_FAILED = "Failed to perform attach..."
+CLI_MAGIC_ATTACH_SIGN_IN = """\
+Please sign in to your Ubuntu Pro account at this link:
+{url}
+And provide the following code: {bold}{{user_code}}{end_bold}""".format(
+    url=PRO_ATTACH_URL,
+    bold=TxtColor.BOLD,
+    end_bold=TxtColor.ENDC,
+)
+CLI_MAGIC_ATTACH_PROCESSING = "Attaching the machine..."
+
 NO_ACTIVE_OPERATIONS = """No Ubuntu Pro operations are running"""
 REBOOT_SCRIPT_FAILED = (
     "Failed running reboot_cmds script. See: /var/log/ubuntu-advantage.log"


### PR DESCRIPTION
## Proposed Commit Message
fix: add support for attach without a token

If during the fix operation we identify that we need a Pro service to install the package fix, we can now allow user to attach without a token.

## Test Steps
On an unattached xenial machine, try running:

$ pro fix USN-5079-2

And type the `s` option when prompted for attach.
After that, make sure that the attach flow work as expected.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
