### PR TITLE
tests: fix integration tests for new release

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -256,7 +256,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Then stdout matches regexp:
         """
         \s*500 <esm-infra-url> <release>-infra-security/main amd64 Packages
-        \s*500 <esm-infra-url> <release>-infra-updates/main amd64 Packages
         """
 
         Examples: ubuntu release

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -111,7 +111,7 @@ Feature: Ua fix command behaviour
         https://ubuntu.com/security/CVE-2020-11728
         1 affected source package is installed: awl
         \(1/1\) awl:
-        Sorry, no fix is available.
+        Ubuntu security engineers are investigating this issue.
         1 package is still affected: awl
         .*✘.* USN-4539-1 is not resolved.
         """
@@ -140,11 +140,11 @@ Feature: Ua fix command behaviour
         """
         .*WARNING: The option --dry-run is being used.
         No packages will be installed when running this command..*
-        CVE-2017-9233: Expat vulnerability
+        CVE-2017-9233: Coin3D vulnerability
         https://ubuntu.com/security/CVE-2017-9233
         3 affected source packages are installed: expat, matanza, swish-e
         \(1/3, 2/3\) matanza, swish-e:
-        Sorry, no fix is available.
+        Ubuntu security engineers are investigating this issue.
         \(3/3\) expat:
         A fix is available in Ubuntu standard updates.
         .*\{ apt update && apt install --only-upgrade -y expat \}.*
@@ -154,11 +154,11 @@ Feature: Ua fix command behaviour
         When I verify that running `pro fix CVE-2017-9233` `with sudo` exits `1`
         Then stdout matches regexp:
         """
-        CVE-2017-9233: Expat vulnerability
+        CVE-2017-9233: Coin3D vulnerability
         https://ubuntu.com/security/CVE-2017-9233
         3 affected source packages are installed: expat, matanza, swish-e
         \(1/3, 2/3\) matanza, swish-e:
-        Sorry, no fix is available.
+        Ubuntu security engineers are investigating this issue.
         \(3/3\) expat:
         A fix is available in Ubuntu standard updates.
         .*\{ apt update && apt install --only-upgrade -y expat \}.*


### PR DESCRIPTION
Fix the following integration tests by:

1) Update some CVE output on a xenial fix test, since the Security has
   update them recently
2) Update the esm-infra check for the libkrad0 package
