### PR TITLE
docs: cosmetic improvements

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,240 @@
+/** Fix the font weight (300 for normal, 400 for slightly bold) **/
+/** Should be 100 for all headers, 400 for normal text  **/
+
+h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button, input, optgroup, select, textarea, th.head {
+    font-weight: 200;
+}
+
+.toc-title {
+    font-weight: 400;
+}
+
+div.page, li.scroll-current>.reference, dl.glossary dt, dl.simple dt, dl:not([class]) dt {
+    font-weight: 300;
+    line-height: 1.5;
+    font-size: var(--font-size--normal);
+}
+
+
+/** Side bars (side-bar tree = left, toc-tree = right) **/
+div.sidebar-tree {
+    font-weight: 200;
+    line-height: 1.5;
+    font-size: var(--font-size--normal);
+}
+
+div.toc-tree {
+    font-weight: 200;
+    font-size: var(--font-size--medium);
+    line-height: 1.5;
+}
+
+.sidebar-tree .toctree-l1>.reference, .toc-tree li.scroll-current>.reference {
+    font-weight: 400;
+}
+
+/** List styling   **/
+ol, ul {
+    margin-bottom: 1.5rem;
+    margin-left: 1rem;
+    margin-top: 0;
+    padding-left: 1rem;
+}
+
+/** Table styling **/
+
+th.head {
+    text-transform: uppercase;
+    font-size: var(--font-size--small);
+}
+
+table.docutils {
+    border: 0;
+    box-shadow: none;
+    width:100%;
+}
+
+table.docutils td, table.docutils th, table.docutils td:last-child, table.docutils th:last-child, table.docutils td:first-child, table.docutils th:first-child {
+    border-right: none;
+    border-left: none;
+}
+
+/* center align table cells with ":-:" */
+td.text-center {
+    text-align: center;
+}
+
+/** No rounded corners **/
+
+.admonition, code.literal, .sphinx-tabs-tab, .sphinx-tabs-panel, .highlight {
+    border-radius: 0;
+}
+
+/** code blocks and literals **/
+code.docutils.literal.notranslate, .highlight pre, pre.literal-block {
+    font-size: var(--font-size--medium);
+}
+
+
+/** Admonition styling **/
+
+.admonition {
+    font-size: var(--font-size--medium);
+    box-shadow: none;
+}
+
+/** Styling for links **/
+/* unvisited link */
+a:link {
+    color: #06c;
+    text-decoration: none;
+}
+
+/* visited link */
+a:visited {
+    color: #7d42b8;
+    text-decoration: none;
+}
+
+/* mouse over link */
+a:hover {
+    text-decoration: underline;
+}
+
+/* selected link */
+a:active {
+    text-decoration: underline;
+}
+
+a.sidebar-brand.centered {
+    text-decoration: none;
+}
+
+/** Color for the "copy link" symbol next to headings **/
+
+a.headerlink {
+    color: var(--color-brand-primary);
+}
+
+/** Line to the left of the current navigation entry **/
+
+.sidebar-tree li.current-page {
+    border-left: 2px solid var(--color-brand-primary);
+}
+
+/** Some tweaks for issue #16 **/
+
+[role="tablist"] {
+    border-bottom: 1px solid var(--color-sidebar-item-background--hover);
+}
+
+.sphinx-tabs-tab[aria-selected="true"] {
+    border: 0;
+    border-bottom: 2px solid var(--color-brand-primary);
+    background-color: var(--color-sidebar-item-background--current);
+    font-weight:300;
+}
+
+.sphinx-tabs-tab{
+    color: var(--color-brand-primary);
+    font-weight:300;
+}
+
+.sphinx-tabs-panel {
+    border: 0;
+    border-bottom: 1px solid var(--color-sidebar-item-background--hover);
+    background: var(--color-background-primary);
+}
+
+button.sphinx-tabs-tab:hover {
+    background-color: var(--color-sidebar-item-background--hover);
+}
+
+/** Custom classes to fix scrolling in tables by decreasing the
+    font size or breaking certain columns.
+    Specify the classes in the Markdown file with, for example:
+    ```{rst-class} break-col-4 min-width-4-8
+    ```
+**/
+
+table.dec-font-size {
+    font-size: smaller;
+}
+table.break-col-1 td.text-left:first-child {
+    word-break: break-word;
+}
+table.break-col-4 td.text-left:nth-child(4) {
+    word-break: break-word;
+}
+table.min-width-1-15 td.text-left:first-child {
+    min-width: 15em;
+}
+table.min-width-4-8 td.text-left:nth-child(4) {
+    min-width: 8em;
+}
+
+/** Underline for abbreviations **/
+
+abbr[title] {
+    text-decoration: underline solid #cdcdcd;
+}
+
+/** Use the same style for right-details as for left-details **/
+.bottom-of-page .right-details {
+    font-size: var(--font-size--small);
+    display: block;
+}
+
+/** Version switcher */
+button.version_select {
+  color: var(--color-foreground-primary);
+  background-color: var(--color-toc-background);
+  padding: 5px 10px;
+  border: none;
+}
+
+.version_select:hover, .version_select:focus {
+    background-color: var(--color-sidebar-item-background--hover);
+}
+
+.version_dropdown {
+  position: relative;
+  display: inline-block;
+  text-align: right;
+  font-size: var(--sidebar-item-font-size);
+}
+
+.available_versions {
+  display: none;
+  position: absolute;
+  right: 0px;
+  background-color: var(--color-toc-background);
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 11;
+}
+
+.available_versions a {
+  color: var(--color-foreground-primary);
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+.available_versions a:hover {background-color: var(--color-sidebar-item-background--current)}
+
+.show {display:block;}
+
+/** Fix for nested numbered list - the nested list is lettered **/
+ol.arabic ol.arabic {
+  list-style: lower-alpha;
+}
+
+/** Make expandable sections look like links **/
+details summary {
+    color: var(--color-link);
+}
+
+/** Context links at the bottom of the page **/
+footer {
+    font-size: var(--font-size--medium);
+}

--- a/docs/_static/css/github_issue_links.css
+++ b/docs/_static/css/github_issue_links.css
@@ -4,4 +4,21 @@
 .github-issue-link {
     font-size: var(--font-size--small);
     font-weight: bold;
+    background-color: #DD4814;
+    padding: 13px 23px;
+    text-decoration: none;
+}
+.github-issue-link:link {
+    color: #FFFFFF;
+}
+.github-issue-link:visited {
+    color: #FFFFFF
+}
+.muted-link.github-issue-link:hover {
+    color: #FFFFFF;
+    text-decoration: underline;
+}
+.github-issue-link:active {
+    color: #FFFFFF;
+    text-decoration: underline;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,18 +14,20 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = "Ubuntu Pro Client"
-copyright = "2022, Canonical Ltd."
-
+author = "Canonical Group Ltd"
+copyright = "%s, %s" % (datetime.date.today().year, author)
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+
 extensions = [
     "myst_parser",
     "sphinx_copybutton",
@@ -33,6 +35,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
+
 templates_path = ["_templates"]
 
 html_extra_path = ["googleaf254801a5285c31.html"]
@@ -40,21 +43,56 @@ html_extra_path = ["googleaf254801a5285c31.html"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
+
 exclude_patterns = []
 
 # It seems we need to request creation of automatic anchors for our headings.
 # Setting to 2 because that's what we need now.
 # If referencing any heading of lesser importance, adjust here.
+
 myst_heading_anchors = 3
 
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
+# a list of builtin themes:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
 html_theme = "furo"
 html_logo = "_static/circle_of_friends.png"
+html_theme_options = {
+    "light_css_variables": {
+        "color-sidebar-background-border": "none",
+        "font-stack": "Ubuntu, -apple-system, Segoe UI, Roboto, Oxygen, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif",
+        "font-stack--monospace": "Ubuntu Mono variable, Ubuntu Mono, Consolas, Monaco, Courier, monospace",
+        "color-foreground-primary": "#111",
+        "color-foreground-secondary": "var(--color-foreground-primary)",
+        "color-foreground-muted": "#333",
+        "color-background-secondary": "#FFF",
+        "color-background-hover": "#f2f2f2",
+        "color-brand-primary": "#111",
+        "color-brand-content": "#06C",
+        "color-inline-code-background": "rgba(0,0,0,.03)",
+        "color-sidebar-link-text": "#111",
+        "color-sidebar-item-background--current": "#ebebeb",
+        "color-sidebar-item-background--hover": "#f2f2f2",
+        "sidebar-item-line-height": "1.3rem",
+        "color-link-underline": "var(--color-background-primary)",
+        "color-link-underline--hover": "var(--color-background-primary)",
+    },
+    "dark_css_variables": {
+        "color-foreground-secondary": "var(--color-foreground-primary)",
+        "color-foreground-muted": "#CDCDCD",
+        "color-background-secondary": "var(--color-background-primary)",
+        "color-background-hover": "#666",
+        "color-brand-primary": "#fff",
+        "color-brand-content": "#06C",
+        "color-sidebar-link-text": "#f7f7f7",
+        "color-sidebar-item-background--current": "#666",
+        "color-sidebar-item-background--hover": "#333",
+    },
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -64,6 +102,7 @@ html_static_path = ["_static"]
 html_css_files = [
     "css/logo.css",
     "css/github_issue_links.css",
+    "css/custom.css"
 ]
 html_js_files = [
     "js/github_issue_links.js",


### PR DESCRIPTION
```
A series of cosmetic docs changes that will make them look more like the
documentation produced on Ubuntu.com. It's not *exactly* the same, but
close enough to make it look recognisable as Canonical docs.

I made the "Have a question" link (top of the page) more prominent and
easier to spot. Hacky or not, it's a great feature that most docs miss
and I want people to be able to find it!

Although I tried to test this on a variety of screen sizes, if you spot
anything that doesn't render right or looks weird, please let me know. The
default font sizes were problematic from an accessibility pov so I made
them larger. They are still variable so they should render right on smaller
screens but it's possible I missed some.

Code literals are now the same size as regular font for the same reason,
but made slightly bolded to help pick them out from text (which should
help e.g. when commands are included as inline text and not a code block.

For easier navigation, I've given the sidebar headings a higher weight, and
as an added bonus, when scrolling through a long page the right-hand side bar
also shows what part you're on.

For accessibility, I changed the weight and spacing between topics in the
side bars to help separate them and make it easier to tell where one link
ends and the next begins.

As always, let me know if there's any other improvements I can make or any
things I've done that don't work!  
```
