### PR TITLE
lock: alert the user about corrupted lock

### DIFF
--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -82,6 +82,14 @@ How to use ``pro`` commands
     :maxdepth: 1
 
     Check Ubuntu Pro Client version <howtoguides/check_pro_version>
+
+``lock``
+-----------
+
+..  toctree::
+    :maxdepth: 1
+
+    Get rid of corrupted locks <howtoguides/get_rid_of_corrupt_lock.md>
     
 Create a ``pro`` Golden Image
 =============================

--- a/docs/howtoguides/get_rid_of_corrupt_lock.md
+++ b/docs/howtoguides/get_rid_of_corrupt_lock.md
@@ -1,0 +1,29 @@
+# How to get rid of a corrupt lock
+
+Some pro commands (`attach`, `enable`, `detach` and `disable`) will potentially change the
+internal state of your system. Since those commands can run in parallel, we have a lock file
+mechanism to guarantee that only one of these commands can run at the same time. The lock follow
+this pattern:
+
+```
+PROCESS_PID:LOCK_HOLDER_NAME
+```
+
+Where:
+
+*PROCESS_PID*: The PID of the process that is running the pro command
+*LOCK_HOLDER_NAME*: The name of the command that is using the lock (i.e. `pro disable`)
+
+If the lock file doesn't follow that pattern, we say that it is corrupted. That might happen if we
+have any type of disk failures in the system. Once we detect a corrupted lock file, any of
+the mentioned pro commands will generate the following output:
+
+```
+There is a corrupted lock file in the system. To continue, please remove it
+from the system by running:
+
+$ sudo rm /var/lib/ubuntu-advantage/lock
+```
+
+You can follow the instructions presented on the output to get rid of the corrupted lock.
+After that, running the command should generate a correct lock file and continue as expected.

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1284,3 +1284,29 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | jq       |
            | bionic  | bundler  |
            | focal   | ant      |
+
+    @series.lts
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: Attached enable with corrupt lock
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `pro disable esm-infra --assume-yes` with sudo
+        And I create the file `/var/lib/ubuntu-advantage/lock` with the following:
+        """
+        corrupted
+        """
+        Then I verify that running `pro enable esm-infra --assume-yes` `with sudo` exits `1`
+        And stderr matches regexp:
+        """
+        There is a corrupted lock file in the system. To continue, please remove it
+        from the system by running:
+
+        \$ sudo rm /var/lib/ubuntu-advantage/lock
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | jammy   |

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -330,7 +330,14 @@ class UAConfig:
         if not os.path.exists(lock_path):
             return no_lock
         lock_content = system.load_file(lock_path)
-        [lock_pid, lock_holder] = lock_content.split(":")
+
+        try:
+            [lock_pid, lock_holder] = lock_content.split(":")
+        except ValueError:
+            raise exceptions.InvalidLockFile(
+                os.path.join(self.data_dir, "lock")
+            )
+
         try:
             system.subp(["ps", lock_pid])
             return (int(lock_pid), lock_holder)

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -469,3 +469,9 @@ class MissingSeriesOnOSReleaseFile(UserFacingError):
     def __init__(self, version):
         msg = messages.MISSING_SERIES_ON_OS_RELEASE.format(version=version)
         super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class InvalidLockFile(UserFacingError):
+    def __init__(self, lock_file_path):
+        msg = messages.INVALID_LOCK_FILE.format(lock_file_path=lock_file_path)
+        super().__init__(msg=msg.msg, msg_code=msg.name)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1160,3 +1160,12 @@ Could not extract series information from /etc/os-release.
 The VERSION filed does not have version information: {version}
 and the VERSION_CODENAME information is not present""",
 )
+
+INVALID_LOCK_FILE = FormattedNamedMessage(
+    "invalid-lock-file",
+    """\
+There is a corrupted lock file in the system. To continue, please remove it
+from the system by running:
+
+$ sudo rm {lock_file_path}""",
+)

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1469,3 +1469,29 @@ class TestGetConfigPath:
         with mock.patch.dict("uaclient.config.os.environ", values={}):
             assert DEFAULT_CONFIG_FILE == get_config_path()
             assert _m_exists.call_count == 1
+
+
+class TestCheckLockInfo:
+    @pytest.mark.parametrize("lock_content", ((""), ("corrupted")))
+    @mock.patch("os.path.exists", return_value=True)
+    @mock.patch("uaclient.system.load_file")
+    def test_raise_exception_for_corrupted_lock(
+        self,
+        m_load_file,
+        _m_path_exists,
+        lock_content,
+        FakeConfig,
+    ):
+        cfg = FakeConfig()
+        m_load_file.return_value = lock_content
+
+        expected_msg = messages.INVALID_LOCK_FILE.format(
+            lock_file_path=cfg.data_dir + "/lock"
+        )
+
+        with pytest.raises(exceptions.InvalidLockFile) as exc_info:
+            cfg.check_lock_info()
+
+        assert expected_msg.msg == exc_info.value.msg
+        assert m_load_file.call_count == 1
+        assert _m_path_exists.call_count == 1


### PR DESCRIPTION
## Proposed Commit Message
lock: alert the user about corrupted lock

If we detect we have a corrupted lock in the system, we are now alerting the user about that with steps to solve that scenario

LP: #1996931

## Test Steps
Run the new integration test for this feature

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
