### PR TITLE
apt news bugfix and document how to disable

### DIFF
--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -34,6 +34,7 @@ How to use ``pro`` commands
 ..  toctree::
     :maxdepth: 1
 
+    Disable or re-enable APT News <howtoguides/disable_enable_apt_news.md>
     Configure a proxy <howtoguides/configure_proxies.md>
     Configure a timer job <howtoguides/configuring_timer_jobs.md>
 

--- a/docs/howtoguides/disable_enable_apt_news.md
+++ b/docs/howtoguides/disable_enable_apt_news.md
@@ -1,0 +1,45 @@
+# How to disable or re-enable APT News
+
+APT News is a feature that allows for timely package-related news to be displayed during an `apt upgrade`. It is distinct from [Ubuntu Pro 'available update' messages](../explanations/apt_messages.md) that are also displayed during an `apt upgrade`. APT News messages are fetched from [https://motd.ubuntu.com/aptnews.json](https://motd.ubuntu.com/aptnews.json) at most once per day.
+
+By default, APT News is turned on. In this How-to-guide, we show how to turn off and on the APT News feature for a particular machine.
+
+## Step 1: Check the current configuration of APT News
+
+```
+pro config show apt_news
+```
+
+The default value is `True`, so if you haven't yet modified this setting, you will see:
+```
+apt_news True
+```
+
+## Step 2: Disable APT News
+
+```
+pro config set apt_news=false
+```
+
+This should also clear any current APT News you may be seeing on your system during `apt upgrade`.
+
+You can double-check that the setting was successful by running the following again:
+
+```
+pro config show apt_news
+```
+
+You should now see:
+```
+apt_news False
+```
+
+## Step 3: (Optional) Re-enable APT News
+
+If you change your mind and want APT News to start appearing again in `apt upgrade`, run the following:
+
+```
+pro config set apt_news=true
+```
+
+And verify the setting worked with `pro config show apt_news`.

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -251,7 +251,6 @@ Feature: APT Messages
         # So there are "wait"s before each pro refresh messages call
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -293,7 +292,6 @@ Feature: APT Messages
 
         # apt update stamp will prevent a apt_news refresh
         When I run `apt-get update` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -310,7 +308,6 @@ Feature: APT Messages
         # manual refresh gets new message
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -331,7 +328,6 @@ Feature: APT Messages
         When I run `rm -rf /var/lib/ubuntu-advantage/messages` with sudo
         When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
         When I run `apt-get update` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -366,7 +362,6 @@ Feature: APT Messages
         """
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -393,7 +388,6 @@ Feature: APT Messages
         """
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -421,7 +415,6 @@ Feature: APT Messages
         """
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -447,7 +440,6 @@ Feature: APT Messages
         """
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -478,7 +470,6 @@ Feature: APT Messages
         """
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -505,7 +496,6 @@ Feature: APT Messages
         """
         When I wait `1` seconds
         When I run `pro refresh messages` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -550,7 +540,6 @@ Feature: APT Messages
         # test that apt update will trigger hook to update apt_news for local override
         When I run shell command `rm -f /var/lib/apt/periodic/update-success-stamp` with sudo
         When I run `apt-get update` with sudo
-        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -326,6 +326,27 @@ Feature: APT Messages
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
 
+        # creates /run/ubuntu-advantage and /var/lib/ubuntu-advantage/messages if not there
+        When I run `rm -rf /run/ubuntu-advantage` with sudo
+        When I run `rm -rf /var/lib/ubuntu-advantage/messages` with sudo
+        When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
+        When I run `apt-get update` with sudo
+        When I run shell command `rm -f /var/lib/ubuntu-advantage/messages/apt-pre*` with sudo
+        When I run `apt upgrade` with sudo
+        Then I will see the following on stdout
+        """
+        Reading package lists...
+        Building dependency tree...
+        Reading state information...
+        Calculating upgrade...
+        #
+        # one
+        # two
+        # three
+        #
+        0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+        """
+
         # more than 3 lines ignored
         When I create the file `/var/www/html/aptnews.json` on the `apt-news-server` machine with the following:
         """

--- a/uaclient/apt_news.py
+++ b/uaclient/apt_news.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import os
 import unicodedata
 from typing import List, Optional
 
@@ -157,6 +158,7 @@ def select_message(
 
 
 def fetch_aptnews_json(cfg: UAConfig):
+    os.makedirs(defaults.UAC_RUN_PATH, exist_ok=True)
     acq = apt_pkg.Acquire()
     apt_news_file = apt_pkg.AcquireFile(
         acq, cfg.apt_news_url, destdir=defaults.UAC_RUN_PATH


### PR DESCRIPTION
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
On a fresh machine. make sure `/run/ubuntu-advantage` doesn't exist. Then run `apt update` and `apt upgrade` and verify that the apt news about phased updates is displayed.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
