### PR TITLE
tests: ensure logging doesn't leak into test output

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -419,10 +419,19 @@ def before_scenario(context: Context, scenario: Scenario):
             return
 
     # before_step doesn't execute early enough to modify the step
-    # so we perform the version step surgery here
+    # so we perform step text surgery here
+    # Also, logging capture is not set up when before_scenario is called,
+    # so if you call logging.info here, then the root logger gets configured
+    # and it messes up all the future behave logging capture machinery.
+    # See https://github.com/behave/behave/blob/v1.2.6/behave/model.py#L700
+    # But we want to log the replacement we're making, so we use the behave
+    # logger and warning log_level to make sure it gets included.
+    logger = logging.getLogger("behave.before_scenario.process_template_vars")
     for step in scenario.steps:
         if step.text:
-            step.text = process_template_vars(context, step.text)
+            step.text = process_template_vars(
+                context, step.text, logger_fn=logger.warn
+            )
 
 
 FAILURE_FILES = (


### PR DESCRIPTION
I noticed that recently our test runs included some unexpected logging output. I found that the cause was calling `logging.debug` in the `before_scenario` behave hook. This commit fixes it.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the _version.feature and ensure that no logging is included in the output.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
