### PR TITLE
Force importing yaml from the system dist-packages

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -13,8 +13,6 @@ import time
 from functools import wraps
 from typing import List, Optional, Tuple  # noqa
 
-import yaml
-
 from uaclient import (
     actions,
     apt,
@@ -32,7 +30,7 @@ from uaclient import (
     security_status,
 )
 from uaclient import status as ua_status
-from uaclient import util, version
+from uaclient import util, version, yaml
 from uaclient.api.api import call_api
 from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
     FullAutoAttachOptions,

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -6,8 +6,6 @@ from collections import namedtuple
 from functools import lru_cache, wraps
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar
 
-import yaml
-
 from uaclient import (
     apt,
     event_logger,
@@ -17,6 +15,7 @@ from uaclient import (
     snap,
     system,
     util,
+    yaml,
 )
 from uaclient.defaults import (
     APT_NEWS_URL,

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -623,7 +623,7 @@ class UAConfig:
             key: getattr(self, key, None) for key in UA_CONFIGURABLE_KEYS
         }
 
-        content += yaml.dump(cfg_dict, default_flow_style=False)
+        content += yaml.safe_dump(cfg_dict, default_flow_style=False)
         system.write_file(config_path, content)
 
     def warn_about_invalid_keys(self):

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -5,9 +5,15 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import yaml
-
-from uaclient import config, contract, event_logger, messages, system, util
+from uaclient import (
+    config,
+    contract,
+    event_logger,
+    messages,
+    system,
+    util,
+    yaml,
+)
 from uaclient.defaults import DEFAULT_HELP_FILE
 from uaclient.entitlements.entitlement_status import (
     ApplicabilityStatus,

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -231,7 +231,7 @@ class EventLogger:
                 )
             )
         elif self._event_logger_mode == EventLoggerMode.YAML:
-            print(yaml.dump(output, default_flow_style=False))
+            print(yaml.safe_dump(output, default_flow_style=False))
 
     def process_events(self) -> None:
         """

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -11,7 +11,7 @@ import json
 import sys
 from typing import Any, Dict, List, Optional, Set, Union  # noqa: F401
 
-import yaml
+from uaclient import yaml
 
 JSON_SCHEMA_VERSION = "0.1"
 EventFieldErrorType = Optional[Union[str, Dict[str, str]]]

--- a/uaclient/files/data_types.py
+++ b/uaclient/files/data_types.py
@@ -2,9 +2,7 @@ import json
 from enum import Enum
 from typing import Callable, Dict, Generic, Optional, Type, TypeVar
 
-import yaml
-
-from uaclient import exceptions
+from uaclient import exceptions, yaml
 from uaclient.data_types import DataObject
 from uaclient.files.files import UAFile
 from uaclient.util import DatetimeAwareJSONDecoder

--- a/uaclient/files/data_types.py
+++ b/uaclient/files/data_types.py
@@ -67,7 +67,7 @@ class DataObjectFile(Generic[DOFType]):
             str_content = content.to_json()
         elif self.file_format == DataObjectFileFormat.YAML:
             data = content.to_dict()
-            str_content = yaml.dump(data, default_flow_style=False)
+            str_content = yaml.safe_dump(data, default_flow_style=False)
 
         self.ua_file.write(str_content)
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1171,3 +1171,10 @@ from the system by running:
 
 $ sudo rm {lock_file_path}""",
 )
+
+MISSING_YAML_MODULE = NamedMessage(
+    "missing-yaml-module",
+    """\
+Couldn't import the YAML module from /usr/lib/python3/dist-packages.
+Make sure the 'python3-yaml' package is installed correctly.""",
+)

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -6,9 +6,8 @@ import textwrap
 
 import mock
 import pytest
-import yaml
 
-from uaclient import event_logger, messages, status, util
+from uaclient import event_logger, messages, status, util, yaml
 from uaclient.cli import (
     UA_AUTH_TOKEN_URL,
     action_attach,

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -400,7 +400,7 @@ class TestActionAttach:
     ):
         args = mock.MagicMock(
             token=None,
-            attach_config=FakeFile(yaml.dump({"token": "faketoken"})),
+            attach_config=FakeFile(yaml.safe_dump({"token": "faketoken"})),
         )
         cfg = FakeConfig()
         action_attach(args, cfg=cfg)
@@ -417,7 +417,9 @@ class TestActionAttach:
         args = mock.MagicMock(
             token=None,
             attach_config=FakeFile(
-                yaml.dump({"token": "something", "enable_services": "cis"}),
+                yaml.safe_dump(
+                    {"token": "something", "enable_services": "cis"}
+                ),
                 name="fakename",
             ),
         )
@@ -427,7 +429,7 @@ class TestActionAttach:
         assert "Error while reading fakename: " in e.value.msg
 
         args.attach_config = FakeFile(
-            yaml.dump({"token": "something", "enable_services": "cis"}),
+            yaml.safe_dump({"token": "something", "enable_services": "cis"}),
             name="fakename",
         )
         with pytest.raises(SystemExit):
@@ -495,7 +497,9 @@ class TestActionAttach:
         args = mock.MagicMock(
             token=None,
             attach_config=FakeFile(
-                yaml.dump({"token": "faketoken", "enable_services": ["cis"]})
+                yaml.safe_dump(
+                    {"token": "faketoken", "enable_services": ["cis"]}
+                )
             ),
             auto_enable=auto_enable,
         )
@@ -511,7 +515,7 @@ class TestActionAttach:
             assert [] == m_enable.call_args_list
 
         args.attach_config = FakeFile(
-            yaml.dump({"token": "faketoken", "enable_services": ["cis"]})
+            yaml.safe_dump({"token": "faketoken", "enable_services": ["cis"]})
         )
 
         fake_stdout = io.StringIO()

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -9,9 +9,8 @@ import textwrap
 
 import mock
 import pytest
-import yaml
 
-from uaclient import exceptions, messages, status, util
+from uaclient import exceptions, messages, status, util, yaml
 from uaclient.cli import action_status, get_parser, main, status_parser
 from uaclient.conftest import FakeNotice
 from uaclient.event_logger import EventLoggerMode

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -8,9 +8,8 @@ import stat
 
 import mock
 import pytest
-import yaml
 
-from uaclient import apt, exceptions, messages, util
+from uaclient import apt, exceptions, messages, util, yaml
 from uaclient.config import (
     PRIVATE_SUBDIR,
     UA_CONFIGURABLE_KEYS,

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -386,19 +386,19 @@ class TestWriteCfg:
             (
                 CFG_BASE_CONTENT,
                 CFG_BASE_CONTENT
-                + yaml.dump(UA_CFG_DICT, default_flow_style=False),
+                + yaml.safe_dump(UA_CFG_DICT, default_flow_style=False),
             ),
             (  # Yaml output is sorted alphabetically by key
                 "\n".join(sorted(CFG_BASE_CONTENT.splitlines(), reverse=True)),
                 CFG_BASE_CONTENT
-                + yaml.dump(UA_CFG_DICT, default_flow_style=False),
+                + yaml.safe_dump(UA_CFG_DICT, default_flow_style=False),
             ),
             # Any custom comments or unrecognized config keys are dropped
             (
                 "unknown-keys-not-preserved: true\n# user comments are lost"
                 + CFG_BASE_CONTENT,
                 CFG_BASE_CONTENT
-                + yaml.dump(UA_CFG_DICT, default_flow_style=False),
+                + yaml.safe_dump(UA_CFG_DICT, default_flow_style=False),
             ),
             # All features/settings_overrides ordered after ua_config
             (
@@ -406,7 +406,7 @@ class TestWriteCfg:
                 + "features:\n new: 2\n extra_security_params:\n  hide: true\n"
                 " show_beta: true\nsettings_overrides:\n d: 2\n c: 1\n",
                 CFG_FEATURES_CONTENT
-                + yaml.dump(UA_CFG_DICT, default_flow_style=False),
+                + yaml.safe_dump(UA_CFG_DICT, default_flow_style=False),
             ),
             (
                 "settings_overrides:\n c: 1\n d: 2\nfeatures:\n"
@@ -414,7 +414,7 @@ class TestWriteCfg:
                 "  hide: true\nsettings_overrides:\n d: 2\n c: 1\n"
                 + CFG_BASE_CONTENT,
                 CFG_FEATURES_CONTENT
-                + yaml.dump(UA_CFG_DICT, default_flow_style=False),
+                + yaml.safe_dump(UA_CFG_DICT, default_flow_style=False),
             ),
         ),
     )
@@ -1127,7 +1127,7 @@ class TestParseConfig:
         self, config_dict, expected_invalid_keys, tmpdir
     ):
         config_file = tmpdir.join("uaclient.conf")
-        config_file.write(yaml.dump(config_dict))
+        config_file.write(yaml.safe_dump(config_dict))
         env_vars = {"UA_CONFIG_FILE": config_file.strpath}
         with mock.patch.dict("uaclient.config.os.environ", values=env_vars):
             cfg, invalid_keys = parse_config(config_file.strpath)

--- a/uaclient/tests/test_event_logger.py
+++ b/uaclient/tests/test_event_logger.py
@@ -4,8 +4,8 @@ import json
 
 import mock
 import pytest
-import yaml
 
+from uaclient import yaml
 from uaclient.event_logger import JSON_SCHEMA_VERSION, EventLoggerMode
 
 

--- a/uaclient/tests/test_yaml.py
+++ b/uaclient/tests/test_yaml.py
@@ -1,0 +1,58 @@
+import mock
+import pytest
+
+from uaclient.exceptions import UserFacingError
+from uaclient.yaml import get_imported_yaml_module
+
+M_PREFIX = "uaclient.yaml."
+
+
+@mock.patch(M_PREFIX + "sys")
+class TestYamlImport:
+    def test_get_yaml_module_returns_imported(self, m_sys):
+        imported_yaml = mock.MagicMock()
+        m_sys.modules = {"yaml": imported_yaml}
+        yaml = get_imported_yaml_module()
+        assert yaml is imported_yaml
+
+    @pytest.mark.parametrize("has_yaml_in_system", (True, False))
+    @mock.patch(M_PREFIX + "importlib_machinery")
+    @mock.patch(M_PREFIX + "importlib_util")
+    def test_get_yaml_module_imports_from_system(
+        self, m_util, m_machinery, m_sys, has_yaml_in_system
+    ):
+        m_sys.modules = {}
+
+        m_yaml_spec = mock.MagicMock()
+        m_yaml_module = mock.MagicMock()
+
+        m_util.module_from_spec.return_value = m_yaml_module
+
+        if has_yaml_in_system:
+            m_machinery.PathFinder.find_spec.return_value = m_yaml_spec
+        else:
+            m_machinery.PathFinder.find_spec.return_value = None
+
+        if has_yaml_in_system:
+            yaml = get_imported_yaml_module()
+
+            assert m_yaml_module == yaml
+            assert [
+                mock.call("yaml", path=["/usr/lib/python3/dist-packages"])
+            ] == m_machinery.PathFinder.find_spec.call_args_list
+            assert [
+                mock.call(m_yaml_spec)
+            ] == m_util.module_from_spec.call_args_list
+            assert m_sys.modules["yaml"] == m_yaml_module
+            assert [
+                mock.call(m_yaml_module)
+            ] == m_yaml_spec.loader.exec_module.call_args_list
+        else:
+            with pytest.raises(UserFacingError) as excinfo:
+                yaml = get_imported_yaml_module()
+
+            assert "missing-yaml-module" == excinfo.value.msg_code
+            assert "Couldn't import the YAML module" in excinfo.value.msg
+            assert [
+                mock.call("yaml", path=["/usr/lib/python3/dist-packages"])
+            ] == m_machinery.PathFinder.find_spec.call_args_list

--- a/uaclient/yaml.py
+++ b/uaclient/yaml.py
@@ -1,0 +1,42 @@
+import sys
+from importlib import machinery as importlib_machinery
+from importlib import util as importlib_util
+
+from uaclient.exceptions import UserFacingError
+from uaclient.messages import MISSING_YAML_MODULE
+
+
+def get_imported_yaml_module():
+    # Maybe we already imported it?
+    if "yaml" in sys.modules:
+        return sys.modules["yaml"]
+
+    # Try to get the system yaml module
+    pyyaml_spec = importlib_machinery.PathFinder.find_spec(
+        "yaml", path=["/usr/lib/python3/dist-packages"]
+    )
+    # If there is no system 'yaml' module (which is weird enough),
+    # then raise an exception asking for it to be there
+    if pyyaml_spec is None:
+        raise UserFacingError(
+            MISSING_YAML_MODULE.msg, MISSING_YAML_MODULE.name
+        )
+
+    # Import it!
+    yaml_module = importlib_util.module_from_spec(pyyaml_spec)
+    sys.modules["yaml"] = yaml_module
+    loader = pyyaml_spec.loader
+    # The loader shouldn't be None, documentation says:
+    # "The finder should always set this attribute."
+    # But mypy complains, so we check anyway.
+    if loader is not None:
+        loader.exec_module(yaml_module)
+
+    return yaml_module
+
+
+yaml = get_imported_yaml_module()
+
+safe_load = yaml.safe_load
+safe_dump = yaml.safe_dump
+parser = yaml.parser


### PR DESCRIPTION
When users install a new pyyaml using pip, it will end up in pythonpath with a higher priority.
This PR introduces some logic to import yaml only directly from the system dist-packages.
This fixes two bugs:
LP: #2007234 : If yaml is not present, then a UserFacingError is thrown - this can only happen if the `python3-yaml` deb is not present or was directly modified, and as it is a dependency, it does not make sense to support anything like this.
LP: #2007241 : The system yaml won't have a version which is incompatible with the python version, so the safe_load bug is prevented.


## Test Steps
Added unit tests and integration tests to verify the fix.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [ ] No
 - [x] I hope not
