### PR TITLE
test: pin oscap to 1.3.7 to avoid epoch error message

### DIFF
--- a/dev-docs/howtoguides/building.md
+++ b/dev-docs/howtoguides/building.md
@@ -30,7 +30,7 @@ bash ./tools/setup_sbuild.sh
 debuild -S
 sbuild --dist=<target> ../ubuntu-advantage-tools_*.dsc
 # emulating different architectures in sbuild-launchpad-chroot
-sbuild-launchpad-chroot create --architecture="riscv64" "--name=focal-riscv64" "--series=focal
+sbuild-launchpad-chroot create --architecture="riscv64" "--name=focal-riscv64" "--series=focal"
 ```
 
 > **Note**

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -32,7 +32,7 @@ Feature: API security/security status tests
         And I run `apt install jq bzip2 -y` with sudo
         # Install the oscap version 1.3.7 which solved the epoch error message issue
         And I run `apt-get install lcov swig xsltproc rpm-common lua5.3 libyaml-dev libapt-pkg-dev libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libxslt1-dev libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev librtmp-dev libxmlsec1-dev libxmlsec1-openssl cmake make build-essential -y` with sudo
-        And I run `apt-get remove rpm -y` with sudo
+        And I run `apt-get remove *rpm* -y` with sudo
         And I run `wget https://github.com/OpenSCAP/openscap/releases/download/1.3.7/openscap-1.3.7.tar.gz` as non-root
         And I run `tar xzf openscap-1.3.7.tar.gz` as non-root
         And I run shell command `cd openscap-1.3.7/ && mkdir build && cd build/` as non-root

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -31,12 +31,13 @@ Feature: API security/security status tests
         And I run `apt upgrade -y` with sudo
         And I run `apt install jq bzip2 -y` with sudo
         # Install the oscap version 1.3.7 which solved the epoch error message issue
-        And I run `apt-get install lcov swig xsltproc rpm-common lua5.3 libyaml-dev libapt-pkg-dev libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libxslt1-dev libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev librtmp-dev libxmlsec1-dev libxmlsec1-openssl cmake make build-essential -y` with sudo
-        And I run `apt-get remove *rpm* -y` with sudo
+        And I run `apt-get install -y cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev g++ libapt-pkg-dev libyaml-dev libxmlsec1-dev libxmlsec1-openssl` with sudo
         And I run `wget https://github.com/OpenSCAP/openscap/releases/download/1.3.7/openscap-1.3.7.tar.gz` as non-root
         And I run `tar xzf openscap-1.3.7.tar.gz` as non-root
-        And I run shell command `cd openscap-1.3.7/ && mkdir build && cd build/` as non-root
-        And I run shell command `cd openscap-1.3.7/build/ && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../ && make install` with sudo
+        And I run shell command `mkdir -p openscap-1.3.7/build` as non-root
+        And I run shell command `cd openscap-1.3.7/build/ && cmake ..` with sudo
+        And I run shell command `cd openscap-1.3.7/build/ && make` with sudo
+        And I run shell command `cd openscap-1.3.7/build/ && make install` with sudo
         # Installs its shared libs in /usr/local/lib/
         And I run `ldconfig` with sudo
         And I run shell command `pro api u.security.package_manifest.v1 | jq -r '.data.attributes.manifest_data' > manifest` as non-root

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -29,7 +29,16 @@ Feature: API security/security status tests
         """
         When I run `apt update` with sudo
         And I run `apt upgrade -y` with sudo
-        And I run `apt install jq bzip2 libopenscap8 -y` with sudo
+        And I run `apt install jq bzip2 -y` with sudo
+        # Install the oscap version 1.3.7 which solved the epoch error message issue
+        And I run `apt-get install lcov swig xsltproc rpm-common lua5.3 libyaml-dev libapt-pkg-dev libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libxslt1-dev libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev librtmp-dev libxmlsec1-dev libxmlsec1-openssl cmake make build-essential -y` with sudo
+        And I run `apt-get remove rpm -y` with sudo
+        And I run `wget https://github.com/OpenSCAP/openscap/releases/download/1.3.7/openscap-1.3.7.tar.gz` as non-root
+        And I run `tar xzf openscap-1.3.7.tar.gz` as non-root
+        And I run shell command `cd openscap-1.3.7/ && mkdir build && cd build/` as non-root
+        And I run shell command `cd openscap-1.3.7/build/ && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../ && make install` with sudo
+        # Installs its shared libs in /usr/local/lib/
+        And I run `ldconfig` with sudo
         And I run shell command `pro api u.security.package_manifest.v1 | jq -r '.data.attributes.manifest_data' > manifest` as non-root
         And I run shell command `wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.<release>.usn.oval.xml.bz2` as non-root
         And I run `bunzip2 oci.com.ubuntu.<release>.usn.oval.xml.bz2` as non-root

--- a/features/steps/shell.py
+++ b/features/steps/shell.py
@@ -127,9 +127,9 @@ def when_i_verify_that_running_cmd_with_spec_exits_with_codes(
 
 def get_command_prefix_for_user_spec(user_spec):
     prefix = []
-    if user_spec == "with sudo":
+    if user_spec.lstrip() == "with sudo":
         prefix = ["sudo"]
-    elif user_spec != "as non-root":
+    elif user_spec.lstrip() != "as non-root":
         raise Exception(
             "The two acceptable values for user_spec are: 'with sudo',"
             " 'as non-root'"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

test: pin oscap to 1.3.7
We are pinning our tests to the latest,as of the pr time, of the oscap tool. 
It has solved the issue with the `invalid epoch` error message.
This [Oscap PR](https://github.com/OpenSCAP/openscap/commit/ce34cd227439e17248dfdf55b0fc19859c88d075) better explains.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
