### PR TITLE
cli: fix config subcommands usage help

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -324,9 +324,11 @@ def collect_logs_parser(parser):
     return parser
 
 
-def config_show_parser(parser):
+def config_show_parser(parser, parent_command: str):
     """Build or extend an arg parser for 'config show' subcommand."""
-    parser.usage = USAGE_TMPL.format(name=NAME, command="show [key]")
+    parser.usage = USAGE_TMPL.format(
+        name=NAME, command="{} show [key]".format(parent_command)
+    )
     parser.prog = "show"
     parser.description = "Show customisable configuration settings"
     parser.add_argument(
@@ -337,10 +339,12 @@ def config_show_parser(parser):
     return parser
 
 
-def config_set_parser(parser):
+def config_set_parser(parser, parent_command: str):
     """Build or extend an arg parser for 'config set' subcommand."""
-    parser.usage = USAGE_TMPL.format(name=NAME, command="set <key>=<value>")
-    parser.prog = "set"
+    parser.usage = USAGE_TMPL.format(
+        name=NAME, command="{} set <key>=<value>".format(parent_command)
+    )
+    parser.prog = "aset"
     parser.description = "Set and apply Ubuntu Pro configuration settings"
     parser._optionals.title = "Flags"
     parser.add_argument(
@@ -355,9 +359,11 @@ def config_set_parser(parser):
     return parser
 
 
-def config_unset_parser(parser):
+def config_unset_parser(parser, parent_command: str):
     """Build or extend an arg parser for 'config unset' subcommand."""
-    parser.usage = USAGE_TMPL.format(name=NAME, command="unset <key>")
+    parser.usage = USAGE_TMPL.format(
+        name=NAME, command="{} unset <key>".format(parent_command)
+    )
     parser.prog = "unset"
     parser.description = "Unset Ubuntu Pro configuration setting"
     parser.add_argument(
@@ -374,8 +380,11 @@ def config_unset_parser(parser):
 
 def config_parser(parser):
     """Build or extend an arg parser for config subcommand."""
-    parser.usage = USAGE_TMPL.format(name=NAME, command="config <command>")
-    parser.prog = "config"
+    command = "config"
+    parser.usage = USAGE_TMPL.format(
+        name=NAME, command="{} <command>".format(command)
+    )
+    parser.prog = command
     parser.description = "Manage Ubuntu Pro configuration"
     parser._optionals.title = "Flags"
     subparsers = parser.add_subparsers(
@@ -385,19 +394,19 @@ def config_parser(parser):
         "show", help="show all Ubuntu Pro configuration setting(s)"
     )
     parser_show.set_defaults(action=action_config_show)
-    config_show_parser(parser_show)
+    config_show_parser(parser_show, parent_command=command)
 
     parser_set = subparsers.add_parser(
         "set", help="set Ubuntu Pro configuration setting"
     )
     parser_set.set_defaults(action=action_config_set)
-    config_set_parser(parser_set)
+    config_set_parser(parser_set, parent_command=command)
 
     parser_unset = subparsers.add_parser(
         "unset", help="unset Ubuntu Pro configuration setting"
     )
     parser_unset.set_defaults(action=action_config_unset)
-    config_unset_parser(parser_unset)
+    config_unset_parser(parser_unset, parent_command=command)
     return parser
 
 

--- a/uaclient/tests/test_cli_config.py
+++ b/uaclient/tests/test_cli_config.py
@@ -1,0 +1,57 @@
+import mock
+import pytest
+
+from uaclient.cli import main
+
+M_PATH = "uaclient.cli."
+
+HELP_OUTPUT = """\
+usage: pro config <command> [flags]
+
+Manage Ubuntu Pro configuration
+
+Flags:
+  -h, --help  show this help message and exit
+
+Available Commands:
+  
+    show      show all Ubuntu Pro configuration setting(s)
+    set       set Ubuntu Pro configuration setting
+    unset     unset Ubuntu Pro configuration setting
+"""  # noqa
+
+
+@mock.patch("uaclient.cli.logging.error")
+@mock.patch("uaclient.cli.setup_logging")
+@mock.patch(M_PATH + "contract.get_available_resources")
+class TestMainConfig:
+    @pytest.mark.parametrize("additional_params", ([], ["--help"]))
+    def test_config_help(
+        self,
+        _m_resources,
+        _logging,
+        logging_error,
+        additional_params,
+        capsys,
+        FakeConfig,
+    ):
+        """Show help for --help and absent positional param"""
+        with pytest.raises(SystemExit):
+            with mock.patch(
+                "sys.argv", ["/usr/bin/ua", "config"] + additional_params
+            ):
+                with mock.patch(
+                    "uaclient.config.UAConfig",
+                    return_value=FakeConfig(),
+                ):
+                    main()
+        out, err = capsys.readouterr()
+        assert HELP_OUTPUT == out
+        if additional_params == ["--help"]:
+            assert "" == err
+        else:
+            # When lacking show, set or unset inform about valid values
+            assert "\n<command> must be one of: show, set, unset\n" == err
+            assert [
+                mock.call("\n<command> must be one of: show, set, unset")
+            ] == logging_error.call_args_list

--- a/uaclient/tests/test_cli_config_set.py
+++ b/uaclient/tests/test_cli_config_set.py
@@ -7,7 +7,7 @@ from uaclient.entitlements.entitlement_status import ApplicationStatus
 from uaclient.exceptions import NonRootUserError, UserFacingError
 
 HELP_OUTPUT = """\
-usage: pro set <key>=<value> [flags]
+usage: pro config set <key>=<value> [flags]
 
 Set and apply Ubuntu Pro configuration settings
 

--- a/uaclient/tests/test_cli_config_show.py
+++ b/uaclient/tests/test_cli_config_show.py
@@ -6,39 +6,32 @@ from uaclient.cli import action_config_show, main
 M_PATH = "uaclient.cli."
 
 HELP_OUTPUT = """\
-usage: pro config <command> [flags]
+usage: pro config show [key] [flags]
 
-Manage Ubuntu Pro configuration
+Show customisable configuration settings
 
-Flags:
-  -h, --help  show this help message and exit
+positional arguments:
+  key         Optional key or key(s) to show configuration settings.
 
-Available Commands:
-  
-    show      show all Ubuntu Pro configuration setting(s)
-    set       set Ubuntu Pro configuration setting
-    unset     unset Ubuntu Pro configuration setting
-"""  # noqa
+"""
 
 
 @mock.patch("uaclient.cli.logging.error")
 @mock.patch("uaclient.cli.setup_logging")
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestMainConfigShow:
-    @pytest.mark.parametrize("additional_params", ([], ["--help"]))
     def test_config_show_help(
         self,
         _m_resources,
         _logging,
         logging_error,
-        additional_params,
         capsys,
         FakeConfig,
     ):
         """Show help for --help and absent positional param"""
         with pytest.raises(SystemExit):
             with mock.patch(
-                "sys.argv", ["/usr/bin/ua", "config"] + additional_params
+                "sys.argv", ["/usr/bin/ua", "config", "show", "--help"]
             ):
                 with mock.patch(
                     "uaclient.config.UAConfig",
@@ -46,15 +39,8 @@ class TestMainConfigShow:
                 ):
                     main()
         out, err = capsys.readouterr()
-        assert HELP_OUTPUT == out
-        if additional_params == ["--help"]:
-            assert "" == err
-        else:
-            # When lacking show, set or unset inform about valid values
-            assert "\n<command> must be one of: show, set, unset\n" == err
-            assert [
-                mock.call("\n<command> must be one of: show, set, unset")
-            ] == logging_error.call_args_list
+        assert out.startswith(HELP_OUTPUT)
+        assert "" == err
 
     def test_config_show_error_on_invalid_subcommand(
         self, _m_resources, _logging, _logging_error, capsys, FakeConfig

--- a/uaclient/tests/test_cli_config_unset.py
+++ b/uaclient/tests/test_cli_config_unset.py
@@ -6,7 +6,7 @@ from uaclient.entitlements.entitlement_status import ApplicationStatus
 from uaclient.exceptions import NonRootUserError
 
 HELP_OUTPUT = """\
-usage: pro unset <key> [flags]
+usage: pro config unset <key> [flags]
 
 Unset Ubuntu Pro configuration setting
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
cli: fix config subcommands usage help

Fixes: #2278
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
pro config set --help
pro config unset --help
pro config show --help
```

Verify that the `usage` part contains `pro config <sub-cmd> ...`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
