### PR TITLE
docs: fix typo ("offical") in front page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Ubuntu Pro Client
 #################
 
-The Ubuntu Pro Client (``pro``) is the offical tool to enable Canonical
+The Ubuntu Pro Client (``pro``) is the official tool to enable Canonical
 offerings on your system.
 
 ``pro`` provides support to view, enable, and disable the following Canonical


### PR DESCRIPTION
Fix typo in docs front page 
("official" was misspelled as "offical")

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
