### PR TITLE
Revert "apt: remove one call to apt-cache policy"

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -202,29 +202,13 @@ def run_apt_command(
 
 
 @lru_cache(maxsize=None)
-def _read_apt_source_files():
-    import apt_pkg
-
-    try:
-        apt_pkg.init()
-        source_lists = apt_pkg.SourceList()
-        source_lists.read_main_list()
-    except Exception as e:
-        raise exceptions.ErrorParsingAPTSourceFile(str(e))
-
-    return source_lists.list
-
-
-def is_uri_in_apt_source_files(url: str) -> bool:
-    """
-    Search the current apt source files for a given url and return
-    trues if it is present.
-    """
-    for pkg in _read_apt_source_files():
-        if url == pkg.uri:
-            return True
-
-    return False
+def get_apt_cache_policy(
+    error_msg: Optional[str] = None,
+    env: Optional[Dict[str, str]] = {},
+) -> str:
+    return run_apt_command(
+        cmd=["apt-cache", "policy"], error_msg=error_msg, env=env
+    )
 
 
 def get_apt_cache_policy_for_package(
@@ -251,9 +235,9 @@ def run_apt_update_command(env: Optional[Dict[str, str]] = {}) -> str:
         )
     finally:
         # Whenever we run an apt-get update command, we must invalidate
-        # the existing _read_apt_source_files cache. Otherwise, we could
-        # provide users with incorrect values.
-        _read_apt_source_files.cache_clear()
+        # the existing apt-cache policy cache. Otherwise, we could provide
+        # users with incorrect values.
+        get_apt_cache_policy.cache_clear()
 
     return out
 

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -1,6 +1,7 @@
 import abc
 import copy
 import logging
+import re
 from os.path import exists
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -114,9 +115,11 @@ class RepoEntitlement(base.UAEntitlement):
                 ApplicationStatus.DISABLED,
                 messages.NO_APT_URL_FOR_SERVICE.format(title=self.title),
             )
-
-        repo_url = "{}/ubuntu/".format(repo_url)
-        if apt.is_uri_in_apt_source_files(repo_url):
+        policy = apt.get_apt_cache_policy(
+            error_msg=messages.APT_POLICY_FAILED.msg
+        )
+        match = re.search(r"{}/ubuntu".format(repo_url), policy)
+        if match:
             return (
                 ApplicationStatus.ENABLED,
                 messages.SERVICE_IS_ACTIVE.format(title=self.title),

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -3,7 +3,7 @@
 import mock
 import pytest
 
-from uaclient import apt
+from uaclient import apt, messages
 from uaclient.entitlements.cis import CIS_DOCS_URL, CISEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
 
@@ -36,7 +36,7 @@ class TestCISEntitlementCanEnable:
 
 
 class TestCISEntitlementEnable:
-    @mock.patch("uaclient.apt.is_uri_in_apt_source_files", return_value=False)
+    @mock.patch("uaclient.apt.get_apt_cache_policy")
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch("uaclient.system.should_reboot")
     @mock.patch("uaclient.system.subp")
@@ -47,7 +47,7 @@ class TestCISEntitlementEnable:
         m_subp,
         m_should_reboot,
         m_setup_apt_proxy,
-        _m_is_uri_in_apt_source_files,
+        m_apt_policy,
         capsys,
         event,
         entitlement,
@@ -62,6 +62,7 @@ class TestCISEntitlementEnable:
 
         m_platform_info.side_effect = fake_platform
         m_subp.return_value = ("fakeout", "")
+        m_apt_policy.return_value = "fakeout"
         m_should_reboot.return_value = False
 
         with mock.patch(M_REPOPATH + "exists", mock.Mock(return_value=True)):
@@ -77,6 +78,12 @@ class TestCISEntitlementEnable:
                 ["xenial"],
                 entitlement.repo_key_file,
             )
+        ]
+
+        m_apt_policy_cmds = [
+            mock.call(
+                error_msg=messages.APT_POLICY_FAILED.msg,
+            ),
         ]
 
         subp_apt_cmds = [
@@ -107,7 +114,8 @@ class TestCISEntitlementEnable:
         assert [] == m_add_pin.call_args_list
         assert 1 == m_setup_apt_proxy.call_count
         assert subp_apt_cmds == m_subp.call_args_list
-        assert 1 == _m_is_uri_in_apt_source_files.call_count
+        assert 1 == m_apt_policy.call_count
+        assert m_apt_policy_cmds == m_apt_policy.call_args_list
         assert 1 == m_should_reboot.call_count
         expected_stdout = (
             "Updating package lists\n"

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1035,6 +1035,24 @@ class TestFIPSEntitlementApplicationStatus:
         assert expected_msg.msg == actual_msg.msg
         assert expected_msg.name == actual_msg.name
 
+    def test_fips_does_not_show_enabled_when_fips_updates_is(
+        self, _m_should_reboot, entitlement
+    ):
+        with mock.patch("uaclient.apt.get_apt_cache_policy") as m_apt_policy:
+            m_apt_policy.return_value = (
+                "1001 http://FIPS-UPDATES/ubuntu"
+                " xenial-updates/main amd64 Packages\n"
+                ""
+            )
+
+            application_status, _ = entitlement.application_status()
+
+        expected_status = ApplicationStatus.DISABLED
+        if isinstance(entitlement, FIPSUpdatesEntitlement):
+            expected_status = ApplicationStatus.ENABLED
+
+        assert expected_status == application_status
+
 
 class TestFipsEntitlementInstallPackages:
     @mock.patch(M_PATH + "apt.run_apt_command")

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -475,11 +475,3 @@ class InvalidLockFile(UserFacingError):
     def __init__(self, lock_file_path):
         msg = messages.INVALID_LOCK_FILE.format(lock_file_path=lock_file_path)
         super().__init__(msg=msg.msg, msg_code=msg.name)
-
-
-class ErrorParsingAPTSourceFile(UserFacingError):
-    def __init__(self, exception_str: str):
-        msg = messages.ERROR_PARSING_APT_SOURCE_FILES.format(
-            exception_str=exception_str
-        )
-        super().__init__(msg=msg.msg, msg_code=msg.name)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1178,10 +1178,3 @@ MISSING_YAML_MODULE = NamedMessage(
 Couldn't import the YAML module from /usr/lib/python3/dist-packages.
 Make sure the 'python3-yaml' package is installed correctly.""",
 )
-
-ERROR_PARSING_APT_SOURCE_FILES = FormattedNamedMessage(
-    name="error-parsing-apt-source-files",
-    msg="""\
-Error parsing APT source files:
-{exception_str}""",
-)


### PR DESCRIPTION
## Proposed Commit Message
Revert "apt: remove one call to apt-cache policy"

This reverts commit e7a6e424138f50584dc1957a663e4b9bc50db288.

Since we are having troubles integrating the `apt` and `apt_pkg` libraries, we have decided to rollback this change as it is being affected by the integration issues between the libs

## Test Steps
Check if security-status tests are working as expected

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
