### PR TITLE
Add check to not prompt user on apt_news changes

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -382,6 +382,23 @@ case "$1" in
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "27.13~"; then
           cleanup_apt_news_flag_file
       fi
+
+      
+      # LP: #2003977
+      # The version gate is open ended, and should be closed when the apt_news
+      # configuration is moved away from a conffile.
+      if dpkg --compare-versions "$2" ge 27.11.3~; then
+          if [ -f /var/lib/ubuntu-advantage/preinst-detected-apt-news-disabled ]; then
+              # The preinst has left us a note to tell us that apt-news was
+              # previously disabled and should be re-disabled, so disable it
+              # and discard the note.
+              pro config set apt_news=false
+              rm /var/lib/ubuntu-advantage/preinst-detected-apt-news-disabled
+          fi
+          # Remove the conffile backup if it exists now that an error unwind is
+          # no longer possible
+          rm -f /etc/ubuntu-advantage/uaclient.conf.preinst-remove
+      fi
       ;;
 esac
 

--- a/debian/ubuntu-advantage-tools.postrm
+++ b/debian/ubuntu-advantage-tools.postrm
@@ -30,6 +30,15 @@ case "$1" in
         remove_logs
         remove_gpg_files
         ;;
+    abort-install|abort-upgrade)
+        # LP: #2003977
+        # The version gate is open ended, and should be closed when the
+        # apt_news configuration is moved away from a conffile.
+        if dpkg --compare-versions "$2" ge 27.11.3~; then
+            rm -f /var/lib/ubuntu-advantage/preinst-detected-apt-news-disabled
+            [ -f /etc/ubuntu-advantage/uaclient.conf.preinst-remove ] && mv /etc/ubuntu-advantage/uaclient.conf.preinst-remove /etc/ubuntu-advantage/uaclient.conf
+        fi
+        ;;
 esac
 
 #DEBHELPER#

--- a/debian/ubuntu-advantage-tools.preinst
+++ b/debian/ubuntu-advantage-tools.preinst
@@ -11,11 +11,62 @@ remove_old_config_fields() {
     fi
 }
 
+restore_previous_conffile() {
+    # Back up existing conffile in case of an error unwind
+    cp -a /etc/ubuntu-advantage/uaclient.conf /etc/ubuntu-advantage/uaclient.conf.preinst-remove
+    # Restore the default conffile that shipped with 27.11.3 through 27.12
+    cat > /etc/ubuntu-advantage/uaclient.conf <<EOT
+# Ubuntu Pro Client config file.
+# If you modify this file, run "pro refresh config" to ensure changes are
+# picked up by Ubuntu Pro Client.
+
+contract_url: https://contracts.canonical.com
+data_dir: /var/lib/ubuntu-advantage
+log_file: /var/log/ubuntu-advantage.log
+log_level: debug
+security_url: https://ubuntu.com/security
+timer_log_file: /var/log/ubuntu-advantage-timer.log
+daemon_log_file: /var/log/ubuntu-advantage-daemon.log
+ua_config:
+  apt_http_proxy: null
+  apt_https_proxy: null
+  http_proxy: null
+  https_proxy: null
+  update_messaging_timer: 21600
+  update_status_timer: 43200
+  metering_timer: 14400
+EOT
+}
+
 case "$1" in
     install|upgrade)
         if [ -n "$2" ]; then
             PREVIOUS_PKG_VER=$2
             remove_old_config_fields "$PREVIOUS_PKG_VER"
+        fi
+    
+        # LP: #2003977
+        # If the user used "pro config set apt_news=false|true" previously,
+        # then we don't want a conffile prompt if they haven't otherwise
+        # changed the conffile. In these two cases, restore the conffile back
+        # to how it shipped, and then fix up in postinst if required. The
+        # version gate is open ended, and should be closed when the apt_news
+        # configuration is moved away from a conffile.
+        if dpkg --compare-versions "$2" ge 27.11.3~; then
+            if [ -f /etc/ubuntu-advantage/uaclient.conf ]; then
+                conffile_hash=$(md5sum /etc/ubuntu-advantage/uaclient.conf|awk '{print $1}')
+                if [ "$conffile_hash" = "038902993a843cac6cbe3efa4d1fcb92" -o "$conffile_hash" = "664dff27e212a77aef514e4b64" ]; then
+                    # User had run "pro config set apt_news=false" with no other
+                    # conffile changes
+                    mkdir -p /var/lib/ubuntu-advantage
+                    touch /var/lib/ubuntu-advantage/preinst-detected-apt-news-disabled
+                    restore_previous_conffile
+                elif [ "$conffile_hash" = "3b01d7406cbb4ba628a9ffa57485d324" -o "$conffile_hash" = "d9971401a6409032b1c9069236040dc4" ]; then
+                    # User had run "pro config set apt_news=true" with no other
+                    # conffile changes
+                    restore_previous_conffile
+                fi
+            fi
         fi
         ;;
 esac

--- a/debian/ubuntu-advantage-tools.preinst
+++ b/debian/ubuntu-advantage-tools.preinst
@@ -55,17 +55,20 @@ case "$1" in
         if dpkg --compare-versions "$2" ge 27.11.3~; then
             if [ -f /etc/ubuntu-advantage/uaclient.conf ]; then
                 conffile_hash=$(md5sum /etc/ubuntu-advantage/uaclient.conf|awk '{print $1}')
-                if [ "$conffile_hash" = "038902993a843cac6cbe3efa4d1fcb92" -o "$conffile_hash" = "664dff27e212a77aef514e4b64" ]; then
-                    # User had run "pro config set apt_news=false" with no other
-                    # conffile changes
-                    mkdir -p /var/lib/ubuntu-advantage
-                    touch /var/lib/ubuntu-advantage/preinst-detected-apt-news-disabled
-                    restore_previous_conffile
-                elif [ "$conffile_hash" = "3b01d7406cbb4ba628a9ffa57485d324" -o "$conffile_hash" = "d9971401a6409032b1c9069236040dc4" ]; then
-                    # User had run "pro config set apt_news=true" with no other
-                    # conffile changes
-                    restore_previous_conffile
-                fi
+                case "$conffile_hash" in
+                    038902993a843cac6cbe3efa4d1fcb92|664dff27e212a77aef514e4b64)
+                        # User had run "pro config set apt_news=false" with no other
+                        # conffile changes
+                        mkdir -p /var/lib/ubuntu-advantage
+                        touch /var/lib/ubuntu-advantage/preinst-detected-apt-news-disabled
+                        restore_previous_conffile
+                        ;;
+                    3b01d7406cbb4ba628a9ffa57485d324|d9971401a6409032b1c9069236040dc4)
+                        # User had run "pro config set apt_news=true" with no other
+                        # conffile changes
+                        restore_previous_conffile
+                        ;;
+                esac
             fi
         fi
         ;;


### PR DESCRIPTION
## Proposed Commit Message
Add check to not prompt user on apt_news changes

In the previous release we have changed the uaclient.conf file to capitalized a word. If the user has changed apt_news through pro config, the user will now get a debconf prompt because of it. This is not ideal, since we are the ones that instruct the user to run that command if they don't want apt advertisement on their system. This PR is creating a mechanism to avoid that prompt if the has just changed the apt_news config

## Test Steps
Launch a lxd machine with an older version of the pro client (27.12) and runs either `pro config set apt_news=false` or `pro config set apt_news=true` and verify that upgrading to a package with those fixes applied do not generate a debconf prompt and keep the `apt_news` setting for the user

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
