### PR TITLE
docs: add link to FAQ from front page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Ubuntu Pro Client
 #################
 
-The Ubuntu Pro Client (``pro``) is the offical tool to enable Canonical
+The Ubuntu Pro Client (``pro``) is the official tool to enable Canonical
 offerings on your system.
 
 ``pro`` provides support to view, enable, and disable the following Canonical
@@ -16,7 +16,7 @@ services:
 - `Livepatch`_
 
 If you need any of those services for your machine, ``pro`` is the right tool
-for you.
+for you. 
 
 ``pro`` is already installed on every Ubuntu system. Try it out by running
 ``pro help``!
@@ -58,6 +58,9 @@ Getting help
 Ubuntu Pro is a new product, and we're keen to know about your experience of
 using it!
 
+- **Have questions?**
+  You might find the answers `in our FAQ`_.
+  
 - **Having trouble?**
   We would like to help! To get help on a specific page in this documentation,
   simply click on the "Have a question?" link at the top of that page. This
@@ -71,7 +74,7 @@ using it!
   If you have any comments, requests or suggestions that you'd like to share,
   we'd be very happy to receive them! Please feel free to reach out on
   `our Discourse forum`_, or you can get in touch via the ``#ubuntu-server``
-  `IRC channel on Libera`_
+  `IRC channel on Libera`_.
 
 Project and community
 =====================
@@ -120,3 +123,4 @@ constructive feedback.
 .. _Contribute: https://github.com/canonical/ubuntu-advantage-client/blob/main/CONTRIBUTING.md
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/ubuntu-server
 .. _our Discourse forum: https://discourse.ubuntu.com/c/ubuntu-pro/116
+.. _in our FAQ: https://discourse.ubuntu.com/t/ubuntu-pro-faq/34042


### PR DESCRIPTION
```
FAQ has been published. This PR adds a link to the FAQ
from our docs index page. 
```