### PR TITLE
fix: make sure the local apt cache is isolated on update

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -603,6 +603,7 @@ def update_esm_caches(cfg) -> None:
         return
 
     import apt  # type: ignore
+    import apt_pkg  # type: ignore
 
     from uaclient.entitlements.entitlement_status import ApplicationStatus
     from uaclient.entitlements.esm import (
@@ -623,5 +624,13 @@ def update_esm_caches(cfg) -> None:
             infra.setup_local_esm_repo()
 
     # Read the cache and update it
+    # Take care to initialize the cache with only the
+    # Acquire configuration preserved
+    for key in apt_pkg.config.keys():
+        if "Acquire" not in key:
+            apt_pkg.config.clear(key)
+    apt_pkg.config.set("Dir", ESM_APT_ROOTDIR)
+    apt_pkg.init_config()
+
     cache = apt.Cache(rootdir=ESM_APT_ROOTDIR)
     cache.update()

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1087,8 +1087,12 @@ class TestAptCacheTime:
     @mock.patch("uaclient.apt.system.is_current_series_lts")
     @mock.patch("uaclient.apt.system.is_current_series_active_esm")
     @mock.patch("apt.Cache")
+    @mock.patch("apt_pkg.config")
+    @mock.patch("apt_pkg.init_config")
     def test_update_esm_caches_based_on_lts(
         self,
+        _m_apt_pkg_init_config,
+        _m_apt_pkg_config,
         m_cache,
         m_is_esm,
         m_is_lts,


### PR DESCRIPTION
This isolates the local apt esm cache in the function where it is updated.
There is no need to change it in the other places it is instantiated (security-status, stats hook) because there we only read the package names.
"Acquire" related vars are not cleared, so we can use the same download machinery as the system apt does.

This clears the concerns we had about our internal Cache writing/triggering things it should not.
- logs are dependent on the 'Dir' config entry, so we never log to `/var/log/apt` at all
- Hooks are removed when the config is clear and reinitialized, so none of them are triggered when our update runs
- Acquire related configuration defines how apt downloads things, and we need them preserved to make sure we can get our files the same way as the system is configured to do. Looking at the configuration defined under `Acquire::*`, there is no clear sign that any of that will interfere with the system apt mechanisms.
- Do we really need everything under Acquire? Probably not. But having it all is consistent and it is a fair change compared to inspecting each key in each level individually.