### PR TITLE
fix: consider packages without a candidate as 'unknown'

### DIFF
--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -105,7 +105,7 @@ def get_origin_for_package(package: apt.package.Package) -> str:
     # candidate version. No candidate means we don't know anything about the
     # package. Otherwise we check for the origins of the candidate version.
     if len(available_origins) == 1:
-        if package.installed == package.candidate:
+        if package.candidate is None or package.installed == package.candidate:
             return "unknown"
         available_origins = package.candidate.origins
 

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -238,6 +238,19 @@ class TestSecurityStatus:
         ):
             assert expected_output == get_origin_for_package(package_mock)
 
+    def test_get_origin_for_package_without_candidate(self):
+        """Packages without candidates are unknown."""
+        package_mock = mock_package(
+            "example", mock_version("1.0", [MOCK_ORIGINS["now"]]), []
+        )
+        package_mock.candidate = None
+
+        with mock.patch(
+            M_PATH + "get_origin_information_to_service_map",
+            return_value=ORIGIN_TO_SERVICE_MOCK,
+        ):
+            assert "unknown" == get_origin_for_package(package_mock)
+
     @mock.patch("uaclient.security_status.get_esm_cache", return_value={})
     def test_filter_security_updates(self, _m_get_esm_cache):
         expected_return = defaultdict(


### PR DESCRIPTION
If a package is installed, has a single origin reference, and the installed version is not even a candidate, then there is nothing we can say about the package.

LP: #2006049

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
