### PR TITLE
notices: do not issue notices for non-root users

### DIFF
--- a/uaclient/files/tests/test_notices.py
+++ b/uaclient/files/tests/test_notices.py
@@ -35,6 +35,17 @@ class TestNotices:
             )
         ] == sys_write_file.call_args_list
 
+    @mock.patch("uaclient.files.notices.system.write_file")
+    def test_add_non_root(
+        self,
+        m_sys_write_file,
+        caplog_text,
+    ):
+        notice = NoticesManager()
+        notice.add(False, FakeNotice.a, "content")
+        assert [] == m_sys_write_file.call_args_list
+        assert "Trying to add a notice as non-root user" in caplog_text()
+
     @pytest.mark.parametrize(
         "label,content",
         (
@@ -81,6 +92,17 @@ class TestNotices:
                 os.path.join(defaults.NOTICES_PERMANENT_DIRECTORY, "01-a"),
             )
         ] == sys_file_absent.call_args_list
+
+    @mock.patch("uaclient.files.notices.system.ensure_file_absent")
+    def test_remove_non_root(
+        self,
+        m_sys_file_absent,
+        caplog_text,
+    ):
+        notice = NoticesManager()
+        notice.remove(False, FakeNotice.a)
+        assert [] == m_sys_file_absent.call_args_list
+        assert "Trying to remove a notice as non-root user" in caplog_text()
 
     @mock.patch("uaclient.files.notices.NoticesManager.list")
     @mock.patch("uaclient.files.notices.NoticesManager.remove")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
notices: do not issue notices for non-root users

Prevent dummy warnings to appear in the status json output and
logging console for non-root users

LP: #2006138
```

## Additional Context
https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2006138

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
./tools/test-in-lxd.sh jammy

root@jammy$ pro attach <token>
root@jammy$ su ubuntu
root@jammy$ pro status --format=json
```
Previously, a bunch of `Trying to remove notice as non-root user` warnings appeared.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
