### PR TITLE
apt: make sure all calls to the ESM cache are isolated

### DIFF
--- a/apt-hook/esm-counts.cc
+++ b/apt-hook/esm-counts.cc
@@ -52,11 +52,24 @@ bool get_potential_esm_updates(ESMUpdates &updates) {
    }
 
    // set up esm cache
+   // make sure the configuration is isolated, apart from Acquire
+   for (const Configuration::Item *ConfigItem = _config->Tree(0); ConfigItem != NULL; ConfigItem = ConfigItem->Next) {
+      if (ConfigItem->FullTag(0) != "Acquire") {
+         _config->Clear(ConfigItem->FullTag(0));
+      }
+   }
+
    _config->Set("Dir", "/var/lib/ubuntu-advantage/apt-esm/");
    _config->Set("Dir::State::status", "/var/lib/ubuntu-advantage/apt-esm/var/lib/dpkg/status");
+
+   if (!pkgInitConfig(*_config)) {
+      return false;
+   }
+
    if (!pkgInitSystem(*_config, _system)) {
       return false;
    }
+
    pkgCacheFile esm_cachefile;
    pkgCache *esm_cache = esm_cachefile.GetPkgCache();
    if (esm_cache == NULL) {

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -11,8 +11,8 @@ from typing import Any, DefaultDict, Dict, List, Tuple  # noqa: F401
 import apt  # type: ignore
 
 from uaclient import messages
+from uaclient.apt import get_esm_cache
 from uaclient.config import UAConfig
-from uaclient.defaults import ESM_APT_ROOTDIR
 from uaclient.entitlements import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.entitlement_status import (
     ApplicabilityStatus,
@@ -61,18 +61,6 @@ def get_origin_information_to_service_map():
         ("UbuntuESMApps", "{}-apps-updates".format(series)): "esm-apps",
         ("UbuntuESM", "{}-infra-updates".format(series)): "esm-infra",
     }
-
-
-@lru_cache(maxsize=None)
-def get_esm_cache():
-    try:
-        # If the rootdir folder doesn't contain any apt source info, the
-        # cache will be empty
-        cache = apt.Cache(rootdir=ESM_APT_ROOTDIR)
-    except Exception:
-        cache = {}
-
-    return cache
 
 
 def get_installed_packages_by_origin() -> DefaultDict[

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -18,7 +18,6 @@ from uaclient.apt import (
     APT_KEYS_DIR,
     APT_PROXY_CONF_FILE,
     APT_RETRIES,
-    ESM_APT_ROOTDIR,
     KEYRINGS_DIR,
     add_apt_auth_conf_entry,
     add_auth_apt_repo,
@@ -1073,7 +1072,7 @@ class TestAptCacheTime:
 
     @pytest.mark.parametrize(
         "is_lts,cache_call_list",
-        ((True, [mock.call(rootdir=ESM_APT_ROOTDIR)]), (False, [])),
+        ((True, [mock.call()]), (False, [])),
     )
     @pytest.mark.parametrize(
         "apps_status", (ApplicationStatus.ENABLED, ApplicationStatus.DISABLED)
@@ -1086,14 +1085,14 @@ class TestAptCacheTime:
     @mock.patch("uaclient.entitlements.esm.ESMInfraEntitlement")
     @mock.patch("uaclient.apt.system.is_current_series_lts")
     @mock.patch("uaclient.apt.system.is_current_series_active_esm")
-    @mock.patch("apt.Cache")
+    @mock.patch("uaclient.apt.get_esm_cache")
     @mock.patch("apt_pkg.config")
     @mock.patch("apt_pkg.init_config")
     def test_update_esm_caches_based_on_lts(
         self,
         _m_apt_pkg_init_config,
         _m_apt_pkg_config,
-        m_cache,
+        m_esm_cache,
         m_is_esm,
         m_is_lts,
         m_infra_entitlement,
@@ -1135,7 +1134,7 @@ class TestAptCacheTime:
 
         update_esm_caches(FakeConfig())
 
-        assert m_cache.call_args_list == cache_call_list
+        assert m_esm_cache.call_args_list == cache_call_list
 
         assert (
             m_infra.setup_local_esm_repo.call_count == infra_setup_repo_count


### PR DESCRIPTION
system configuration, except Acquire configuration, is cleared everywhere we call the cache

This PR guarantees a promise we made in the SRU of 27.13.1, where the calls to apt.Cache would guarantee isolation from the system environment except for the needed configuration.

## Test Steps
Green CI, everything still working as normal.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [x] Yes - Robie or Andreas, maybe Julian?
 - [ ] No
