### PR TITLE
apt: remove one call to apt-cache policy

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -1,7 +1,6 @@
 import abc
 import copy
 import logging
-import re
 from os.path import exists
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -115,11 +114,9 @@ class RepoEntitlement(base.UAEntitlement):
                 ApplicationStatus.DISABLED,
                 messages.NO_APT_URL_FOR_SERVICE.format(title=self.title),
             )
-        policy = apt.get_apt_cache_policy(
-            error_msg=messages.APT_POLICY_FAILED.msg
-        )
-        match = re.search(r"{}/ubuntu".format(repo_url), policy)
-        if match:
+
+        repo_url = "{}/ubuntu/".format(repo_url)
+        if apt.is_uri_in_apt_source_files(repo_url):
             return (
                 ApplicationStatus.ENABLED,
                 messages.SERVICE_IS_ACTIVE.format(title=self.title),

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 import mock
 import pytest
 
-from uaclient import apt, messages, status
+from uaclient import apt, status
 from uaclient.entitlements.cc import CC_README, CommonCriteriaEntitlement
 from uaclient.entitlements.tests.conftest import machine_token
 
@@ -116,14 +116,14 @@ class TestCommonCriteriaEntitlementEnable:
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch("uaclient.system.should_reboot")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.apt.get_apt_cache_policy")
+    @mock.patch("uaclient.apt.is_uri_in_apt_source_files", return_value=False)
     @mock.patch("uaclient.system.get_platform_info")
     @mock.patch("uaclient.contract.apply_contract_overrides")
     def test_enable_configures_apt_sources_and_auth_files(
         self,
         _m_contract_overrides,
         m_platform_info,
-        m_apt_cache_policy,
+        _m_is_uri_in_apt_source_files,
         m_subp,
         m_should_reboot,
         m_setup_apt_proxy,
@@ -136,7 +136,6 @@ class TestCommonCriteriaEntitlementEnable:
     ):
         """When entitled, configure apt repo auth token, pinning and url."""
         m_subp.return_value = ("fakeout", "")
-        m_apt_cache_policy.return_value = "fakeout"
         m_should_reboot.return_value = False
         original_exists = os.path.exists
 
@@ -174,12 +173,6 @@ class TestCommonCriteriaEntitlementEnable:
                 "{}-token".format(entitlement.name),
                 ["xenial"],
                 entitlement.repo_key_file,
-            )
-        ]
-
-        apt_cache_policy_cmds = [
-            mock.call(
-                error_msg=messages.APT_POLICY_FAILED.msg,
             )
         ]
 
@@ -235,8 +228,7 @@ class TestCommonCriteriaEntitlementEnable:
         assert [] == m_add_pin.call_args_list
         assert 1 == m_setup_apt_proxy.call_count
         assert 1 == m_should_reboot.call_count
-        assert 1 == m_apt_cache_policy.call_count
-        assert apt_cache_policy_cmds == m_apt_cache_policy.call_args_list
+        assert 1 == _m_is_uri_in_apt_source_files.call_count
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout += "\n".join(
             [

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1035,24 +1035,6 @@ class TestFIPSEntitlementApplicationStatus:
         assert expected_msg.msg == actual_msg.msg
         assert expected_msg.name == actual_msg.name
 
-    def test_fips_does_not_show_enabled_when_fips_updates_is(
-        self, _m_should_reboot, entitlement
-    ):
-        with mock.patch("uaclient.apt.get_apt_cache_policy") as m_apt_policy:
-            m_apt_policy.return_value = (
-                "1001 http://FIPS-UPDATES/ubuntu"
-                " xenial-updates/main amd64 Packages\n"
-                ""
-            )
-
-            application_status, _ = entitlement.application_status()
-
-        expected_status = ApplicationStatus.DISABLED
-        if isinstance(entitlement, FIPSUpdatesEntitlement):
-            expected_status = ApplicationStatus.ENABLED
-
-        assert expected_status == application_status
-
 
 class TestFipsEntitlementInstallPackages:
     @mock.patch(M_PATH + "apt.run_apt_command")

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -962,30 +962,22 @@ class TestApplicationStatus:
         )
 
     @pytest.mark.parametrize(
-        "policy_url,enabled",
+        "enabled",
         (
-            ("https://esm.ubuntu.com/apps/ubuntu", False),
-            ("https://esm.ubuntu.com/ubuntu", True),
+            (False),
+            (True),
         ),
     )
-    @mock.patch(M_PATH + "apt.get_apt_cache_policy")
+    @mock.patch(M_PATH + "apt.is_uri_in_apt_source_files")
     def test_enabled_status_by_apt_policy(
-        self, m_run_apt_policy, policy_url, enabled, entitlement_factory
+        self, m_is_uri_in_apt_source_files, enabled, entitlement_factory
     ):
         """Report ENABLED when apt-policy lists specific aptURL."""
+        m_is_uri_in_apt_source_files.return_value = enabled
         entitlement = entitlement_factory(
             RepoTestEntitlement,
             directives={"aptURL": "https://esm.ubuntu.com"},
         )
-
-        policy_lines = [
-            "500 {policy_url} bionic-security/main amd64 Packages".format(
-                policy_url=policy_url
-            ),
-            " release v=18.04,o=UbuntuESMApps,...,n=bionic,l=UbuntuESMApps",
-            "  origin esm.ubuntu.com",
-        ]
-        m_run_apt_policy.return_value = "\n".join(policy_lines)
 
         application_status, explanation = entitlement.application_status()
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -475,3 +475,11 @@ class InvalidLockFile(UserFacingError):
     def __init__(self, lock_file_path):
         msg = messages.INVALID_LOCK_FILE.format(lock_file_path=lock_file_path)
         super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class ErrorParsingAPTSourceFile(UserFacingError):
+    def __init__(self, exception_str: str):
+        msg = messages.ERROR_PARSING_APT_SOURCE_FILES.format(
+            exception_str=exception_str
+        )
+        super().__init__(msg=msg.msg, msg_code=msg.name)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1178,3 +1178,10 @@ MISSING_YAML_MODULE = NamedMessage(
 Couldn't import the YAML module from /usr/lib/python3/dist-packages.
 Make sure the 'python3-yaml' package is installed correctly.""",
 )
+
+ERROR_PARSING_APT_SOURCE_FILES = FormattedNamedMessage(
+    name="error-parsing-apt-source-files",
+    msg="""\
+Error parsing APT source files:
+{exception_str}""",
+)

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -19,6 +19,7 @@ from uaclient.apt import (
     APT_PROXY_CONF_FILE,
     APT_RETRIES,
     KEYRINGS_DIR,
+    _read_apt_source_files,
     add_apt_auth_conf_entry,
     add_auth_apt_repo,
     add_ppa_pinning,
@@ -26,7 +27,6 @@ from uaclient.apt import (
     clean_apt_files,
     compare_versions,
     find_apt_list_files,
-    get_apt_cache_policy,
     get_apt_cache_time,
     get_installed_packages_names,
     is_installed,
@@ -904,44 +904,60 @@ class TestRunAptCommand:
         expected_message = "\n".join(output_list) + "."
         assert expected_message == excinfo.value.msg
 
+    @mock.patch("apt_pkg.init")
+    @mock.patch("apt_pkg.SourceList")
     @mock.patch("uaclient.apt.system.subp")
-    def test_run_update_command_clean_apt_cache_policy_cache(self, m_subp):
+    def test_run_update_command_clean_read_apt_source_cache(
+        self,
+        m_subp,
+        m_source_list,
+        _m_apt_init,
+    ):
+        m_list = mock.MagicMock()
+        m_source_list.return_value = m_list
+        type(m_list).list = mock.PropertyMock(
+            side_effect=["policy1", "policy2"]
+        )
         m_subp.side_effect = [
-            ("policy1", ""),
             ("update", ""),
-            ("policy2", ""),
         ]
 
-        assert "policy1" == get_apt_cache_policy()
+        assert "policy1" == _read_apt_source_files()
         # Confirming that caching is happening
-        assert "policy1" == get_apt_cache_policy()
+        assert "policy1" == _read_apt_source_files()
 
         run_apt_update_command()
 
         # Confirm cache was cleared
-        assert "policy2" == get_apt_cache_policy()
-        get_apt_cache_policy.cache_clear()
+        assert "policy2" == _read_apt_source_files()
+        _read_apt_source_files.cache_clear()
 
+    @mock.patch("apt_pkg.init")
+    @mock.patch("apt_pkg.SourceList")
     @mock.patch("uaclient.apt.system.subp")
-    def test_failed_run_update_command_clean_apt_cache_policy_cache(
-        self, m_subp
+    def test_failed_run_update_command_clean_read_apt_source_cache(
+        self,
+        m_subp,
+        m_source_list,
+        _m_apt_init,
     ):
-        m_subp.side_effect = [
-            ("policy1", ""),
-            exceptions.UserFacingError("test"),
-            ("policy2", ""),
-        ]
+        m_list = mock.MagicMock()
+        m_source_list.return_value = m_list
+        type(m_list).list = mock.PropertyMock(
+            side_effect=["policy1", "policy2"]
+        )
+        m_subp.side_effect = exceptions.UserFacingError("test")
 
-        assert "policy1" == get_apt_cache_policy()
+        assert "policy1" == _read_apt_source_files()
         # Confirming that caching is happening
-        assert "policy1" == get_apt_cache_policy()
+        assert "policy1" == _read_apt_source_files()
 
         with pytest.raises(exceptions.UserFacingError):
             run_apt_update_command()
 
         # Confirm cache was cleared
-        assert "policy2" == get_apt_cache_policy()
-        get_apt_cache_policy.cache_clear()
+        assert "policy2" == _read_apt_source_files()
+        _read_apt_source_files.cache_clear()
 
 
 class TestAptProxyConfig:


### PR DESCRIPTION
## Proposed Commit Message
apt: remove one call to apt-cache policy

When checking if a repo service is enabled, we don't need to call apt-cache policy directly, as the information we need can be directly extract from python apt modules. This allow us to change the implemantion to not call that command directly, but instead using the python tools avaiable on python-apt to perform that check

I have also performed time comparison between `pro status` on a Xenial container with and without this change:

without: 2.095s
with: 2.234s

Notice however that I have not implemented any cache mechanisms for this code, which we can further discuss if it is necessary

## Test Steps
Verify that are no integration test failures related to this change

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
