### PR TITLE
preinst: add more md5sum checks

### DIFF
--- a/debian/ubuntu-advantage-tools.preinst
+++ b/debian/ubuntu-advantage-tools.preinst
@@ -56,7 +56,7 @@ case "$1" in
             if [ -f /etc/ubuntu-advantage/uaclient.conf ]; then
                 conffile_hash=$(md5sum /etc/ubuntu-advantage/uaclient.conf|awk '{print $1}')
                 case "$conffile_hash" in
-                    038902993a843cac6cbe3efa4d1fcb92|664dff27e212a77aef514e4b64)
+                    038902993a843cac6cbe3efa4d1fcb92|f8049c664dff27e212a77aef514e4b64)
                         # User had run "pro config set apt_news=false" with no other
                         # conffile changes
                         mkdir -p /var/lib/ubuntu-advantage


### PR DESCRIPTION
## Proposed Commit Message
preinst: fix md5sum check

The md5sum for for the situation where the user set apt_news to false on 27.13.1 and later is not entirely correct, as it is missing some values in the beginning of the hash. We are adding those missing characters

## Test Steps
Guarantee that there is no prompt if the user modifies `apt_news` on either 27.13.1 or 27.13.2 and upgrades to this version of pro client

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
