### PR TITLE
fix: only run the services in the apt hook when root

### DIFF
--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -1,5 +1,5 @@
 APT::Update::Pre-Invoke {
-	"[ ! -e /run/systemd/system ] || systemctl start --no-block apt-news.service esm-cache.service || true";
+	"[ ! -e /run/systemd/system ] || [ $(id -u) -ne 0 ] || systemctl start --no-block apt-news.service esm-cache.service || true";
 };
 
 APT::Update::Post-Invoke-Stats {

--- a/sru/release-27.13.2/python-apt-snippet.py
+++ b/sru/release-27.13.2/python-apt-snippet.py
@@ -1,0 +1,5 @@
+from apt import Cache
+
+cache = Cache(rootdir="/home/ubuntu")
+
+cache.update()

--- a/sru/release-27.13.2/test-apt-hook-nonroot.sh
+++ b/sru/release-27.13.2/test-apt-hook-nonroot.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+series=$1
+name=$series-dev
+
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+
+trap on_err ERR
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Check ubuntu-advantage-tools version
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install ubuntu-advantage-tools > /dev/null
+echo -e "\n* UA is still the old one"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Move python snippet to SUT
+lxc file push ./python-apt-snippet.py $name/home/ubuntu/python-apt-snippet.py
+
+# Try to run it, see it fails
+echo -e "\n* Failure when trying to run the python snippet"
+echo "###########################################"
+lxc exec $name --user 1000 -- python3 /home/ubuntu/python-apt-snippet.py
+echo -e "###########################################\n"
+
+# Upgrading UA to new version
+# ----------------------------------------------------------------
+# Uncomment next line for staging
+lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+# Uncomment next line for -proposed
+# lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+# ----------------------------------------------------------------
+
+lxc exec $name -- sudo apt-get update > /dev/null
+lxc exec $name -- apt-get install ubuntu-advantage-tools > /dev/null
+echo -e "\n* Upgrading UA to new version"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Try to run it, see it passes
+echo -e "\n* Success when trying to run the python snippet"
+echo "###########################################"
+lxc exec $name --user 1000 -- python3 /home/ubuntu/python-apt-snippet.py
+echo -e "###########################################\n"
+
+cleanup


### PR DESCRIPTION
There is a corner case happening in other people's test suites when updating the apt cache as non-root presents errors because systemd can't trigger the services we inserted in our hook.

This guarantees we only try to run stuff when we are root, which is the only case we are interested in.

## Test Steps
Added a script to the `sru/` folder. 
Before merging, use the script as a base for a manual test.
For staging/proposed it is a matter of adapting the script when running.