### PR TITLE
system: use VERSION_CODENAME if needed

### DIFF
--- a/lib/esm_cache.py
+++ b/lib/esm_cache.py
@@ -6,9 +6,15 @@ from uaclient.apt import update_esm_caches
 from uaclient.config import UAConfig
 from uaclient.daemon import setup_logging
 
+LOG = logging.getLogger("pro")
+
 
 def main(cfg: UAConfig) -> None:
-    update_esm_caches(cfg)
+    try:
+        update_esm_caches(cfg)
+    except Exception as e:
+        msg = getattr(e, "msg", str(e))
+        LOG.error("Error updating the cache: %s", msg)
 
 
 if __name__ == "__main__":

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -455,3 +455,17 @@ class InvalidFileFormatError(UserFacingError):
             file_name=file_name, file_format=file_format
         )
         super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class ParsingErrorOnOSReleaseFile(UserFacingError):
+    def __init__(self, orig_ver: str, mod_ver: str):
+        msg = messages.ERROR_PARSING_VERSION_OS_RELEASE.format(
+            orig_ver=orig_ver, mod_ver=mod_ver
+        )
+        super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class MissingSeriesOnOSReleaseFile(UserFacingError):
+    def __init__(self, version):
+        msg = messages.MISSING_SERIES_ON_OS_RELEASE.format(version=version)
+        super().__init__(msg=msg.msg, msg_code=msg.name)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1103,3 +1103,17 @@ RETRY_ERROR_DETAIL_URL_ERROR_CODE = "a {code} while reaching {url}"
 RETRY_ERROR_DETAIL_URL_ERROR_URL = "an error while reaching {url}"
 RETRY_ERROR_DETAIL_URL_ERROR_GENERIC = "a network error"
 RETRY_ERROR_DETAIL_UNKNOWN = "an unknown error"
+
+ERROR_PARSING_VERSION_OS_RELEASE = FormattedNamedMessage(
+    "error-parsing-version-os-release",
+    """\
+Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})""",
+)
+
+MISSING_SERIES_ON_OS_RELEASE = FormattedNamedMessage(
+    "missing-series-on-os-release",
+    """\
+Could not extract series information from /etc/os-release.
+The VERSION filed does not have version information: {version}
+and the VERSION_CODENAME information is not present""",
+)

--- a/uaclient/tests/test_esm_cache.py
+++ b/uaclient/tests/test_esm_cache.py
@@ -1,11 +1,35 @@
+import logging
+
 import mock
+import pytest
 
 from lib.esm_cache import main
+from uaclient.exceptions import MissingSeriesOnOSReleaseFile
 
 
+@mock.patch("lib.esm_cache.update_esm_caches")
 class TestUpdateEsmCaches:
-    @mock.patch("lib.esm_cache.update_esm_caches")
     def test_builds_local_cache(self, m_update_caches, FakeConfig):
         main(FakeConfig())
 
         assert m_update_caches.call_count == 1
+
+    @pytest.mark.parametrize("caplog_text", [logging.ERROR], indirect=True)
+    def test_log_user_facing_exception(
+        self, m_update_caches, caplog_text, FakeConfig
+    ):
+        expected_exception = MissingSeriesOnOSReleaseFile(version="version")
+        m_update_caches.side_effect = expected_exception
+        main(cfg=FakeConfig())
+
+        for line in expected_exception.msg.split("\n"):
+            assert line in caplog_text()
+
+    @pytest.mark.parametrize("caplog_text", [logging.ERROR], indirect=True)
+    def test_log_exception(self, m_update_caches, caplog_text, FakeConfig):
+        expected_msg = "unexpected exception"
+        expected_exception = Exception(expected_msg)
+        m_update_caches.side_effect = expected_exception
+        main(cfg=FakeConfig())
+
+        assert expected_msg in caplog_text()


### PR DESCRIPTION
## Proposed Commit Message
system: use VERSION_CODENAME if needed

When parsing the VERSION field from `/etc/os-release`, we might not have the series in the `VERSION` string. If we detect that, we now fallback to `VERSION_CODENAME` for that info

## Test Steps
Guarantee that no integration test fails due to this change or that we don't incorrectly fallback to `VERSION_CODENAME`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
