### PR TITLE
postinst: remove stale esm-apps unauthenticated caches

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -17,11 +17,13 @@ fi
 APT_TRUSTED_KEY_DIR="/etc/apt/trusted.gpg.d"
 
 ESM_INFRA_KEY_TRUSTY="ubuntu-advantage-esm-infra-trusty.gpg"
+ESM_APPS_KEY="ubuntu-advantage-esm-apps.gpg"
 
 APT_SRC_DIR="/etc/apt/sources.list.d"
 APT_PREFERENCES_DIR="/etc/apt/preferences.d"
 ESM_INFRA_OLD_APT_SOURCE_FILE_TRUSTY="$APT_SRC_DIR/ubuntu-esm-infra-trusty.list"
 ESM_INFRA_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-esm-infra.list"
+ESM_APPS_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-esm-apps.list"
 FIPS_APT_SOURCE_FILE="$APT_SRC_DIR/ubuntu-fips.list"
 
 OLD_CLIENT_FIPS_PPA="private-ppa.launchpad.net/ubuntu-advantage/fips/ubuntu"
@@ -35,6 +37,7 @@ XENIAL_CLOUD_ID_SHIM_UNIT_LOCATION="/etc/systemd/system/multi-user.target.wants/
 ESM_APT_PREF_FILE_TRUSTY="$APT_PREFERENCES_DIR/ubuntu-esm-trusty"
 ESM_INFRA_OLD_APT_PREF_FILE_TRUSTY="$APT_PREFERENCES_DIR/ubuntu-esm-infra-trusty"
 ESM_INFRA_APT_PREF_FILE="$APT_PREFERENCES_DIR/ubuntu-esm-infra"
+ESM_APPS_APT_PREF_FILE="$APT_PREFERENCES_DIR/ubuntu-esm-apps"
 
 SYSTEMD_WANTS_AUTO_ATTACH_LINK="/etc/systemd/system/multi-user.target.wants/ua-auto-attach.service"
 SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enabled/ua-auto-attach.service.dsh-also"
@@ -112,7 +115,7 @@ if status:
 }
 
 
-esm_cleanup() {
+esm_infra_cleanup() {
     if ! check_service_is_enabled esm-infra; then
         rm -f "$APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg"  # Remove previous esm keys
         rm -f "$APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY"
@@ -120,6 +123,15 @@ esm_cleanup() {
         rm -f "$ESM_INFRA_OLD_APT_SOURCE_FILE_TRUSTY"
         rm -f "$ESM_APT_PREF_FILE_TRUSTY" "$ESM_INFRA_OLD_APT_PREF_FILE_TRUSTY"
         rm -f "$ESM_INFRA_APT_PREF_FILE"
+    fi
+}
+
+
+esm_apps_cleanup() {
+    if ! check_service_is_enabled esm-apps; then
+        rm -f "$APT_TRUSTED_KEY_DIR/$ESM_APPS_KEY"
+        rm -f "$ESM_APPS_APT_SOURCE_FILE"
+        rm -f "$ESM_APPS_APT_PREF_FILE"
     fi
 }
 
@@ -362,9 +374,15 @@ case "$1" in
         if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "27.13~"; then
           # Clean any unauthenticated ESM infra files previously inserted
           # on Xenial, unless the service is enabled
-          esm_cleanup
+          esm_infra_cleanup
         fi
       fi
+
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "27.13.3~"; then
+          # esm-apps unauthenticated ESM should not be in any release
+          esm_apps_cleanup
+      fi
+
       mark_reboot_for_fips_pro
       rm_old_license_check_marker
       disable_new_timer_if_old_timer_already_disabled $PREVIOUS_PKG_VER

--- a/sru/release-27.13.4/test-no-esm-apps-duplicates-attached.sh
+++ b/sru/release-27.13.4/test-no-esm-apps-duplicates-attached.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -e
+
+series=$1
+name=$series-dev
+
+version=$2
+install_from=$3
+token=$4
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+
+trap on_err ERR
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install ubuntu-advantage-tools 27.11.1 (version which inserted files by accident)
+lxc exec $name -- wget -O ./ua.deb $(curl https://launchpad.net/ubuntu/$series/amd64/ubuntu-advantage-tools/$version | grep -o "http://launchpadlibrarian.net/.*/ubuntu-advantage-tools_${version}_amd64.deb")
+lxc exec $name -- dpkg -i ./ua.deb > /dev/null
+echo -e "\n* UA version 27.11.1 is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Install a universe package (ansible)
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install ansible -y > /dev/null
+echo -e "\n* Ansible (from universe) is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ansible
+echo -e "###########################################\n"
+
+# Attach
+echo -e "\n* Attach, esm-apps enabled"
+echo "###########################################"
+lxc exec $name -- pro attach $token
+echo -e "###########################################\n"
+
+# Run security-status and see the number of esm-apps updates
+echo -e "\n* Updates from esm-apps"
+echo "###########################################"
+lxc exec $name -- pro security-status
+echo -e "###########################################\n"
+
+# Run security-status --esm-apps to check for the updates
+echo -e "\n* Updates from esm-apps"
+echo "###########################################"
+lxc exec $name -- pro security-status --esm-apps
+echo -e "###########################################\n"
+
+# Upgrading UA to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+echo -e "\n* UA now has the fix (updates installed for count to show)"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get upgrade -y > /dev/null
+echo -e "###########################################\n"
+
+# Run security-status and see the number of esm-apps updates
+echo -e "\n* Updates are still normal"
+echo "###########################################"
+lxc exec $name -- pro security-status
+echo -e "###########################################\n"
+
+# Run security-status --esm-apps to check for the updates
+echo -e "\n* Updates are still normal"
+echo "###########################################"
+lxc exec $name -- pro security-status --esm-apps
+echo -e "###########################################\n"
+
+# Check that files don't exist where they shouldn't and vice versa
+echo -e "\n* Authenticated files are there"
+echo "###########################################"
+lxc exec $name -- ls /etc/apt/sources.list.d/ubuntu-esm-apps.list || true
+echo -e "###########################################\n"
+
+echo -e "\n* esm apps cache is not there"
+echo "###########################################"
+lxc exec $name -- ls /var/lib/ubuntu-advantage/apt-esm/etc/apt/sources.list.d/ubuntu-esm-apps.list || true
+echo -e "###########################################\n"
+
+cleanup

--- a/sru/release-27.13.4/test-no-esm-apps-duplicates.sh
+++ b/sru/release-27.13.4/test-no-esm-apps-duplicates.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -e
+
+series=$1
+name=$series-dev
+
+version=$2
+install_from=$3
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+
+trap on_err ERR
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install ubuntu-advantage-tools 27.11.1 (version which inserted files by accident)
+lxc exec $name -- wget -O ./ua.deb $(curl https://launchpad.net/ubuntu/$series/amd64/ubuntu-advantage-tools/$version | grep -o "http://launchpadlibrarian.net/.*/ubuntu-advantage-tools_${version}_amd64.deb")
+lxc exec $name -- dpkg -i ./ua.deb > /dev/null
+echo -e "\n* UA version 27.11.1 is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Install a universe package (ansible)
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install ansible -y > /dev/null
+echo -e "\n* Ansible (from universe) is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ansible
+echo -e "###########################################\n"
+
+# Run security-status and see the number of esm-apps updates
+echo -e "\n* Updates from esm-apps"
+echo "###########################################"
+lxc exec $name -- pro security-status
+echo -e "###########################################\n"
+
+# Run security-status --esm-apps to check for the updates
+echo -e "\n* Updates from esm-apps"
+echo "###########################################"
+lxc exec $name -- pro security-status --esm-apps
+echo -e "###########################################\n"
+
+# Install latest ubuntu-advantage-tools ( < 27.13.4 )
+lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+echo -e "\n* UA is updated to the latest version"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+lxc exec $name -- apt-get update > /dev/null
+
+# Run security-status and see the number of esm-apps updates
+echo -e "\n* Duplicated updates"
+echo "###########################################"
+lxc exec $name -- pro security-status
+echo -e "###########################################\n"
+
+# Run security-status --esm-apps to check for the updates
+echo -e "\n* Duplicated updates"
+echo "###########################################"
+lxc exec $name -- pro security-status --esm-apps
+echo -e "###########################################\n"
+
+# Upgrading UA to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+echo -e "\n* UA now has the fix"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Run security-status and see the number of esm-apps updates
+echo -e "\n* Updates are back to normal"
+echo "###########################################"
+lxc exec $name -- pro security-status
+echo -e "###########################################\n"
+
+# Run security-status --esm-apps to check for the updates
+echo -e "\n* Updates are back to normal"
+echo "###########################################"
+lxc exec $name -- pro security-status --esm-apps
+echo -e "###########################################\n"
+
+# Check that files don't exist where they shouldn't
+echo -e "\n* No unauthenticated apt files"
+echo "###########################################"
+lxc exec $name -- ls /etc/apt/sources.list.d/ubuntu-esm-apps.list || true
+echo -e "###########################################\n"
+
+cleanup


### PR DESCRIPTION
Removes those from any release, as it shouldn't be there unless by mistake or accident.

LP: #2004193

## Test Steps
Scripts provided under the `sru/` folder. The most important one is the unattached scenario, as it is the one which has problems with duplication.
The other script is used to show that nothing changes for an attached system.
To run:
`sru/release-27.13.4/test-no-esm-apps-duplicates.sh <release> 27.11.1~<release-number>.1 <how-to-install-new-ua>`
`sru/release-27.13.4/test-no-esm-apps-duplicates-attached.sh <release> 27.11.1~<release-number>.1 <how-to-install-new-ua> <token>`

The base UA version is 27.11.1, as this is the one which caused trouble - just adjust the numbers after the `~`.
"how to install new UA" is:
- 'proposed' if you want to install from proposed
- 'staging' to use the UA Staging PPA
- a `.deb` file path if you want to install a local built version

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly, kinda
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
